### PR TITLE
'Create URL' command and context menu for OpenShift Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
         "command": "openshift.catalog.list",
         "title": "List Component Types",
         "category": "OpenShift"
+      },
+      {
+        "command": "openshift.url.create",
+        "title": "Create URL",
+        "category": "OpenShift"
       }
     ],
     "viewsContainers": {
@@ -177,6 +182,10 @@
         },
         {
           "command": "openshift.component.watch",
+          "when": "view == openshiftProjectExplorer && viewItem == component"
+        },
+        {
+          "command": "openshift.url.create",
           "when": "view == openshiftProjectExplorer && viewItem == component"
         }
       ]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,9 @@
-import * as shelljs from 'shelljs';
+import * as childProcess from 'child_process';
 import * as vscode from 'vscode';
 import * as path from 'path';
 
 export interface CliExitData {
-    readonly code: number;
+    readonly error: Error;
     readonly stdout: string;
     readonly stderr: string;
 }
@@ -12,10 +12,10 @@ class Cli implements ICli {
     execute(cmd: string, opts: any = {}): Promise<CliExitData> {
         return new Promise<CliExitData>((resolve, reject) => {
             odoChannel.print(cmd);
-            shelljs.exec(cmd, opts, (code, stdout, stderr) => {
+            childProcess.exec(cmd, opts, (error: Error, stdout: string, stderr: string) => {
                 odoChannel.print(stdout);
                 odoChannel.print(stderr);
-                resolve({code, stdout, stderr});
+                resolve({error, stdout, stderr});
             });
         });
     }

--- a/src/odo.ts
+++ b/src/odo.ts
@@ -63,7 +63,7 @@ export interface Odo {
     executeInTerminal(command: string, cwd: string);
     getComponentTypes(): Promise<string[]>;
     getComponentTypeVersions(componentName: string): Promise<string[]>;
-    execute(command: string, cwd?: string);
+    execute(command: string, cwd?: string): Promise<CliExitData>;
 }
 
 export function create(cli: cliInstance.ICli) : Odo {
@@ -80,7 +80,7 @@ class OdoImpl implements Odo {
         const result: cliInstance.CliExitData = await this.cli.execute(
             'odo project list', {}
         );
-        if(result.code) {
+        if(result.error) {
             return [];
         }
         return result.stdout.trim().split("\n").slice(1).map<OpenShiftObject>(value => new OpenShiftObjectImpl(undefined, value.replace(/[\s|\\*]/g, ''), 'project', this));

--- a/test/odo.test.ts
+++ b/test/odo.test.ts
@@ -17,7 +17,7 @@ suite("odo integration tests", function () {
         return {
             execute : function(cmd: string, env: any): Promise<CliExitData> {
                 return Promise.resolve({
-                    code: 0,
+                    error: new Error("Message"),
                     stderr: '',
                     stdout
                 });

--- a/test/odo.test.ts
+++ b/test/odo.test.ts
@@ -17,7 +17,7 @@ suite("odo integration tests", function () {
         return {
             execute : function(cmd: string, env: any): Promise<CliExitData> {
                 return Promise.resolve({
-                    error: new Error("Message"),
+                    error: undefined,
                     stderr: '',
                     stdout
                 });


### PR DESCRIPTION
Fix #14.

Fix adds:
1. Context menu 'Create URL' for components in 'OpenShift Explorer'
2. Check for number of mapped ports and QuickPick for port to expose if there are more than one
