### PR TITLE
Fix odo not starting on linux

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,7 +131,12 @@ async function getToolLocation(cmd): Promise<string> {
                     odoChannel.print(progress + '%');
                 }
             );
-            await unzip(toolDlLocation, path.resolve(Platform.getUserHomePath(), '.vs-openshift'), tools[cmd].prefix);
+            if (toolDlLocation.endsWith('.zip') || toolDlLocation.endsWith('.tar.gz')) {
+                await unzip(toolDlLocation, path.resolve(Platform.getUserHomePath(), '.vs-openshift'), tools[cmd].prefix);
+            }
+            if (process.platform !== 'win32') {
+                fs.chmodSync(toolLocation, 0o765);
+            }
         } else {
             toolLocation = cmd;
         }


### PR DESCRIPTION
 - skip unzip for tools that are not archives
 - make cli tools executable on other plaforms than windows (otherwise you get permission denied)