### PR TITLE
allowing users to "vsce package"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build Status](https://travis-ci.org/redhat-developer/vscode-openshift-tools.svg?branch=master)](https://travis-ci.org/redhat-developer/vscode-openshift-tools)
 
-This is the README for your extension "vscode-openshift-tools". After writing up a brief description, we recommend including the following sections.
-
 ## Features
 
 Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.


### PR DESCRIPTION
Removed the line "This is the README for ..." so that users can at least run "vsce package", which they can't currently, failing on the error:

Error: Make sure to edit the README.md file before you publish your extension.