### PR TITLE
Use '&&' to run sequence of commands in one line on win and unix

### DIFF
--- a/src/openshift/application.ts
+++ b/src/openshift/application.ts
@@ -26,7 +26,7 @@ export class Application extends OpenShiftItem {
     static describe(treeItem: OpenShiftObject): void {
         const projName: string = treeItem.getParent().getName();
         const appName: string = treeItem.getName();
-        Application.odo.executeInTerminal(`odo project set ${projName}; odo app describe ${appName}`, process.cwd());
+        Application.odo.executeInTerminal(`odo project set ${projName} && odo app describe ${appName}`, process.cwd());
     }
 
     static async del(treeItem: OpenShiftObject): Promise<string> {

--- a/test/openshift/application.test.ts
+++ b/test/openshift/application.test.ts
@@ -82,7 +82,7 @@ suite('Openshift/Application', () => {
         test('calls the appropriate odo command in terminal', () => {
             Application.describe(appItem);
 
-            expect(termStub).calledOnceWith(`odo project set ${projectItem.getName()}; odo app describe ${appItem.getName()}`, process.cwd());
+            expect(termStub).calledOnceWith(`odo project set ${projectItem.getName()} && odo app describe ${appItem.getName()}`, process.cwd());
         });
     });
 


### PR DESCRIPTION
Fix #300.