### PR TITLE
Fix requirLogin, tokenLogin and credentialsLogin

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -304,7 +304,7 @@ export class OdoImpl implements Odo {
     }
 
     public async requireLogin(): Promise<boolean> {
-        const result: cliInstance.CliExitData = await this.execute(`odo version && odo list project`);
+        const result: cliInstance.CliExitData = await this.execute(`odo version && odo project list`);
         return result.stdout.indexOf("Please log in to the cluster") > -1;
     }
 }

--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -113,7 +113,7 @@ export class Cluster extends OpenShiftItem {
         });
         if (!passwd) return Promise.resolve(null);
         return Promise.resolve()
-            .then(() => Cluster.odo.execute(`odo login ${clusterURL} -u ${username} -p ${passwd}`))
+            .then(() => Cluster.odo.execute(`odo login ${clusterURL} -u ${username} -p ${passwd} --insecure-skip-tls-verify`))
             .then((result) => Cluster.loginMessage(clusterURL, result))
             .catch((error) => { return Promise.reject(`Failed to login to cluster '${clusterURL}' with '${error}'!`); });
     }
@@ -125,7 +125,7 @@ export class Cluster extends OpenShiftItem {
         });
         if (!ocToken) return Promise.resolve(null);
         return Promise.resolve()
-            .then(() => Cluster.odo.execute(`odo login ${clusterURL} --token=${ocToken}`))
+            .then(() => Cluster.odo.execute(`odo login ${clusterURL} --token=${ocToken} --insecure-skip-tls-verify`))
             .then((result) => Cluster.loginMessage(clusterURL, result))
             .catch((error) => { return Promise.reject(`Failed to login to cluster '${clusterURL}' with '${error}'!`); });
     }

--- a/test/openshift/cluster.test.ts
+++ b/test/openshift/cluster.test.ts
@@ -110,7 +110,7 @@ suite('Openshift/Cluster', () => {
                 const status = await Cluster.login();
 
                 expect(status).equals(`Successfully logged in to '${testUrl}'`);
-                expect(execStub).calledOnceWith(`odo login ${testUrl} -u ${testUser} -p ${password}`);
+                expect(execStub).calledOnceWith(`odo login ${testUrl} -u ${testUser} -p ${password} --insecure-skip-tls-verify`);
                 expect(commandStub).calledOnceWith('setContext', 'isLoggedIn', true);
             });
 
@@ -150,7 +150,7 @@ suite('Openshift/Cluster', () => {
                 const status = await Cluster.login();
 
                 expect(status).equals(`Successfully logged in to '${testUrl}'`);
-                expect(execStub).calledOnceWith(`odo login ${testUrl} --token=${token}`);
+                expect(execStub).calledOnceWith(`odo login ${testUrl} --token=${token} --insecure-skip-tls-verify`);
                 expect(commandStub).calledOnceWith('setContext', 'isLoggedIn', true);
             });
 


### PR DESCRIPTION
In check login && odo project list is required, because now
`odo version` would not print out 'Please log in to the cluster',
in case user is nod logged in, but 'odo project list' would.

Fix #369.