### PR TITLE
 Use the same tool location when running in terminal or through odo.execute

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -286,8 +286,13 @@ export class OdoImpl implements Odo {
         return [... await this.getComponents(application), ... await this.getServices(application)];
     }
 
-    public executeInTerminal(command: string, cwd: string = process.cwd(), name: string = 'OpenShift') {
-        const terminal: Terminal = WindowUtil.createTerminal(name, cwd);
+    public async executeInTerminal(command: string, cwd: string = process.cwd(), name: string = 'OpenShift') {
+        const cmd = command.split(' ')[0];
+        let toolLocation = await ToolsConfig.detectOrDownload(cmd);
+        if (toolLocation) {
+            toolLocation = path.dirname(toolLocation);
+        }
+        const terminal: Terminal = WindowUtil.createTerminal(name, cwd, toolLocation);
         terminal.sendText(command, true);
         terminal.show();
     }

--- a/src/util/windowUtils.ts
+++ b/src/util/windowUtils.ts
@@ -10,14 +10,15 @@ import * as path from 'path';
 import { Platform } from './platform';
 
 export class WindowUtil {
-    private static readonly toolsLocation: string = path.resolve(Platform.getUserHomePath(), '.vs-openshift');
 
-    static createTerminal(name: string, cwd: string, env: NodeJS.ProcessEnv = process.env): Terminal {
+    static createTerminal(name: string, cwd: string, toolLocation?: string, env: NodeJS.ProcessEnv = process.env): Terminal {
         const finalEnv: NodeJS.ProcessEnv = {};
         Object.assign(finalEnv, env);
         const key = process.platform === 'win32' ? 'Path' : 'PATH';
-        finalEnv[key] = `${this.toolsLocation}${path.delimiter}${env[key]}`;
 
+        if (toolLocation && env[key] && !env[key].includes(toolLocation)) {
+            finalEnv[key] = `${toolLocation}${path.delimiter}${env[key]}`;
+        }
         const options: TerminalOptions = {
             cwd: cwd,
             name: name,

--- a/test/util/window.test.ts
+++ b/test/util/window.test.ts
@@ -40,7 +40,6 @@ suite('Window Utility', () => {
         const env: NodeJS.ProcessEnv = {};
         const key = process.platform === 'win32' ? 'Path' : 'PATH';
         Object.assign(env, process.env);
-
         env[key] = `${toolLocationDir}${path.delimiter}${process.env[key]}`;
 
         const options: TerminalOptions = {

--- a/test/util/window.test.ts
+++ b/test/util/window.test.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { window, TerminalOptions } from 'vscode';
 import { WindowUtil } from '../../src/util/windowUtils';
 import { Platform } from '../../src/util/platform';
+import { ToolsConfig } from '../../src/tools';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -31,15 +32,16 @@ suite('Window Utility', () => {
 
     test('createTerminal creates a terminal object', () => {
         WindowUtil.createTerminal('name', process.cwd());
-
         expect(termStub).calledOnce;
     });
 
     test('createTerminal adds tools location and shell path to the environment', () => {
+        const toolLocationDir = path.dirname(path.join("dir", "where", "tool", "is", "located", "tool"));
         const env: NodeJS.ProcessEnv = {};
         const key = process.platform === 'win32' ? 'Path' : 'PATH';
         Object.assign(env, process.env);
-        env[key] = `${path.join(Platform.getUserHomePath(), '.vs-openshift')}${path.delimiter}${process.env[key]}`;
+
+        env[key] = `${toolLocationDir}${path.delimiter}${process.env[key]}`;
 
         const options: TerminalOptions = {
             cwd: process.cwd(),
@@ -47,7 +49,7 @@ suite('Window Utility', () => {
             shellPath: process.platform === 'win32' ? undefined : '/bin/bash',
             env: env
         };
-        WindowUtil.createTerminal('terminal', process.cwd());
+        WindowUtil.createTerminal('terminal', process.cwd(), toolLocationDir);
 
         expect(termStub).calledOnceWith(options);
     });


### PR DESCRIPTION
Fix #305.