### PR TITLE
Synchronize creation of ~/.kube directory

### DIFF
--- a/src/util/watch.ts
+++ b/src/util/watch.ts
@@ -16,7 +16,7 @@ export class WatchUtil {
         const emitter: EventEmitter = new EventEmitter();
         let timer: NodeJS.Timer;
         let context = '';
-        fsex.ensureDir(location);
+        fsex.ensureDirSync(location);
         const watcher: fs.FSWatcher = fsex.watch(location, (eventType, changedFile) => {
             if (filename === changedFile) {
                 if (timer) {

--- a/test/util/watch.test.ts
+++ b/test/util/watch.test.ts
@@ -22,7 +22,7 @@ suite('File Watch Utility', () => {
 
     setup(() => {
         sandbox = sinon.createSandbox();
-        ensureStub = sandbox.stub(fs, 'ensureDir');
+        ensureStub = sandbox.stub(fs, 'ensureDirSync');
         watchStub = sandbox.stub(fs, 'watch');
     });
 


### PR DESCRIPTION
Intermittent test failures started occurring on CI, crashing while the extension is being launched with 
```
Error: watch /home/hudson/.kube ENOENT
```
This seems due to a race condition in the ~/.kube/config watcher, as sometimes it takes longer to create the directory than to call the watcher. Synchronizing the folder creation seems to fix the problem.