### PR TITLE
Delete tools archives after download

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -142,6 +142,7 @@ export class ToolsConfig {
                         } else if (toolDlLocation.endsWith('.gz')) {
                             await Archive.unzip(toolDlLocation, toolCacheLocation, ToolsConfig.tools[cmd].filePrefix);
                         }
+                        fsex.removeSync(toolDlLocation);
                         if (Platform.OS !== 'win32') {
                             fs.chmodSync(toolCacheLocation, 0o765);
                         }


### PR DESCRIPTION
After downloading the tools archives and unzipping them, these archives are left in the `.vs-openshift` folder. It's useless having them so this PR just delete these files (in the same way it happens that the SHA if wrong).