### PR TITLE
Merge execute and executeAsync in one function

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,34 +19,34 @@ import { Service } from './openshift/service';
 export function activate(context: vscode.ExtensionContext) {
     const explorer: explorerFactory.OpenShiftExplorer = explorerFactory.OpenShiftExplorer.getInstance();
     const disposable = [
-        vscode.commands.registerCommand('openshift.about', (context) => executeSync(Cluster.about, context)),
+        vscode.commands.registerCommand('openshift.about', (context) => execute(Cluster.about, context)),
         vscode.commands.registerCommand('openshift.openshiftConsole', (context) => execute(Cluster.openshiftConsole, context)),
         vscode.commands.registerCommand('openshift.openshiftConsole.palette', (context) => execute(Cluster.openshiftConsole, context)),
         vscode.commands.registerCommand('openshift.explorer.login', (context) => execute(Cluster.login, context)),
         vscode.commands.registerCommand('openshift.explorer.logout', (context) => execute(Cluster.logout, context)),
-        vscode.commands.registerCommand('openshift.explorer.refresh', (context) => executeSync(Cluster.refresh, context)),
-        vscode.commands.registerCommand('openshift.catalog.listComponents', (context) => executeSync(Catalog.listComponents, context)),
-        vscode.commands.registerCommand('openshift.catalog.listServices', (context) => executeSync(Catalog.listServices, context)),
+        vscode.commands.registerCommand('openshift.explorer.refresh', (context) => execute(Cluster.refresh, context)),
+        vscode.commands.registerCommand('openshift.catalog.listComponents', (context) => execute(Catalog.listComponents, context)),
+        vscode.commands.registerCommand('openshift.catalog.listServices', (context) => execute(Catalog.listServices, context)),
         vscode.commands.registerCommand('openshift.project.create', (context) => execute(Project.create, context)),
         vscode.commands.registerCommand('openshift.project.delete', (context) => execute(Project.del, context)),
         vscode.commands.registerCommand('openshift.project.delete.palette', (context) => execute(Project.del, context)),
         vscode.commands.registerCommand('openshift.app.delete.palette', (context) => execute(Application.del, context)),
-        vscode.commands.registerCommand('openshift.app.describe', (context) => executeSync(Application.describe, context)),
+        vscode.commands.registerCommand('openshift.app.describe', (context) => execute(Application.describe, context)),
         vscode.commands.registerCommand('openshift.app.describe.palette', (context) => execute(Application.describe, context)),
         vscode.commands.registerCommand('openshift.app.create', (context) => execute(Application.create, context)),
         vscode.commands.registerCommand('openshift.app.delete', (context) => execute(Application.del, context)),
-        vscode.commands.registerCommand('openshift.component.describe', (context) => executeSync(Component.describe, context)),
+        vscode.commands.registerCommand('openshift.component.describe', (context) => execute(Component.describe, context)),
         vscode.commands.registerCommand('openshift.component.describe.palette', (context) => execute(Component.describe, context)),
         vscode.commands.registerCommand('openshift.component.create', (context) => execute(Component.create, context)),
         vscode.commands.registerCommand('openshift.component.delete.palette', (context) => execute(Component.del, context)),
-        vscode.commands.registerCommand('openshift.component.push', (context) => executeSync(Component.push, context)),
-        vscode.commands.registerCommand('openshift.component.push.palette', (context) => executeSync(Component.push, context)),
-        vscode.commands.registerCommand('openshift.component.watch', (context) => executeSync(Component.watch, context)),
+        vscode.commands.registerCommand('openshift.component.push', (context) => execute(Component.push, context)),
+        vscode.commands.registerCommand('openshift.component.push.palette', (context) => execute(Component.push, context)),
+        vscode.commands.registerCommand('openshift.component.watch', (context) => execute(Component.watch, context)),
         vscode.commands.registerCommand('openshift.component.watch.palette', (context) => execute(Component.watch, context)),
-        vscode.commands.registerCommand('openshift.component.log', (context) => executeSync(Component.log, context)),
-        vscode.commands.registerCommand('openshift.component.log.palette', (context) => executeSync(Component.log, context)),
-        vscode.commands.registerCommand('openshift.component.followLog', (context) => executeSync(Component.followLog, context)),
-        vscode.commands.registerCommand('openshift.component.followLog.palette', (context) => executeSync(Component.followLog, context)),
+        vscode.commands.registerCommand('openshift.component.log', (context) => execute(Component.log, context)),
+        vscode.commands.registerCommand('openshift.component.log.palette', (context) => execute(Component.log, context)),
+        vscode.commands.registerCommand('openshift.component.followLog', (context) => execute(Component.followLog, context)),
+        vscode.commands.registerCommand('openshift.component.followLog.palette', (context) => execute(Component.followLog, context)),
         vscode.commands.registerCommand('openshift.component.openUrl', (context) => execute(Component.openUrl, context)),
         vscode.commands.registerCommand('openshift.component.openUrl.palette', (context) => execute(Component.openUrl, context)),
         vscode.commands.registerCommand('openshift.component.delete', (context) => execute(Component.del, context)),
@@ -69,19 +69,17 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {
 }
 
-function execute<T>(command: (...args: T[]) => Promise<any>, ...params: T[]) {
-    return command.call(null, ...params)
-    .then((result) => {
-        displayResult(result);
-    }).catch((err) => {
-        vscode.window.showErrorMessage(err.message ? err.message : err);
-    });
-}
-
-function executeSync<T>(command: (...args: T[]) => any, ...params: T[]) {
+function execute<T>(command: (...args: T[]) => Promise<any> | void, ...params: T[]) {
     try {
-        const result = command.call(null, ...params);
-        displayResult(result);
+        const res = command.call(null, ...params)
+        return res && res.then 
+            ? res.then((result: any) => {
+                displayResult(result);
+    
+            }).catch((err: any) => {
+                vscode.window.showErrorMessage(err.message ? err.message : err);
+            }) 
+            : undefined;
     } catch (err) {
         vscode.window.showErrorMessage(err);
     }


### PR DESCRIPTION
This fix #528 lets to avoid extra changes in extension.ts file if command
changes form async to sync and vice versa.