### PR TITLE
Remove kubernetes Clusters View from OpenShift Views Container

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,10 +278,6 @@
     "views": {
       "openshiftView": [
         {
-          "id": "extension.vsKubernetesExplorer",
-          "name": "Clusters"
-        },
-        {
           "id": "openshiftProjectExplorer",
           "name": "OpenShift Application Explorer"
         }


### PR DESCRIPTION
Fix #87. It removes `Clusters` view from OpenShift Views Container. Dependency for k8s extension was removed accidentally in previous commits. 