### PR TITLE
Show progress for while deleting service and wait until it is gone

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -104,6 +104,8 @@ export const Command = {
         `odo service create ${template} --plan ${plan} ${name} --app ${app} --project ${project}`,
     deleteService: (project: string, app: string, name: string) =>
         `odo service delete ${name} -f --project ${project} --app ${app}`,
+    waitForServiceToBeGone: (project: string, service: string) =>
+        `oc wait ServiceInstance/${service} --for delete --namespace ${project}`,
     createCompontentUrl: (project: string, app: string, component: string, port: string) =>
         `odo url create --port ${port} --project ${project} --app ${app} --component ${component}`,
     getComponentJson: (project: string, app: string, component: string) =>

--- a/test/openshift/service.test.ts
+++ b/test/openshift/service.test.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
-import { OdoImpl } from '../../src/odo';
+import { OdoImpl, Command } from '../../src/odo';
 import { TestItem } from './testOSItem';
 import { Progress } from '../../src/util/progress';
 import { Service } from '../../src/openshift/service';
@@ -176,14 +176,16 @@ suite('Openshift/Service', () => {
             const result = await Service.del(serviceItem);
 
             expect(result).equals(`Service '${serviceItem.getName()}' successfully deleted`);
-            expect(execStub).calledOnceWith(`odo service delete ${serviceItem.getName()} -f --project ${projectItem.getName()} --app ${appItem.getName()}`);
+            expect(execStub.getCall(0).args[0]).equals(Command.deleteService(projectItem.getName(), appItem.getName(), serviceItem.getName()));
+            expect(execStub.getCall(1).args[0]).equals(Command.waitForServiceToBeGone(projectItem.getName(), serviceItem.getName()));
         });
 
         test('works without context item', async () => {
             const result = await Service.del(null);
 
             expect(result).equals(`Service '${serviceItem.getName()}' successfully deleted`);
-            expect(execStub).calledOnceWith(`odo service delete ${serviceItem.getName()} -f --project ${projectItem.getName()} --app ${appItem.getName()}`);
+            expect(execStub.getCall(0).args[0]).equals(Command.deleteService(projectItem.getName(), appItem.getName(), serviceItem.getName()));
+            expect(execStub.getCall(1).args[0]).equals(Command.waitForServiceToBeGone(projectItem.getName(), serviceItem.getName()));
         });
 
         test('returns null with no application selected', async () => {


### PR DESCRIPTION
Fix #146. The fix uses `oc wait` to postpone Explorer refresh command
after deleting service command is called and confirmed.