### PR TITLE
Fix refresh call after create or delete service

### DIFF
--- a/src/openshift/service.ts
+++ b/src/openshift/service.ts
@@ -42,7 +42,7 @@ export class Service extends OpenShiftItem {
                 const project = application.getParent();
                 return Progress.execCmdWithProgress(`Creating a new Service '${serviceName}'`,
                     Command.createService(project.getName(), application.getName(), serviceTemplateName, serviceTemplatePlanName, serviceName.trim()))
-                    .then(() => Service.explorer.refresh())
+                    .then(() => Service.explorer.refresh(context ? context : undefined))
                     .then(() => `Service '${serviceName}' successfully created`)
                     .catch((err) => Promise.reject(`Failed to create Service with error '${err}'`));
             }
@@ -68,7 +68,7 @@ export class Service extends OpenShiftItem {
                 return Progress.execFunctionWithProgress(`Deleting Service '${service.getName()}' from Application '${service.getParent().getName()}'`,
                     (progress) => Service.odo.execute(Command.deleteService(service.getParent().getParent().getName(), service.getParent().getName(), service.getName()))
                         .then(() => Service.odo.execute(Command.waitForServiceToBeGone(service.getParent().getParent().getName(), service.getName())))
-                        .then(() => Service.explorer.refresh(service.getParent()))
+                        .then(() => Service.explorer.refresh(treeItem ? treeItem.getParent() : undefined))
                         .then(() => `Service '${service.getName()}' successfully deleted`)
                         .catch((err) => Promise.reject(`Failed to delete Service with error '${err}'`))
                 );


### PR DESCRIPTION
Fix avoids to call full refresh if command executed form
context menu.

Fix #584.