### PR TITLE
Stub keytar in tests

### DIFF
--- a/test/openshift/cluster.test.ts
+++ b/test/openshift/cluster.test.ts
@@ -47,6 +47,7 @@ suite('Openshift/Cluster', () => {
 
     setup(() => {
         sandbox = sinon.createSandbox();
+        sandbox.stub(keytar);
         execStub = sandbox.stub(OdoImpl.prototype, 'execute').resolves(testData);
         inputStub = sandbox.stub(vscode.window, 'showInputBox');
         commandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves();
@@ -136,7 +137,6 @@ suite('Openshift/Cluster', () => {
 
             (keytar ? test : test.skip)('returns with no username set', async () => {
                 inputStub.onSecondCall().resolves();
-                sandbox.stub(keytar, 'getPassword').returns(undefined);
                 const status = await Cluster.login();
 
                 expect(status).null;


### PR DESCRIPTION
The rhel CI machines really don't like keytar. Any time keytar is called, this error is produced:
```Unknown or unsupported transport “disabled” for address “disabled:”```
Stubbing keytar in related tests to have it built successfully on rhel.