### PR TITLE
Cancelling the login type quick pick automatically selects token login

### DIFF
--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -72,6 +72,7 @@ export class Cluster extends OpenShiftItem {
         const response = await Cluster.requestLoginConfirmation();
         if (response !== 'Yes') return null;
         const loginMethod = await vscode.window.showQuickPick(['Credentials', 'Token'], {placeHolder: 'Select the way to log in to the cluster.'});
+        if (!loginMethod) return null;
         if (loginMethod === "Credentials") {
             return Cluster.credentialsLogin(true);
         } else {


### PR DESCRIPTION
Fix: #714 