### PR TITLE
Fix revealing objects

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -68,7 +68,9 @@ export class OpenShiftExplorer implements TreeDataProvider<OpenShiftObject>, Dis
     }
 
     async reveal(item: OpenShiftObject): Promise<void> {
-       this.refresh(item.getParent());
+        this.refresh(item.getParent());
+        // double call of reveal is workaround for possible upstream issue
+        // https://github.com/redhat-developer/vscode-openshift-tools/issues/762
         await this.treeView.reveal(item);
         this.treeView.reveal(item);
     }

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -67,8 +67,9 @@ export class OpenShiftExplorer implements TreeDataProvider<OpenShiftObject>, Dis
         this.treeView.dispose();
     }
 
-    async reveal(newProject: OpenShiftObject): Promise<void> {
-        this.refresh(newProject.getParent());
-        await this.treeView.reveal(newProject);
+    async reveal(item: OpenShiftObject): Promise<void> {
+       this.refresh(item.getParent());
+        await this.treeView.reveal(item);
+        this.treeView.reveal(item);
     }
 }

--- a/src/openshift/application.ts
+++ b/src/openshift/application.ts
@@ -17,9 +17,8 @@ export class Application extends OpenShiftItem {
         const applicationList: Array<OpenShiftObject> = await OpenShiftItem.odo.getApplications(project);
         const applicationName = await Application.getName('Application name', applicationList);
         if (!applicationName) return null;
-        return Progress.execFunctionWithProgress(`Deleting the Application '${applicationName}'.`, () =>
+        return Progress.execFunctionWithProgress(`Creating the Application '${applicationName}'.`, () =>
             Application.odo.createApplication(project, applicationName)
-                .then(() => Application.explorer.refresh(project))
                 .then(() => `Application '${applicationName}' successfully created`)
                 .catch((error) => Promise.reject(`Failed to create Application with error '${error}'`)));
     }

--- a/test/openshift/application.test.ts
+++ b/test/openshift/application.test.ts
@@ -117,7 +117,7 @@ suite('OpenShift/Application', () => {
 
                 await Application.create(projectItem);
 
-                expect(execStub).calledOnceWith(Command.createApplication(projectItem.getName(), 'name'));
+                expect(execStub).calledWith(Command.createApplication(projectItem.getName(), 'name'));
             });
 
             test('returns a message when successful', async () => {


### PR DESCRIPTION
Fix #762. 
Workaround is calling reveal second time, to make newly created object selected.