### PR TITLE
Rename 'Delete URL' to 'Delete' in OpenShift App Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "onCommand:openshift.catalog.listServices",
     "onCommand:openshift.url.create",
     "onCommand:openshift.url.delete",
+    "onCommand:openshift.url.delete.palette",
     "onCommand:openshift.component.openUrl",
     "onCommand:openshift.component.openUrl.palette",
     "onCommand:openshift.storage.create",
@@ -273,6 +274,11 @@
       },
       {
         "command": "openshift.url.delete",
+        "title": "Delete",
+        "category": "OpenShift"
+      },
+      {
+        "command": "openshift.url.delete.palette",
         "title": "Delete URL",
         "category": "OpenShift"
       },
@@ -410,6 +416,10 @@
         },
         {
           "command": "openshift.storage.delete",
+          "when": "view == openshiftProjectExplorer"
+        },
+        {
+          "command": "openshift.url.delete",
           "when": "view == openshiftProjectExplorer"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('openshift.storage.delete', (context) => execute(Storage.del, context)),
         vscode.commands.registerCommand('openshift.url.create', (context) => execute(Url.create, context)),
         vscode.commands.registerCommand('openshift.url.delete', (context) => execute(Url.del, context)),
+        vscode.commands.registerCommand('openshift.url.delete.palette', (context) => execute(Url.del, context)),
         vscode.commands.registerCommand('openshift.service.create', (context) => execute(Service.create, context)),
         vscode.commands.registerCommand('openshift.service.delete', (context) => execute(Service.del, context)),
         vscode.commands.registerCommand('openshift.service.delete.palette', (context) => execute(Service.del, context)),


### PR DESCRIPTION
Fix remanes URL commands available for URL node to just 'Delete'
and restores 'Delete URL' available from command palette.