### PR TITLE
 Add verbosity settings for create, push and watch commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -595,6 +595,12 @@
           "type": "boolean",
           "default": false,
           "description": "Show OpenShift Connector output channel when new text added to output stream."
+        },
+        "openshiftConnector.outputVerbosityLevel": {
+          "title": "OpenShift commands output verbosity level",
+          "type": "number",
+          "default": 0,
+          "description": "Configure output verbosity level (value between 0 and 9) for OpenShift create, push and watch commands in output channel and terminal view"
         }
       }
     }

--- a/src/odo.ts
+++ b/src/odo.ts
@@ -66,6 +66,7 @@ export class Command {
     static waitForProjectToBeGone(project: string) {
         return `oc wait project/${project} --for delete`;
     }
+    @verbose
     static createProject(name: string) {
         return `odo project create ${name}`;
     }


### PR DESCRIPTION
Firs iteration fix for #754.

To enable verbose output user must manually setup ```openshiftConnector.outputVerbosityLevel``` setting through VSCode settings editor and that would affect only commands create, push and watch annotated with @verbose annotation.