### PR TITLE
Run build instead of compile on vscode:prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -834,7 +834,7 @@
   "extensionDependencies": [],
   "scripts": {
     "verify": "node ./out/build/verify-tools.js",
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "npm run build",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",

--- a/src/openshift/url.ts
+++ b/src/openshift/url.ts
@@ -72,7 +72,6 @@ export class Url extends OpenShiftItem{
         const app = component.getParent();
         const namespace = app.getParent();
         const urlDetails = await Url.odo.execute(Command.getComponentUrl(namespace.getName(), app.getName(), component.getName()), component.contextPath.fsPath);
-        const stdout = urlDetails.stdout;
         let urlObject: any;
         let result: any[];
         try {


### PR DESCRIPTION
This is mostly to run tslint during PR checks. Also fix a tslint error.