### PR TITLE
add console url for 3.x and 4.x clusters

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "onCommand:openshift.component.folder.create",
     "onCommand:openshift.explorer.reportIssue",
     "onCommand:openshift.explorer.switchContext",
-    "onCommand:clusters.openshift.openProjectConsole",
+    "onCommand:clusters.openshift.project.openConsole",
     "onCommand:clusters.openshift.useProject",
     "onCommand:clusters.openshift.deploy",
     "onCommand:clusters.openshift.build.start",
@@ -402,7 +402,7 @@
         "category": "OpenShift"
       },
       {
-        "command": "clusters.openshift.openProjectConsole",
+        "command": "clusters.openshift.project.openConsole",
         "title": "Open Project in Console"
       },
       {
@@ -802,8 +802,8 @@
           "when": "viewItem =~ /\\.openshift\\.inactiveProject/i"
         },
         {
-          "command": "clusters.openshift.openProjectConsole",
-          "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.\\w*cluster/i"
+          "command": "clusters.openshift.project.openConsole",
+          "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.project*/i"
         },
         {
           "command": "openshift.explorer.switchContext",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,6 +70,7 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('clusters.openshift.build.openConsole', (context) => execute(Console.openBuildConfig, context)),
         vscode.commands.registerCommand('clusters.openshift.deployment.openConsole', (context) => execute(Console.openDeploymentConfig, context)),
         vscode.commands.registerCommand('clusters.openshift.imagestream.openConsole', (context) => execute(Console.openImageStream, context)),
+        vscode.commands.registerCommand('clusters.openshift.project.openConsole', (context) => execute(Console.openProject, context)),
         vscode.commands.registerCommand('openshift.component.createFromLocal', (context) => execute(Component.createFromLocal, context)),
         vscode.commands.registerCommand('openshift.component.createFromGit', (context) => execute(Component.createFromGit, context)),
         vscode.commands.registerCommand('openshift.component.createFromBinary', (context) => execute(Component.createFromBinary, context)),
@@ -101,7 +102,6 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('openshift.component.linkComponent', (context) => execute(Component.linkComponent, context)),
         vscode.commands.registerCommand('openshift.component.linkService', (context) => execute(Component.linkService, context)),
         vscode.commands.registerCommand('openshift.explorer.reportIssue', () => OpenShiftExplorer.reportIssue()),
-        vscode.commands.registerCommand('clusters.openshift.openProjectConsole', openProjectConsole),
         vscode.commands.registerCommand('clusters.openshift.useProject', (context) => vscode.commands.executeCommand('extension.vsKubernetesUseNamespace', context)),
         OpenShiftExplorer.getInstance()
     ];
@@ -147,21 +147,6 @@ async function initNamespaceName(node: ClusterExplorerV1.ClusterExplorerResource
             return "";
         }
         return currentContext.context.namespace || "default";
-    }
-}
-
-async function openProjectConsole (commandTarget: any) {
-    if (!commandTarget) {
-        vscode.window.showErrorMessage("Cannot load the Project");
-        return;
-    }
-
-    if (isOpenShift()) {
-        const project = commandTarget.id.split('/')[0];
-        const clusterUrl = commandTarget.metadata.clusterName.replace(/-/g, '.');
-        vscode.window.showInformationMessage(`Opening Console for project '${project}'`);
-        await open(`https://${clusterUrl}/console/project/${project}/overview`);
-        return;
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,6 @@ import { ClusterExplorerV1 } from 'vscode-kubernetes-tools-api';
 import { BuildConfigNodeContributor } from './k8s/build';
 import { Console } from './k8s/console';
 import { OdoImpl } from './odo';
-import open = require("open");
 import { Build } from './k8s/build';
 import * as Deployment from './k8s/deployment';
 

--- a/src/odo.ts
+++ b/src/odo.ts
@@ -110,6 +110,9 @@ export class Command {
     static printOdoVersion() {
         return 'odo version';
     }
+    static printOdoVersionAndProjects() {
+        return 'odo version && odo project list';
+    }
     static odoLogout() {
         return `odo logout`;
     }
@@ -539,7 +542,7 @@ export class OdoImpl implements Odo {
     private async getClustersWithOdo(): Promise<OpenShiftObject[]> {
         let clusters: OpenShiftObject[] = [];
         const result: cliInstance.CliExitData = await this.execute(
-            Command.printOdoVersion(), process.cwd(), false
+            Command.printOdoVersionAndProjects(), process.cwd(), false
         );
         if (this.odoLoginMessages.some((element) => result.stderr ? result.stderr.indexOf(element) > -1 : false)) {
             const loginErrorMsg: string = 'Please log in to the cluster';
@@ -762,7 +765,7 @@ export class OdoImpl implements Odo {
     }
 
     public async requireLogin(): Promise<boolean> {
-        const result: cliInstance.CliExitData = await this.execute(Command.printOdoVersion(), process.cwd(), false);
+        const result: cliInstance.CliExitData = await this.execute(Command.printOdoVersionAndProjects(), process.cwd(), false);
         return this.odoLoginMessages.some((element) => { return result.stderr.indexOf(element) > -1; });
     }
 

--- a/test/odo.test.ts
+++ b/test/odo.test.ts
@@ -523,7 +523,7 @@ suite("odo", () => {
             const stub = sandbox.stub(odoCli, 'execute').resolves({ error: null, stdout: 'logged in', stderr: ''});
             const result = await odoCli.requireLogin();
 
-            expect(stub).calledOnceWith(odo.Command.printOdoVersion());
+            expect(stub).calledOnceWith(odo.Command.printOdoVersionAndProjects());
             expect(result).false;
         });
 


### PR DESCRIPTION
fix #1021 


- This fix allows to differentiate between console url for 3.x and 4.x for all k8 resources.

- Add `Open Project in Console` to Project resources
