### PR TITLE
`Open in Browser` commands should show only components in 'pushed' state

### DIFF
--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -292,7 +292,9 @@ export class Component extends OpenShiftItem {
         const component = await Component.getOpenShiftCmdData(context,
             'Select a Project',
             'Select an Application',
-            'Select a Component you want to open in browser');
+            'Select a Component you want to open in browser',
+            (value: OpenShiftObject) => value.contextValue === ContextType.COMPONENT_PUSHED
+        );
         if (!component) return null;
         const app: OpenShiftObject = component.getParent();
         const namespace: string = app.getParent().getName();


### PR DESCRIPTION
Fix: #1081 