### PR TITLE
New binary component appears in 'pushed' state

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -924,7 +924,7 @@ export class OdoImpl implements Odo {
             if (!targetApplication) {
                 await this.insertAndReveal(application);
             }
-            this.insertAndReveal(new OpenShiftObjectImpl(application, name, ContextType.COMPONENT, false, this, Collapsed, undefined, 'binary'));
+            this.insertAndReveal(new OpenShiftObjectImpl(application, name, ContextType.COMPONENT, false, this, Collapsed, context, 'binary'));
         }
         workspace.updateWorkspaceFolders(workspace.workspaceFolders? workspace.workspaceFolders.length : 0 , null, { uri: context });
         return null;


### PR DESCRIPTION
Fix passes selected context folder to the component's constructor.
Fix #1072.