### PR TITLE
Remove recursive search from binary component selection

### DIFF
--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -524,17 +524,12 @@ export class Component extends OpenShiftItem {
         }
 
         if (!workspacePath) return null;
-
-        const paths = globby.sync(workspacePath.path, {
-                expandDirectories: {
-                    files: ['*'],
-                    extensions: ['jar', 'war']
-                }
-            });
+        const globPath = process.platform === 'win32' ? workspacePath.fsPath.replace(/\\/g, '/') : workspacePath.path;
+        const paths = globby.sync(`${globPath}/*.+(jar|war)`, { extglob: true });
 
         if (paths.length === 0) return window.showInformationMessage("No binary file present in the context folder selected. We currently only support .jar and .war files. If you need support for any other file, please raise an issue.");
 
-        const binaryFileObj: QuickPickItem[] = paths.map((file) => ({ label: `$(file-zip) ${file.split('/').pop()}`, description: `${file}`}));
+        const binaryFileObj: QuickPickItem[] = paths.map((file) => ({ label: `$(file-zip) ${path.basename(file)}`, description: `${file}`}));
 
         const binaryFile: any = await window.showQuickPick(binaryFileObj, {placeHolder: "Select binary file"});
 


### PR DESCRIPTION
Searching for jar/war files recursively doesn't make much sense when you specifically select the folder they are in. And it is especially insane when searching from, say, the user home (that actually crashed vscode after it reached ~8GB of memory allocated).

Also, the URI style path didn't work for windows, so I just took the standard fsPath and replaced backslashes with forward ones.