### PR TITLE
Restore odo executable file name for windows binary in tools.json

### DIFF
--- a/src/tools.json
+++ b/src/tools.json
@@ -13,7 +13,8 @@
             "win32": {
                 "url": "https://github.com/openshift/odo/releases/download/v1.0.0-beta5/odo-windows-amd64.exe.tar.gz",
                 "sha256sum": "7cf31f35b53ad954eeec690afd4a8ad2ed433cb1b982964ba5b1484c021660d8",
-                "dlFileName": "odo-windows-amd64.exe.tar.gz"
+                "dlFileName": "odo-windows-amd64.exe.tar.gz",
+                "cmdFileName": "odo.exe"
             },
             "darwin": {
                 "url": "https://github.com/openshift/odo/releases/download/v1.0.0-beta5/odo-darwin-amd64.tar.gz",


### PR DESCRIPTION
Fix #1142.