### PR TITLE
Remove never executed code

### DIFF
--- a/src/k8s/deployment.ts
+++ b/src/k8s/deployment.ts
@@ -67,9 +67,6 @@ export class DeploymentConfig {
         const result = await DeploymentConfig.odo.execute(cmd);
         const replica: string = result.stdout;
         const replicationList = replica.split("\n");
-        if (replicationList.length === 0) {
-            throw Error(errorMessage);
-        }
         return replicationList;
     }
 


### PR DESCRIPTION
Remove `replicationList.length` because when we delete last replica it recreates a new replica.