### PR TITLE
Fix `npm run build` failure in case there is no `./out` folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -978,7 +978,7 @@
     "vscode:prepublish": "npm run build",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "clean": "rm -rf out || rmdir out /s /q",
+    "clean": "rm -rf out || rmdir out /s /q || echo 'no out folder, ignoring errors'",
     "test": "npm run clean && npm run compile && npm run verify && node ./out/build/unit-tests.js",
     "update-deps": "node_modules/.bin/ncu --upgrade --loglevel verbose --packageFile package.json && npm update",
     "coverage:upload": "codecov -f coverage/coverage-final.json",


### PR DESCRIPTION
Fix #1290.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>