### PR TITLE
Using built-in compiler to check no-unused-variable

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         /* Strict Type-Checking Option */
         "strict": false,   /* enable all strict type-checking options */
         /* Additional Checks */
-        "noUnusedLocals": false, /* Report errors on unused locals. */
+        "noUnusedLocals": true, /* Report errors on unused locals. */
         // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
         // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
         // "noUnusedParameters": true,  /* Report errors on unused parameters. */

--- a/tslint.json
+++ b/tslint.json
@@ -52,7 +52,6 @@
             }
         ],
         "no-trailing-whitespace": true,
-        "no-debugger": true,
-        "no-unused-variable": true
+        "no-debugger": true
     }
 }


### PR DESCRIPTION
Fix: #1289 