### PR TITLE
Catch exceptions when accessing env.clipboard and return empty string

### DIFF
--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -180,7 +180,12 @@ export class Cluster extends OpenShiftItem {
     }
 
     static async readFromClipboard(): Promise<string> {
-        return env.clipboard ? await env.clipboard.readText() : "";
+        let r = "";
+        try {
+            r = await env.clipboard.readText();
+        } catch (ignore) {
+        }
+        return r;
     }
 
     static async getUrlFromClipboard() {


### PR DESCRIPTION
Fix #1304.
Signed-off-by: Denis Golovin <dgolovin@redhat.com>