### PR TITLE
Update nodejs for build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node('rhel7'){
 	}
 
 	stage('Install requirements') {
-		def nodeHome = tool 'nodejs-8.11.1'
+		def nodeHome = tool 'nodejs-12.13.1'
 		env.PATH="${env.PATH}:${nodeHome}/bin"
 		sh "npm install -g typescript vsce"
 	}


### PR DESCRIPTION
Build is failing due to outdated nodejs runtime
```
> node ./out/build/verify-tools.js

internal/util.js:209
    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'original', 'function');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "original" argument must be of type function
```
Update it to v12.