### PR TITLE
Do not request to clone repo used to create git component

### DIFF
--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -475,8 +475,6 @@ export class Component extends OpenShiftItem {
 
         if (!componentTypeVersion) return null;
 
-        const response = await window.showInformationMessage('Do you want to clone git repository for created Component?', 'Yes', 'No');
-        if (response === 'Yes') await commands.executeCommand('git.clone', repoURI);
         await Component.odo.createComponentFromGit(application, componentTypeName, componentTypeVersion, componentName, repoURI, workspacePath, gitRef.label);
         return `Component '${componentName}' successfully created. To deploy it on cluster, perform 'Push' action.`;
     }

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -41,7 +41,6 @@ suite('OpenShift/Component', () => {
     let getProjects: sinon.SinonStub;
     let getApps: sinon.SinonStub;
     let Component: any;
-    let infoStub: sinon.SinonStub;
     let fetchTag: sinon.SinonStub;
     let commandStub: sinon.SinonStub;
 

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -193,7 +193,7 @@ suite('OpenShift/Component', () => {
                 quickPickStub.onCall(3).resolves(componentType);
                 quickPickStub.onCall(4).resolves(version);
                 inputStub.onSecondCall().resolves(componentItem.getName());
-                infoStub = sandbox.stub(vscode.window, 'showInformationMessage').resolves();
+                sandbox.stub(vscode.window, 'showInformationMessage').resolves();
                 sandbox.stub(vscode.window, 'showOpenDialog').resolves([vscode.Uri.parse('file:///c%3A/Temp')]);
             });
 

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -252,13 +252,6 @@ suite('OpenShift/Component', () => {
                 expect(result).null;
             });
 
-            test('clones the git repo if selected', async () => {
-                infoStub.resolves('Yes');
-                await Component.create(appItem);
-
-                expect(commandStub).calledOnceWith('git.clone', uri);
-            });
-
             test('allows to continue with valid git repository url', async () => {
                 let result: string | Thenable<string>;
                 inputStub.onFirstCall().callsFake(async (options?: vscode.InputBoxOptions, token?: vscode.CancellationToken): Promise<string> => {


### PR DESCRIPTION
Doing so will cancel creating git component workflow for the cases:
1. When there is no workspace yet
2. When none multi folder workspace is used

Fix #1337.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>