### PR TITLE
Fix regex for token to work with 3.x and 4.x clusters

### DIFF
--- a/src/openshift/openshiftItem.ts
+++ b/src/openshift/openshiftItem.ts
@@ -86,7 +86,7 @@ export abstract class OpenShiftItem {
     }
 
     static getToken(value: string): string | null {
-        const tokenRegex = value.match(/--token\s*=\s*(.*)/);
+        const tokenRegex = value.match(/--token\s*=\s*(\S*).*/);
         return (tokenRegex) ? tokenRegex[1] : null;
     }
 


### PR DESCRIPTION
Fix #1350.
Signed-off-by: Denis Golovin <dgolovin@redhat.com>