### PR TITLE
Disable no-unused-expressions rule to fix eslint errors on assertions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,8 @@
       ".jsx",
       ".ts"
     ]
-  },  "rules": {
+  },
+  "rules": {
     "header/header": [2, "./header.js"],
     "camelcase": 2,
     "consistent-return": 0,
@@ -79,5 +80,13 @@
     "prefer-template": 2,
     "radix": 2,
     "no-trailing-spaces": "error"
-  }
+  },
+  "overrides": [
+    {
+        "files": ["*.test.ts"],
+        "rules": {
+            "no-unused-expressions": "off"
+        }
+    }
+  ]
 }


### PR DESCRIPTION
Signed-off-by: Denis Golovin <dgolovin@redhat.com>