### PR TITLE
Get imageStreamRef data using oc call

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -87,6 +87,10 @@ function verbose(_target: any, key: string, descriptor: any): void {
 }
 
 export class Command {
+    static printCatalogComponentImageStreamRefJson(name: string, namespace: string): string {
+        return `oc get imagestream ${name} -n ${namespace} -o json`
+    }
+
     static listProjects(): string {
         return `odo project list -o json`;
     }
@@ -471,6 +475,7 @@ export interface Odo {
     getComponents(application: OpenShiftObject, condition?: (value: OpenShiftObject) => boolean): Promise<OpenShiftObject[]>;
     getComponentTypes(): Promise<string[]>;
     getComponentTypesJson(): Promise<any[]>;
+    getImageStreamRef(name: string, namespace: string): Promise<any>;
     getComponentChildren(component: OpenShiftObject): Promise<OpenShiftObject[]>;
     getRoutes(component: OpenShiftObject): Promise<OpenShiftObject[]>;
     getComponentPorts(component: OpenShiftObject): Promise<odo.Port[]>;
@@ -801,6 +806,11 @@ export class OdoImpl implements Odo {
     public async getComponentTypesJson(): Promise<any> {
         const result: cliInstance.CliExitData = await this.execute(Command.listCatalogComponentsJson());
         return JSON.parse(result.stdout).items;
+    }
+
+    public async getImageStreamRef(name: string, namespace: string): Promise<any> {
+        const result: cliInstance.CliExitData = await this.execute(Command.printCatalogComponentImageStreamRefJson(name, namespace));
+        return JSON.parse(result.stdout);
     }
 
     public async getComponentChildren(component: OpenShiftObject): Promise<OpenShiftObject[]> {

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -543,7 +543,8 @@ export class Component extends OpenShiftItem {
     static async startDebugger(component: OpenShiftObject): Promise<string | undefined> {
         const components = await Component.odo.getComponentTypesJson();
         const componentBuilder = components.find((builder) => builder.metadata.name === component.builderImage.name);
-        const tag = componentBuilder.spec.imageStreamRef.spec.tags.find((element: { name: string }) => element.name === component.builderImage.tag);
+        const imageStreamRef = await Component.odo.getImageStreamRef(componentBuilder.metadata.name, componentBuilder.metadata.namespace);
+        const tag = imageStreamRef.spec.tags.find((element: { name: string }) => element.name === component.builderImage.tag);
         const isJava = tag.annotations.tags.includes('java');
         const isNode = tag.annotations.tags.includes('nodejs');
         const JAVA_EXT = 'redhat.java';


### PR DESCRIPTION
Fix #1399.

Latest odo release removed imageStreamRef attribute from json output for `odo catalog list components -o json` command.
This change add oc call to fetch that data from cluster using  `oc get imagestream name -o json` command.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>