### PR TITLE
Fix spelling/grammar "too" "log's" => "to" "logs"

### DIFF
--- a/src/k8s/build.ts
+++ b/src/k8s/build.ts
@@ -86,7 +86,7 @@ export class Build {
     }
 
     static async showLog(context: { impl: any}): Promise<string> {
-        const build = await Build.selectBuild(context, "Select a build too see the logs");
+        const build = await Build.selectBuild(context, "Select a build to see the logs");
         if (build) {
             Build.odo.executeInTerminal(Build.command.showLog(build, '-build'));
         }
@@ -98,7 +98,7 @@ export class Build {
         if (context) {
             resourceId = context.impl.name;
         } else {
-            const name = await Build.selectBuild(context, "select too rebuild");
+            const name = await Build.selectBuild(context, "select to rebuild");
             if (name) {
                 resourceId = name;
             }
@@ -110,7 +110,7 @@ export class Build {
     }
 
     static async followLog(context: { impl: any}): Promise<string> {
-        const build = await Build.selectBuild(context, "Select a build too follow the logs");
+        const build = await Build.selectBuild(context, "Select a build to follow the logs");
         if (build) {
             Build.odo.executeInTerminal(Build.command.followLog(build, '-build'));
         }
@@ -119,7 +119,7 @@ export class Build {
 
     static async delete(context: { impl: any}): Promise<string> {
         let result: null | string | Promise<string> | PromiseLike<string> = null;
-        const build = await Build.selectBuild(context, "Select a build too delete");
+        const build = await Build.selectBuild(context, "Select a build to delete");
         if (build) {
             result = Progress.execFunctionWithProgress(`Deleting build`, () => Build.odo.execute(Build.command.delete(build)))
                 .then(() => `Build '${build}' successfully deleted`)

--- a/src/k8s/deployment.ts
+++ b/src/k8s/deployment.ts
@@ -78,7 +78,7 @@ export class DeploymentConfig {
     }
 
     static async rcShowLog(context: { impl: any }): Promise<string> {
-        const replica = await DeploymentConfig.selectReplica(context, "Select a Replica too see the logs");
+        const replica = await DeploymentConfig.selectReplica(context, "Select a Replica to see the logs");
         if (replica) {
             DeploymentConfig.odo.executeInTerminal(DeploymentConfig.command.showLog(replica));
         }
@@ -87,7 +87,7 @@ export class DeploymentConfig {
 
     static async showLog(context: { name: string }): Promise<string> {
         let deployName: string = context ? context.name : null;
-        if (!deployName) deployName = await common.selectResourceByName(DeploymentConfig.getDeploymentConfigNames("You have no DeploymentConfigs available to see log's"), "Select a DeploymentConfig too see logs");
+        if (!deployName) deployName = await common.selectResourceByName(DeploymentConfig.getDeploymentConfigNames("You have no DeploymentConfigs available to see logs"), "Select a DeploymentConfig to see logs");
         if (deployName) {
             DeploymentConfig.odo.executeInTerminal(DeploymentConfig.command.showDeploymentConfigLog(deployName));
         }
@@ -109,7 +109,7 @@ export class DeploymentConfig {
 
     static async delete(context: { impl: any }): Promise<string> {
         let result: null | string | Promise<string> | PromiseLike<string> = null;
-        const replica = await DeploymentConfig.selectReplica(context, "Select a Replica too delete");
+        const replica = await DeploymentConfig.selectReplica(context, "Select a Replica to delete");
         if (replica) {
             result = Progress.execFunctionWithProgress(`Deleting replica`, () => DeploymentConfig.odo.execute(DeploymentConfig.command.delete(replica)))
                 .then(() => `Replica '${replica}' successfully deleted`)

--- a/test/unit/oc.test.ts
+++ b/test/unit/oc.test.ts
@@ -115,7 +115,7 @@ suite('Oc', () => {
         expect(result).equals('Resources were successfully created.');
     });
 
-    test('errors when fail too create resource', async () => {
+    test('errors when fail to create resource', async () => {
         let savedErr: any;
         execStub.resolves({
             error: 'error',


### PR DESCRIPTION
Fix spelling/grammar:  "too" => "to" and "log's" => "logs"

Fix instances where the word "too" is used where "to" should be used.
Fix instance where "log's" is used where "logs" should be used.