### PR TITLE
Enable user's permission & collect usage metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.11.1",
+    "@types/analytics-node": "^3.1.2",
+    "analytics-node": "3.4.0-beta.1",
     "binary-search": "^1.3.6",
     "byline": "^5.0.0",
     "fs-extra": "^8.1.0",
@@ -1103,6 +1105,12 @@
           "type": "boolean",
           "default": false,
           "description": "Force extension to search for `oc` and `odo` CLI tools in PATH locations before using bundled binaries."
+        },
+        "openshiftConnector.collectTelemetryData": {
+          "Title": "Enable Telemetry",
+          "type": "boolean",
+          "default": true,
+          "description": "Enable usage data and errors to be sent to Red Hat online services"
         }
       }
     }

--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -4,13 +4,15 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { window, commands, env, QuickPickItem, ExtensionContext, Uri } from 'vscode';
-import { Command } from "../odo";
+import { Command, OdoImpl } from "../odo";
 import { OpenShiftItem } from './openshiftItem';
 import { CliExitData, CliChannel } from "../cli";
 import { TokenStore } from "../util/credentialManager";
 import { KubeConfigUtils } from '../util/kubeUtils';
 import { Filters } from "../util/filters";
 import { Progress } from "../util/progress";
+import { Metrics } from '../util/metrics';
+
 
 export class Cluster extends OpenShiftItem {
     public static extensionContext: ExtensionContext;
@@ -213,6 +215,8 @@ export class Cluster extends OpenShiftItem {
         if (result.stderr === "") {
             Cluster.explorer.refresh();
             await commands.executeCommand('setContext', 'isLoggedIn', true);
+            await OdoImpl.Instance.setToolVersions();
+            Metrics.publishUsageMetrics("Logged into the cluster");
             return `Successfully logged in to '${clusterURL}'`;
         }
         throw new Error(result.stderr);

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -1,0 +1,76 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+
+import * as vscode from 'vscode';
+
+import segmentanalytics = require('analytics-node');
+
+let odoVersionString:string;
+let ocVersionString:string;
+let ocClientVersionString:string;
+let kubeVersionString:string;
+
+const segmentToken = "zP4QDen55HVeYDdsHNCcULqfenB2NQDL";
+
+export class Metrics {
+
+  public static setODOVersionString(odoversion: string) {
+    odoVersionString = odoversion;
+  }
+
+  public static setOCVersionString(ocversion: string) {
+    ocVersionString = ocversion;
+  }
+
+  public static setOCClientVersionString(ocClientversion: string) {
+    ocClientVersionString = ocClientversion;
+  }
+
+  public static setKubeVersionString(kubeVersion: string) {
+    kubeVersionString = kubeVersion;
+  }
+
+  public static getODOVersionString() : string {
+    return odoVersionString;
+  }
+
+  public static getOCVersionString() : string {
+    return ocVersionString;
+  }
+
+  public static getOCClientVersionString() : string {
+    return ocClientVersionString;
+  }
+
+  public static getKubeVersionString(): string {
+    return kubeVersionString;
+  }
+
+  static shallSendMetrics()  {
+    if (vscode.workspace.getConfiguration("openshiftConnector").get("collectTelemetryData")) {
+        return true;
+    }
+    return false;
+  }
+
+  public static publishUsageMetrics(eventMessage: string) {
+    const analytics = new segmentanalytics(segmentToken);
+
+      if (Metrics.shallSendMetrics()) {
+           analytics.track({
+            userId: 'anonymous',
+            event: eventMessage,
+            properties: {
+              odoVersion: Metrics.getODOVersionString(),
+              ocServerVersion: Metrics.getOCVersionString(),
+              ocClientVersion: Metrics.getOCClientVersionString(),
+              kubeVersion: Metrics.getKubeVersionString()
+
+            }
+          });
+      }
+  }
+}

--- a/src/util/metrics.ts
+++ b/src/util/metrics.ts
@@ -56,8 +56,8 @@ export class Metrics {
     return false;
   }
 
-  public static publishUsageMetrics(eventMessage: string) {
-    const analytics = new segmentanalytics(segmentToken);
+  public static publishUsageMetrics(eventMessage: string) : boolean {
+    const analytics = new segmentanalytics(segmentToken, { flushAt: 1 }); // Flush events to Segment with NO buffering
 
       if (Metrics.shallSendMetrics()) {
            analytics.track({
@@ -68,9 +68,13 @@ export class Metrics {
               ocServerVersion: Metrics.getOCVersionString(),
               ocClientVersion: Metrics.getOCClientVersionString(),
               kubeVersion: Metrics.getKubeVersionString()
-
             }
+          }, function(error, batch) {
+              if (error) {
+                return false;
+              }
           });
-      }
+        }
+        return true;
   }
-}
+  }

--- a/test/unit/odo.test.ts
+++ b/test/unit/odo.test.ts
@@ -16,6 +16,7 @@ import { WindowUtil } from '../../src/util/windowUtils';
 import { ToolsConfig } from '../../src/tools';
 import { CliExitData, CliChannel } from '../../src/cli';
 import * as odo from '../../src/odo';
+import { Metrics } from '../../src/util/metrics';
 
 import jsYaml = require('js-yaml');
 
@@ -600,6 +601,20 @@ suite("odo", () => {
             sandbox.stub(odo.OdoImpl.prototype, 'convertObjectsFromPreviousOdoReleases');
             const cluster: odo.OpenShiftObject[] = await odo.getInstance().getClusters();
             assert.equal(cluster[0].getName(), clusterUrl);
+        });
+
+        test('capture versions of OC, ODO and Kube', async () => {
+            sandbox.stub(odoCli, 'execute').resolves({ error: null, stdout: '', stderr: 'Please log in to the cluster'});
+            const result = await odoCli.setToolVersions();
+
+            expect(result).true;
+        });
+
+        test('send usage metrics to Segment', function () {
+            sandbox.stub(odoCli, 'execute').resolves({ error: null, stdout: '', stderr: 'Please verify API key for Segment'});
+            const result = Metrics.publishUsageMetrics("From automated tests..");
+
+            expect(result).true;
         });
 
         test('extension uses odo version to determine if login is required', async () => {


### PR DESCRIPTION
This PR enables
1) VSCode extension user to enable / disable collection of usage metrics
2) Collects OpenShift, Odo and Kube versions used by users
3) Does not collect any information specific to a user / user's clusters

Fix #1868.