### PR TITLE
When deleting url delete it in cluster as storage delete does

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -283,7 +283,7 @@ export class Command {
     }
 
     static deleteComponentUrl(name: string): string {
-        return `odo url delete -f ${name}`;
+        return `odo url delete -f ${name} --now`;
     }
 
     static getComponentJson(): string {


### PR DESCRIPTION
Fix #1172.
odo storage delete now  delete both local config and storage
volume in cluster, to have some sort of consistency we should
do the same for url, until storage delete allow two steps
deletion.
Signed-off-by: Denis Golovin <dgolovin@redhat.com>