### PR TITLE
Freeze vscode-extension-tester to 2.6.0 to avoid compilation for opencv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6895,9 +6895,9 @@
       }
     },
     "jszip": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.3.0.tgz",
-      "integrity": "sha512-EJ9k766htB1ZWnsV5ZMDkKLgA+201r/ouFF8R2OigVjVdcm2rurcBrrdXaeqBJbqnUVMko512PYmlncBKE1Huw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -8166,9 +8166,9 @@
       }
     },
     "node-abi": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
-      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
+      "integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
@@ -12358,15 +12358,15 @@
       }
     },
     "vscode-extension-tester": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-2.5.2.tgz",
-      "integrity": "sha512-78weOhHmVNxx1Htux8fPmx6Ds1IiWyB/eJwTeOB5zKwk+aO3G4erk27TVQKKCtF+wdSKSFFV+2cpeSIgF/FYkQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-2.6.0.tgz",
+      "integrity": "sha512-LGjV3fXOB+PPEASSOamGV0GqIXb8Eb4U3xfj5ktJdEOTSZiuHe+80/EsLoDuzbyu84w/6u4kL1P8frVTMGhOTw==",
       "dev": true,
       "requires": {
         "@nut-tree/nut-js": "^1.3.1",
         "@types/selenium-webdriver": "^3.0.15",
         "clipboardy": "^2.0.0",
-        "commander": "^3.0.1",
+        "commander": "^5.0.0",
         "compare-versions": "^3.5.1",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.6",
@@ -12379,6 +12379,14 @@
         "ts-essentials": "^3.0.5",
         "unzip-stream": "^0.3.0",
         "vsce": "^1.71.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        }
       }
     },
     "vscode-json-languageservice": {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "tslint": "^5.20.1",
     "typescript": "^3.8.3",
     "utf-8-validate": "^5.0.2",
-    "vscode-extension-tester": "^2.4.0",
+    "vscode-extension-tester": "2.6.0",
     "vscode-test": "^1.2.3",
     "walker": "^1.0.7",
     "webpack": "^4.35.2",


### PR DESCRIPTION
opencv compilation during `npm install` adds anorher 10 to 15 minutes
to build time.