### PR TITLE
Fix SHA for odo-darwin

### DIFF
--- a/src/tools.json
+++ b/src/tools.json
@@ -17,7 +17,7 @@
             },
             "darwin": {
                 "url": "https://mirror.openshift.com/pub/openshift-v4/clients/odo/v1.2.0/odo-darwin-amd64.tar.gz",
-                "sha256sum": "572b76cb79509c7ecb09a0bac1dc70400634dfe5f93a882024eeea7bd1c057ee",
+                "sha256sum": "963db0f410f69bf370eb77a84a054223cff0348f731e16c68a408b332960aad1",
                 "dlFileName": "odo-darwin-amd64.tar.gz",
                 "cmdFileName": "odo"
             },


### PR DESCRIPTION
The SHA256_SUM for odo-darwin was incorrect. 

Even the odo download location for SHA has 2 references for `odo-darwin-amd64.tar.gz` https://mirror.openshift.com/pub/openshift-v4/clients/odo/v1.2.0/SHA256_SUM