### PR TITLE
Use '--client' option when detectin tools version

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -57,7 +57,7 @@ export class ToolsConfig {
     public static async getVersion(location: string): Promise<string> {
         let detectedVersion: string;
         if (fs.existsSync(location)) {
-            const result = await CliChannel.getInstance().execute(`"${location}" version`);
+            const result = await CliChannel.getInstance().execute(`"${location}" version --client`);
             if (result.stdout) {
                 const versionRegExp = /.*([0-9]+\.[0-9]+\.[0-9]+).*/;
                 const toolVersion: string[] = result.stdout.trim().split('\n').filter((value) => {


### PR DESCRIPTION
Fix #1608.

This option suppress detection of current cluster URL,
which takes time in case cluster is not available

Signed-off-by: Denis Golovin <dgolovin@redhat.com>