### PR TITLE
Watch view implementation to track running 'odo watch' commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -727,7 +727,7 @@
         },
         {
           "id": "openshiftWatchView",
-          "name": "OpenShift Watch Sessions"
+          "name": "Watch Sessions"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -190,6 +190,8 @@
     "onCommand:openshift.component.push.palette",
     "onCommand:openshift.component.watch",
     "onCommand:openshift.component.watch.palette",
+    "onCommand:openshift.component.watch.terminate",
+    "onCommand:openshift.component.watch.showLog",
     "onCommand:openshift.catalog.listComponents",
     "onCommand:openshift.catalog.listServices",
     "onCommand:openshift.url.create",
@@ -432,6 +434,16 @@
       {
         "command": "openshift.component.linkService",
         "title": "Link Service",
+        "category": "OpenShift"
+      },
+      {
+        "command": "openshift.component.watch.terminate",
+        "title": "Stop",
+        "category": "OpenShift"
+      },
+      {
+        "command": "openshift.component.watch.showLog",
+        "title": "Show Log",
         "category": "OpenShift"
       },
       {
@@ -712,6 +724,10 @@
         {
           "id": "openshiftProjectExplorer",
           "name": "Application Explorer"
+        },
+        {
+          "id": "openshiftWatchView",
+          "name": "OpenShift Watch Sessions"
         }
       ]
     },
@@ -1143,6 +1159,14 @@
         {
           "command": "openshift.explorer.login.credentialsLogin",
           "when": "view == openshiftProjectExplorer && viewItem == loginRequired"
+        },
+        {
+          "command": "openshift.component.watch.terminate",
+          "when": "view == openshiftWatchView && viewItem == openshift.watch.process"
+        },
+        {
+          "command": "openshift.component.watch.showLog",
+          "when": "view == openshiftWatchView && viewItem == openshift.watch.process"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import { TokenStore } from './util/credentialManager';
 import { registerCommands } from './vscommand';
 import { ToolsConfig } from './tools';
 import { extendClusterExplorer } from './k8s/clusterExplorer';
+import { WatchSessionsView } from './watch';
 
 import path = require('path');
 import fsx = require('fs-extra');
@@ -68,6 +69,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<any>
             commands.executeCommand('extension.vsKubernetesUseNamespace', context),
         ),
         OpenShiftExplorer.getInstance(),
+        WatchSessionsView.getInstance(),
         ...Component.init(extensionContext)
     ];
     disposable.forEach((value) => extensionContext.subscriptions.push(value));

--- a/src/odo.ts
+++ b/src/odo.ts
@@ -49,6 +49,7 @@ export interface OpenShiftObject extends QuickPickItem {
     contextPath?: Uri;
     path?: string;
     builderImage?: BuilderImage;
+    iconPath?: Uri;
 }
 
 export enum ContextType {
@@ -404,8 +405,6 @@ class OdoModel {
         array.splice(array.indexOf(item), 1);
         this.pathToObject.delete(item.path);
         this.contextToObject.delete(item.contextPath.fsPath);
-        const ps = this.objectToProcess.get(item);
-        if (ps) ps.kill('SIGINT');
     }
 
     public deleteContext(context: string): void {

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -495,6 +495,10 @@ export class Component extends OpenShiftItem {
     )
     static async watch(component: OpenShiftObject): Promise<void> {
         if (!component) return null;
+        if (component.compType !== SourceType.LOCAL && component.compType !== SourceType.BINARY) {
+            window.showInformationMessage(`Watch is supported only for Components with local or binary source type.`)
+            return null;
+        }
         if (Component.watchSessions.get(component.contextPath.fsPath)) {
             const sel = await window.showInformationMessage(`Watch process is already running for '${component.getName()}'`, 'Show Log');
             if (sel === 'Show Log') {

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -66,6 +66,13 @@ export class Component extends OpenShiftItem {
         }
     }
 
+    static stopWatchSession(component: OpenShiftObject): void {
+        const ws = Component.watchSessions.get(component.contextPath.fsPath);
+        if (ws) {
+            treeKill(ws.pid);
+        }
+    }
+
     static async getOpenshiftData(context: OpenShiftObject): Promise<OpenShiftObject> {
         return Component.getOpenShiftCmdData(context,
             "In which Project you want to create a Component",
@@ -128,6 +135,7 @@ export class Component extends OpenShiftItem {
                     await Component.unlinkAllComponents(component);
                 }
                 Component.stopDebugSession(component);
+                Component.stopWatchSession(component);
                 await Component.odo.deleteComponent(component);
 
             }).then(() => `Component '${name}' successfully deleted`)
@@ -149,6 +157,7 @@ export class Component extends OpenShiftItem {
         if (value === 'Yes') {
             return Progress.execFunctionWithProgress(`Undeploying the Component '${component.getName()} '`, async () => {
                 Component.stopDebugSession(component);
+                Component.stopWatchSession(component);
                 await Component.odo.undeployComponent(component);
             }).then(() => `Component '${name}' successfully undeployed`)
             .catch((err) => Promise.reject(new VsCommandError(`Failed to undeploy Component with error '${err}'`)));

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -501,7 +501,7 @@ export class Component extends OpenShiftItem {
                 commands.executeCommand('openshift.component.watch.showLog', component.contextPath.fsPath);
             }
         } else {
-            const process :ChildProcess = await Component.odo.spawn(Command.watchComponent(component.getParent().getParent().getName(), component.getParent().getName(), component.getName()), component.contextPath.fsPath);
+            const process: ChildProcess = await Component.odo.spawn(Command.watchComponent(component.getParent().getParent().getName(), component.getParent().getName(), component.getName()), component.contextPath.fsPath);
             Component.addWatchSession(component, process);
             process.on('exit', () => {
                 Component.removeWatchSession(component);

--- a/src/view/log/LogViewLoader.ts
+++ b/src/view/log/LogViewLoader.ts
@@ -30,7 +30,7 @@ export default class LogViewLoader {
         const cmd = cmdFunction(target.getParent().getParent().getName(), target.getParent().getName(), target.getName());
 
         // TODO: When webview is going to be ready?
-        panel.webview.html = LogViewLoader.getWebviewContent(LogViewLoader.extensionPath, cmd);
+        panel.webview.html = LogViewLoader.getWebviewContent(LogViewLoader.extensionPath, cmd.replace(/\\/g, '\\\\'));
 
         const process = existingProcess? existingProcess : await odo.getInstance().spawn(cmd, target.contextPath.fsPath);
         process.stdout.on('data', (data) => {

--- a/src/view/log/app/spinner.tsx
+++ b/src/view/log/app/spinner.tsx
@@ -72,8 +72,9 @@ declare global {
     }
 }
 
+const vscode = window.acquireVsCodeApi();
+
 function stop() {
-    const vscode = window.acquireVsCodeApi();
     vscode.postMessage({action: 'stop'});
 }
 

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -94,7 +94,7 @@ export class WatchSessionsView implements TreeDataProvider<string>, Disposable {
 
     @vsCommand('openshift.component.watch.showLog')
     static showWatchSessionLog(context: string): void {
-        LogViewLoader.loadView(`${context} Watch Log`,  () => "command to watch", WatchSessionsView.odoctl.getOpenShiftObjectByContext(context), WatchSessionsView.sessions.get(context).process);
+        LogViewLoader.loadView(`${context} Watch Log`,  () => `odo watch --context ${context}`, WatchSessionsView.odoctl.getOpenShiftObjectByContext(context), WatchSessionsView.sessions.get(context).process);
     }
 
     refresh(): void {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -73,7 +73,8 @@ export class WatchSessionsView implements TreeDataProvider<string>, Disposable {
         return {
             label: WatchSessionsView.sessions.get(element).label,
             collapsibleState: TreeItemCollapsibleState.None,
-            contextValue: 'openshift.watch.process'
+            contextValue: 'openshift.watch.process',
+            iconPath: WatchSessionsView.odoctl.getOpenShiftObjectByContext(element).iconPath
         };
     }
 

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,0 +1,116 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import {
+    TreeDataProvider,
+    TreeItem,
+    Event,
+    ProviderResult,
+    EventEmitter,
+    Disposable,
+    TreeView,
+    window,
+    TreeItemCollapsibleState,
+} from 'vscode';
+
+import { ChildProcess } from 'child_process';
+import { Odo, OdoImpl } from './odo';
+import { vsCommand } from './vscommand';
+import { Component, ComponentEvent } from './openshift/component';
+import LogViewLoader from './view/log/LogViewLoader';
+
+import treeKill = require('tree-kill');
+
+class WatchSessionEntry {
+    label: string;
+    process: ChildProcess;
+}
+
+export class WatchSessionsView implements TreeDataProvider<string>, Disposable {
+    private static instance: WatchSessionsView;
+    private static sessions: Map<string, WatchSessionEntry> = new Map();
+
+    private static odoctl: Odo = OdoImpl.Instance;
+
+    private treeView: TreeView<string>;
+
+    private onDidChangeTreeDataEmitter: EventEmitter<string> =
+        new EventEmitter<string | undefined>();
+
+    readonly onDidChangeTreeData: Event<string | undefined> = this
+        .onDidChangeTreeDataEmitter.event;
+
+    private constructor() {
+        this.treeView = window.createTreeView('openshiftWatchView', {
+            treeDataProvider: this,
+        });
+        Component.watchSubject.subscribe((event: ComponentEvent) => {
+            if (event.type === 'watchStarted') {
+                const osObj = WatchSessionsView.odoctl.getOpenShiftObjectByContext(event.component.contextPath.fsPath);
+                WatchSessionsView.sessions.set(event.component.contextPath.fsPath, {
+                    label: `${osObj.getParent().getParent().getName()}/${osObj.getParent().getName()}/${osObj.getName()}`,
+                    process: event.process
+                });
+                this.refresh();
+            } else if (event.type === 'watchTerminated') {
+                WatchSessionsView.sessions.delete(event.component.contextPath.fsPath);
+                this.refresh();
+            }
+        })
+    }
+
+    static getInstance(): WatchSessionsView {
+        if (!WatchSessionsView.instance) {
+            WatchSessionsView.instance = new WatchSessionsView();
+        }
+        return WatchSessionsView.instance;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getTreeItem(element: string): TreeItem | Thenable<TreeItem> {
+        return {
+            label: WatchSessionsView.sessions.get(element).label,
+            collapsibleState: TreeItemCollapsibleState.None,
+            contextValue: 'openshift.watch.process'
+        };
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getChildren(): ProviderResult<string[]> {
+        return [...WatchSessionsView.sessions.keys()];
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    getParent?(): string {
+        return undefined;
+    }
+
+    @vsCommand('openshift.component.watch.terminate')
+    static terminateWatchSession(context: string): void {
+        treeKill(WatchSessionsView.sessions.get(context).process.pid, 'SIGSTOP');
+    }
+
+    @vsCommand('openshift.component.watch.showLog')
+    static showWatchSessionLog(context: string): void {
+        LogViewLoader.loadView(`${context} Watch Log`,  () => "command to watch", WatchSessionsView.odoctl.getOpenShiftObjectByContext(context), WatchSessionsView.sessions.get(context).process);
+    }
+
+    refresh(): void {
+        this.onDidChangeTreeDataEmitter.fire();
+    }
+
+    dispose(): void {
+        this.treeView.dispose();
+    }
+
+    async reveal(item: string): Promise<void> {
+        this.refresh();
+        // double call of reveal is workaround for possible upstream issue
+        // https://github.com/redhat-developer/vscode-openshift-tools/issues/762
+        await this.treeView.reveal(item);
+        this.treeView.reveal(item);
+    }
+
+}

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
+import { ChildProcess } from 'child_process';
 import { TestItem } from './testOSItem';
 import { OdoImpl, ContextType } from '../../../src/odo';
 import { Command } from "../../../src/odo/command";
@@ -18,6 +19,7 @@ import OpenShiftItem from '../../../src/openshift/openshiftItem';
 
 import pq = require('proxyquire');
 import globby = require('globby');
+
 
 const {expect} = chai;
 chai.use(sinonChai);
@@ -43,6 +45,7 @@ suite('OpenShift/Component', () => {
     let Component: any;
     let fetchTag: sinon.SinonStub;
     let commandStub: sinon.SinonStub;
+    let spawnStub: sinon.SinonStub;
 
     setup(() => {
         sandbox = sinon.createSandbox();
@@ -51,6 +54,7 @@ suite('OpenShift/Component', () => {
         Component = pq('../../../src/openshift/component', {}).Component;
         termStub = sandbox.stub(OdoImpl.prototype, 'executeInTerminal');
         execStub = sandbox.stub(OdoImpl.prototype, 'execute').resolves({ stdout: "" });
+        spawnStub = sandbox.stub(OdoImpl.prototype, 'spawn');
         sandbox.stub(OdoImpl.prototype, 'getServices');
         sandbox.stub(OdoImpl.prototype, 'getProjects').resolves([]);
         sandbox.stub(OdoImpl.prototype, 'getApplications').resolves([]);
@@ -1122,15 +1126,17 @@ suite('OpenShift/Component', () => {
         });
 
         test('calls the correct odo command w/ context', async () => {
+            const cpStub = {on: sinon.stub()} as any as ChildProcess;
+            spawnStub.resolves(cpStub);
             await Component.watch(componentItem);
-
-            expect(termStub).calledOnceWith(Command.watchComponent(projectItem.getName(), appItem.getName(), componentItem.getName()));
+            expect(spawnStub).calledOnceWith(Command.watchComponent(projectItem.getName(), appItem.getName(), componentItem.getName()));
         });
 
         test('calls the correct odo command w/o context', async () => {
+            const cpStub = {on: sinon.stub()} as any as ChildProcess;
+            spawnStub.resolves(cpStub);
             await Component.watch(null);
-
-            expect(termStub).calledOnceWith(Command.watchComponent(projectItem.getName(), appItem.getName(), componentItem.getName()));
+            expect(spawnStub).calledOnceWith(Command.watchComponent(projectItem.getName(), appItem.getName(), componentItem.getName()));
         });
     });
 

--- a/test/unit/openshift/testOSItem.ts
+++ b/test/unit/openshift/testOSItem.ts
@@ -5,6 +5,7 @@
 
 import { Uri } from "vscode";
 import { OpenShiftObject, ContextType } from "../../../src/odo";
+import { SourceType } from "../../../src/odo/config";
 
 export class TestItem implements OpenShiftObject {
     public treeItem = null;
@@ -16,7 +17,8 @@ export class TestItem implements OpenShiftObject {
         public contextValue: ContextType,
         private children = [],
         public contextPath = Uri.parse('file:///c%3A/Temp'),
-        public path?: string) {
+        public path?: string,
+        public compType: string = SourceType.LOCAL) {
     }
 
     getName(): string {


### PR DESCRIPTION
Watch commands can be executed for different components at the same time
and that is done in terminal veiw. Over time terminal is getting
polluted with different commands and it is getting not easy to navigate
and search for watch sessions to see the log or stop them.

Related to #1425.
Fix #1617.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>