### PR TITLE
Remove `OpehShift` from `OpenShift Application Explorer' view name

### DIFF
--- a/package.json
+++ b/package.json
@@ -711,7 +711,7 @@
       "openshiftView": [
         {
           "id": "openshiftProjectExplorer",
-          "name": "OpenShift Application Explorer"
+          "name": "Application Explorer"
         }
       ]
     },


### PR DESCRIPTION
VSCode shows category before the name. View declaration in
package.json has category 'OpenShift' that leads to having
two `OpenShift` word follow each other in view separated
by `:`.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>