### PR TITLE
Return null when 'Set Active Project' command is canceled

### DIFF
--- a/src/openshift/project.ts
+++ b/src/openshift/project.ts
@@ -13,10 +13,14 @@ export class Project extends OpenShiftItem {
 
     @vsCommand('openshift.project.set', true)
     static async set(): Promise<string | null> {
+        let message = null;
         const project = await window.showQuickPick((await getInstance().getProjects()).filter((prj: OpenShiftProject) => !prj.active), {placeHolder: 'Select a Project to activate'});
-        await Project.odo.execute(`odo project set ${project.getName()}`);
-        Project.explorer.refresh();
-        return `Project '${project.getName()}' set as active.`;
+        if (project) {
+            await Project.odo.execute(`odo project set ${project.getName()}`);
+            Project.explorer.refresh();
+            message = `Project '${project.getName()}' set as active.`;
+        }
+        return message;
     }
 
     @vsCommand('openshift.project.create')


### PR DESCRIPTION
Fix #1639.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>