### PR TITLE
Fix condition to trigger refresh after kubeconfig has changed

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -59,7 +59,7 @@ export class OpenShiftExplorer implements TreeDataProvider<OpenShiftObject>, Dis
             if (!this.kubeContext
                 || (this.kubeContext.cluster !== newCtx.cluster
                     || this.kubeContext.user !== newCtx.user
-                    || this.kubeContext.namespace !== newCtx.user)) {
+                    || this.kubeContext.namespace !== newCtx.namespace)) {
                 this.refresh();
             }
             this.kubeContext = newCtx;


### PR DESCRIPTION
This change fixes obvious error in condition where namespace compared to user name.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>