### PR TITLE
Fix component context folder validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change Log
 
-## 0.1.6 (August 26, 2020)
-
-
-
 ## 0.1.5 (May 18, 2020)
 
 Noteworthy issues fixed in this release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.6 (August 26, 2020)
+
+
+
 ## 0.1.5 (May 18, 2020)
 
 Noteworthy issues fixed in this release:

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "onCommand:openshift.component.createFromLocal",
     "onCommand:openshift.component.createFromGit",
     "onCommand:openshift.component.createFromBinary",
+    "onCommand:openshift.component.createFromWorkspaceFolder",
     "onCommand:openshift.component.describe",
     "onCommand:openshift.component.describe.palette",
     "onCommand:openshift.component.log",
@@ -391,6 +392,11 @@
       {
         "command": "openshift.component.createFromBinary",
         "title": "New Component form binary",
+        "category": "OpenShift"
+      },
+      {
+        "command": "openshift.component.createFromWorkspaceFolder",
+        "title": "New Component",
         "category": "OpenShift"
       },
       {
@@ -1214,6 +1220,12 @@
           "when": "view == openshiftProjectExplorer && viewItem == project",
           "group": "inline"
         }
+      ],
+      "explorer/context": [
+        {
+          "command": "openshift.component.createFromWorkspaceFolder",
+          "when": "explorerResourceIsFolder && explorerResourceIsRoot"
+        }
       ]
     },
     "configuration": {
@@ -1239,11 +1251,17 @@
           "description": "Force extension to search for `oc` and `odo` CLI tools in PATH locations before using bundled binaries."
         },
         "openshiftConnector.useWebviewInsteadOfTerminalView": {
-          "Title": "Use Webview based editors to show 'Show Log', 'Follow Log' and 'Describe' commands output",
+          "Title": "Use Webview based editors to show 'Show Log', 'Follow Log' and 'Describe' commands output.",
           "type": "boolean",
           "defaul": false,
           "description": "By default the Terminal View is used to execute OpenShift 'Show Log', 'Follow Log' and 'Describe' commands. Select this option if you want to use Webview based editors for it."
-        }
+        },
+        "openshiftConnector.removeContextFolderAfterDeletingComponent": {
+            "Title": "Remove Component's context folder from workspace after Component is deleted.",
+            "type": "boolean",
+            "defaul": false,
+            "description": "Force 'Delete' command for component to remove Component's context folder from workspace."
+          }
       }
     }
   },

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -21,13 +21,13 @@ export const AddWorkspaceFolder: QuickPickItem = {
 export async function selectWorkspaceFolder(): Promise<Uri> {
     let folder: WorkspaceFolderItem[] = [];
     if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+
         folder = workspace.workspaceFolders
             .filter((value) => {
                 let result = true;
                 try {
                     result = !fs
-                        .statSync(path.join(value.uri.fsPath, '.odo', 'config.yaml'))
-                        .isFile();
+                        .statSync(path.join(value.uri.fsPath, '.odo')).isDirectory();
                 } catch (ignore) {
                     // ignore errors if file does not exist
                 }
@@ -57,7 +57,14 @@ export async function selectWorkspaceFolder(): Promise<Uri> {
         if (!folders) return null;
         if (fs.existsSync(path.join(folders[0].fsPath, '.odo', 'config.yaml'))) {
             window.showInformationMessage(
-                'The folder selected already contains a component. Please select a different folder.',
+                'Selected folder already contains a component. Please select a different folder.',
+            );
+            return this.selectWorkspaceFolder();
+        }
+        const wsFolder = workspace.getWorkspaceFolder(folders[0]);
+        if (wsFolder && wsFolder.uri !== folders[0]) {
+            window.showInformationMessage(
+                'Selected folder cannot be used, because it is a sub-folder of existing workspace folder.  Please select a different folder.',
             );
             return this.selectWorkspaceFolder();
         }

--- a/test/integration/odo.test.ts
+++ b/test/integration/odo.test.ts
@@ -140,7 +140,7 @@ suite('odo integration', () => {
     }
 
     setup(async () => {
-        await oi.execute(Command.odoLoginWithUsernamePassword('https://10.0.0.193:8443', 'developer', 'developer'));
+        await oi.execute(Command.odoLoginWithUsernamePassword('https://api.crc.testing:6443', 'developer', 'developer'));
     });
 
     teardown(() => {
@@ -250,9 +250,6 @@ suite('odo integration', () => {
         test('delete component', async () => {
             sb.stub(window, 'showWarningMessage').resolves('Yes');
             const errMessStub = sb.stub(window, 'showErrorMessage');
-            if (!!component || !!componentFromGit || !!componentFromBinary) {
-                this.skip();
-            }
             if (component) {
                 await commands.executeCommand('openshift.component.delete', component);
             }


### PR DESCRIPTION
Fix #1708.

When selecting context for new component, there should be validation
that it is not subfolder of one of workspace folders, because
extension supports only components based on workspace root folders.

Also enable back create from workspace folder command, because
it is possible enable create component command for root workspace
folders only.

Add preference to allow control over context folder removal from
workspace right after component removal. That allows to keep doing
local development after openshift component removed and .odo folder is
gone.

Allways call component delete command even for not deployed components
because that should delete .odo config subfolder with configuration from
context folder and let user to create component again just selecting
existing workspace folder from quickpick list.

Since context folder not always deleted from workspace (based on
preference value) it requires additional cleanup in data model.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>