### PR TITLE
Get rid of save workspace request in the end of integration tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -56,8 +56,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
-                "${workspaceFolder}/test/fixtures/components/comp1",
-                "${workspaceFolder}/test/fixtures/components/comp2",
+                "${workspaceFolder}/test/fixtures/components/components.code-workspace",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/out/test/integration"
             ],

--- a/build/run-tests.ts
+++ b/build/run-tests.ts
@@ -24,8 +24,7 @@ async function main(): Promise<void> {
             extensionTestsPath,
             launchArgs: tests === 'integration' ? [
                 // this is required to create multi root workspace to run tests on
-                path.resolve(extensionRootPath,'test', 'fixtures', 'components', 'comp1'),
-                path.resolve(extensionRootPath,'test', 'fixtures', 'components', 'comp2'),
+                path.resolve(extensionRootPath,'test', 'fixtures', 'components', 'components.code-workspace')
             ] : []
         });
     } catch(error) {


### PR DESCRIPTION
When integration tests are finished and vscode is about to exit
it shows 'Save Workspace Changes' request. That holds vscode form
exit and requires manually pushing skip button to finish tests.
To avoid this `.code-workspace` file should be used instead.
When tests end workspace should have the same projects it started
with and that lets vscode to close without any requests.

Signed-off-by: Denis Golovin dgolovin@redhat.com