### PR TITLE
Fix double refresh when creating a project

### DIFF
--- a/package.json
+++ b/package.json
@@ -935,6 +935,11 @@
       ],
       "view/item/context": [
         {
+          "command": "openshift.explorer.refresh",
+          "when": "view == openshiftProjectExplorer && viewItem == cluster",
+          "group": "inline"
+        },
+        {
           "command": "clusters.openshift.deployment.openConsole",
           "group": "3@0",
           "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.dc"

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -60,7 +60,11 @@ export class OpenShiftExplorer implements TreeDataProvider<OpenShiftObject>, Dis
                 || (this.kubeContext.cluster !== newCtx.cluster
                     || this.kubeContext.user !== newCtx.user
                     || this.kubeContext.namespace !== newCtx.namespace)) {
-                this.refresh();
+                OdoImpl.Instance.getProjects().then((projects) => {
+                    if(!projects.find((item:OpenShiftObject) => item.getName() === newCtx.namespace)) {
+                        this.refresh();
+                    }
+                });
             }
             this.kubeContext = newCtx;
         });
@@ -112,10 +116,7 @@ export class OpenShiftExplorer implements TreeDataProvider<OpenShiftObject>, Dis
 
     async reveal(item: OpenShiftObject): Promise<void> {
         this.refresh(item.getParent());
-        // double call of reveal is workaround for possible upstream issue
-        // https://github.com/redhat-developer/vscode-openshift-tools/issues/762
         await this.treeView.reveal(item);
-        this.treeView.reveal(item);
     }
 
     @vsCommand('openshift.explorer.reportIssue')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<any>
         OdoImpl.Instance.loadWorkspaceComponents(event);
     });
 
-    OdoImpl.Instance.loadWorkspaceComponents(null);
+    await OdoImpl.Instance.loadWorkspaceComponents(null);
 
     return {
         verifyBundledBinaries,

--- a/src/odo.ts
+++ b/src/odo.ts
@@ -184,6 +184,7 @@ export class OpenShiftCluster extends OpenShiftObjectImpl {
         const array = await this.odo.getProjects();
         return insert(array, item);
     }
+
 }
 
 export class OpenShiftProject extends OpenShiftObjectImpl {
@@ -796,9 +797,9 @@ export class OdoImpl implements Odo {
     }
 
     public async createProject(projectName: string): Promise<OpenShiftObject> {
-        await OdoImpl.instance.execute(Command.createProject(projectName));
         const clusters = await this.getClusters();
         const currentProjects = await this.getProjects()
+        await OdoImpl.instance.execute(Command.createProject(projectName));
         currentProjects.forEach((project:OpenShiftProject) => project.active = false);
         return this.insertAndReveal(new OpenShiftProject(clusters[0], projectName, true));
     }
@@ -991,7 +992,7 @@ export class OdoImpl implements Odo {
 
     async loadWorkspaceComponents(event: WorkspaceFoldersChangeEvent): Promise<void> {
         const clusters = (await this.getClusters());
-        if(!clusters) return;
+        if(!clusters || clusters.length === 0) return;
         if (event === null && workspace.workspaceFolders || event && event.added && event.added.length > 0) {
             const addedFolders = event === null? workspace.workspaceFolders : event.added;
             await OdoImpl.data.addContexts(addedFolders);

--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -15,6 +15,7 @@ import { Platform } from '../util/platform';
 import { WindowUtil } from '../util/windowUtils';
 import { vsCommand, VsCommandError } from '../vscommand';
 import ClusterViewLoader from '../view/cluster/clusterViewLoader';
+import { OpenShiftObject } from '../odo';
 
 export class Cluster extends OpenShiftItem {
     public static extensionContext: ExtensionContext;
@@ -42,8 +43,8 @@ export class Cluster extends OpenShiftItem {
     }
 
     @vsCommand('openshift.explorer.refresh')
-    static refresh(): void {
-        Cluster.explorer.refresh();
+    static refresh(context: OpenShiftObject): void {
+        Cluster.explorer.refresh(context);
     }
 
     @vsCommand('openshift.about')

--- a/src/openshift/project.ts
+++ b/src/openshift/project.ts
@@ -49,6 +49,7 @@ export class Project extends OpenShiftItem {
                                 // this changes kubeconfig and that triggers full tree refresh
                                 // there is no need to call explorer.refresh() manully
                                 await Project.odo.execute(`odo project set ${p[0].getName()}`);
+                                Project.explorer.refresh();
                             }
                         })
                         .then(() => `Project '${project.getName()}' successfully deleted`)

--- a/src/openshift/project.ts
+++ b/src/openshift/project.ts
@@ -43,15 +43,6 @@ export class Project extends OpenShiftItem {
             if (value === 'Yes') {
                 result = Progress.execFunctionWithProgress(`Deleting Project '${project.getName()}'`,
                     () => Project.odo.deleteProject(project)
-                        .then(async () => {
-                            const p = await Project.odo.getProjects();
-                            if (p.length>0) {
-                                // this changes kubeconfig and that triggers full tree refresh
-                                // there is no need to call explorer.refresh() manully
-                                await Project.odo.execute(`odo project set ${p[0].getName()}`);
-                                Project.explorer.refresh();
-                            }
-                        })
                         .then(() => `Project '${project.getName()}' successfully deleted`)
                         .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Project with error '${err}'`)))
                 );


### PR DESCRIPTION
This PR fixes the issue with double refresh when create new project.
Creating new project triggers update of application view because of
changes in kubeconfig. At the same time create new project command
itself triggers tree update. That ends with tree updated, but error
appears in debug output about three item requested to be revealed
does not exists in the tree, because it was refreshed as result of
kubeconfig changes.

Signed-off-by: Denis Golovin dgolovin@redhat.com