### PR TITLE
Show "Context: not set" for components w/o context in app explorer

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -280,7 +280,7 @@ export class OpenShiftComponent extends OpenShiftObjectImpl {
     }
 
     get tooltip(): string {
-        return `Component: ${this.name}\nContext: ${this.contextPath.fsPath}`;
+        return `Component: ${this.name}\nContext: ${this.contextPath ? this.contextPath.fsPath : 'not set'}`;
     }
 
     get description(): string {


### PR DESCRIPTION
This PR fixes #1729.

Signed-off-by: Denis Golovin dgolovin@redhat.com