### PR TITLE
Use original devfile.yaml if present in context folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-openshift-connector",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -76,7 +76,7 @@
       "dependencies": {
         "@types/node": {
           "version": "10.17.44",
-          "resolved": "http://localhost:4873/@types%2fnode/-/node-10.17.44.tgz",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
           "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
         }
       }
@@ -210,12 +210,12 @@
     },
     "@panva/asn1.js": {
       "version": "1.0.0",
-      "resolved": "http://localhost:4873/@panva%2fasn1.js/-/asn1.js-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@sindresorhus/is": {
       "version": "4.0.0",
-      "resolved": "http://localhost:4873/@sindresorhus%2fis/-/is-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
       "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ=="
     },
     "@sinonjs/commons": {
@@ -303,7 +303,7 @@
     },
     "@types/caseless": {
       "version": "0.12.2",
-      "resolved": "http://localhost:4873/@types%2fcaseless/-/caseless-0.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
     "@types/chai": {
@@ -399,7 +399,7 @@
     },
     "@types/minipass": {
       "version": "2.2.0",
-      "resolved": "http://localhost:4873/@types%2fminipass/-/minipass-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-2.2.0.tgz",
       "integrity": "sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==",
       "requires": {
         "@types/node": "*"
@@ -493,7 +493,7 @@
     },
     "@types/request": {
       "version": "2.48.5",
-      "resolved": "http://localhost:4873/@types%2frequest/-/request-2.48.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
       "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
       "requires": {
         "@types/caseless": "*",
@@ -551,7 +551,7 @@
     },
     "@types/stream-buffers": {
       "version": "3.0.3",
-      "resolved": "http://localhost:4873/@types%2fstream-buffers/-/stream-buffers-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.3.tgz",
       "integrity": "sha512-NeFeX7YfFZDYsCfbuaOmFQ0OjSmHreKBpp7MQ4alWQBHeh2USLsj7qyMyn9t82kjqIX516CR/5SRHnARduRtbQ==",
       "requires": {
         "@types/node": "*"
@@ -571,7 +571,7 @@
     },
     "@types/tar": {
       "version": "4.0.3",
-      "resolved": "http://localhost:4873/@types%2ftar/-/tar-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.3.tgz",
       "integrity": "sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==",
       "requires": {
         "@types/minipass": "*",
@@ -614,7 +614,7 @@
     },
     "@types/tough-cookie": {
       "version": "4.0.0",
-      "resolved": "http://localhost:4873/@types%2ftough-cookie/-/tough-cookie-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "@types/uglify-js": {
@@ -628,7 +628,7 @@
     },
     "@types/underscore": {
       "version": "1.10.24",
-      "resolved": "http://localhost:4873/@types%2funderscore/-/underscore-1.10.24.tgz",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.24.tgz",
       "integrity": "sha512-T3NQD8hXNW2sRsSbLNjF/aBo18MyJlbw0lSpQHB/eZZtScPdexN4HSa8cByYwTw9Wy7KuOFr81mlDQcQQaZ79w=="
     },
     "@types/validator": {
@@ -684,7 +684,7 @@
     },
     "@types/ws": {
       "version": "6.0.4",
-      "resolved": "http://localhost:4873/@types%2fws/-/ws-6.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
       "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
       "requires": {
         "@types/node": "*"
@@ -975,7 +975,7 @@
     },
     "aggregate-error": {
       "version": "3.1.0",
-      "resolved": "http://localhost:4873/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "requires": {
         "clean-stack": "^2.0.0",
@@ -1161,7 +1161,7 @@
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "http://localhost:4873/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -1216,7 +1216,7 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "http://localhost:4873/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
@@ -1257,7 +1257,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "http://localhost:4873/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
@@ -1268,7 +1268,7 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "http://localhost:4873/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
@@ -1388,7 +1388,7 @@
     },
     "base64url": {
       "version": "3.0.1",
-      "resolved": "http://localhost:4873/base64url/-/base64url-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "batch": {
@@ -1399,7 +1399,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "http://localhost:4873/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -1811,7 +1811,7 @@
     },
     "cacheable-lookup": {
       "version": "5.0.3",
-      "resolved": "http://localhost:4873/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz",
       "integrity": "sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w=="
     },
     "cacheable-request": {
@@ -1868,7 +1868,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "http://localhost:4873/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
@@ -1935,7 +1935,7 @@
     },
     "chownr": {
       "version": "2.0.0",
-      "resolved": "http://localhost:4873/chownr/-/chownr-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "chrome-trace-event": {
@@ -1991,7 +1991,7 @@
     },
     "clean-stack": {
       "version": "2.2.0",
-      "resolved": "http://localhost:4873/clean-stack/-/clean-stack-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-cursor": {
@@ -2100,7 +2100,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "http://localhost:4873/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -2459,7 +2459,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "http://localhost:4873/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -2496,7 +2496,7 @@
     },
     "decompress-response": {
       "version": "6.0.0",
-      "resolved": "http://localhost:4873/decompress-response/-/decompress-response-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "requires": {
         "mimic-response": "^3.1.0"
@@ -2504,7 +2504,7 @@
       "dependencies": {
         "mimic-response": {
           "version": "3.1.0",
-          "resolved": "http://localhost:4873/mimic-response/-/mimic-response-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
           "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
         }
       }
@@ -2667,7 +2667,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "http://localhost:4873/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "des.js": {
@@ -2876,7 +2876,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "http://localhost:4873/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -3602,7 +3602,7 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "http://localhost:4873/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
@@ -3721,7 +3721,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "http://localhost:4873/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
@@ -4165,12 +4165,12 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "http://localhost:4873/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.5.1",
-      "resolved": "http://localhost:4873/form-data/-/form-data-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
       "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "requires": {
         "asynckit": "^0.4.0",
@@ -4227,7 +4227,7 @@
     },
     "fs-minipass": {
       "version": "2.1.0",
-      "resolved": "http://localhost:4873/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "requires": {
         "minipass": "^3.0.0"
@@ -4302,7 +4302,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "http://localhost:4873/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -4538,12 +4538,12 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "http://localhost:4873/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.5",
-      "resolved": "http://localhost:4873/har-validator/-/har-validator-5.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "requires": {
         "ajv": "^6.12.3",
@@ -4990,7 +4990,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "http://localhost:4873/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -5000,7 +5000,7 @@
     },
     "http2-wrapper": {
       "version": "1.0.0-beta.5.2",
-      "resolved": "http://localhost:4873/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
       "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
       "requires": {
         "quick-lru": "^5.1.1",
@@ -5161,7 +5161,7 @@
     },
     "indent-string": {
       "version": "4.0.0",
-      "resolved": "http://localhost:4873/indent-string/-/indent-string-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "indexes-of": {
@@ -5476,7 +5476,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "http://localhost:4873/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
@@ -5510,12 +5510,12 @@
     },
     "isomorphic-ws": {
       "version": "4.0.1",
-      "resolved": "http://localhost:4873/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "http://localhost:4873/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul": {
@@ -5584,7 +5584,7 @@
     },
     "jose": {
       "version": "2.0.3",
-      "resolved": "http://localhost:4873/jose/-/jose-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.3.tgz",
       "integrity": "sha512-L+RlDgjO0Tk+Ki6/5IXCSEnmJCV8iMFZoBuEgu2vPQJJ4zfG/k3CAqZUMKDYNRHIDyy0QidJpOvX0NgpsAqFlw==",
       "requires": {
         "@panva/asn1.js": "^1.0.0"
@@ -5607,7 +5607,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "http://localhost:4873/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-buffer": {
@@ -5623,7 +5623,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "http://localhost:4873/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -5639,7 +5639,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "http://localhost:4873/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json2xml": {
@@ -5678,12 +5678,12 @@
     },
     "jsonpath-plus": {
       "version": "0.19.0",
-      "resolved": "http://localhost:4873/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
       "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg=="
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "http://localhost:4873/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -6099,7 +6099,7 @@
     },
     "lru-cache": {
       "version": "6.0.0",
-      "resolved": "http://localhost:4873/lru-cache/-/lru-cache-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
@@ -6125,7 +6125,7 @@
     },
     "make-error": {
       "version": "1.3.6",
-      "resolved": "http://localhost:4873/make-error/-/make-error-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "map-cache": {
@@ -6277,7 +6277,7 @@
     },
     "minipass": {
       "version": "3.1.3",
-      "resolved": "http://localhost:4873/minipass/-/minipass-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
       "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "requires": {
         "yallist": "^4.0.0"
@@ -6285,7 +6285,7 @@
     },
     "minizlib": {
       "version": "2.1.2",
-      "resolved": "http://localhost:4873/minizlib/-/minizlib-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "requires": {
         "minipass": "^3.0.0",
@@ -6891,7 +6891,7 @@
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "http://localhost:4873/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
@@ -6924,7 +6924,7 @@
     },
     "object-hash": {
       "version": "2.0.3",
-      "resolved": "http://localhost:4873/object-hash/-/object-hash-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.3.tgz",
       "integrity": "sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg=="
     },
     "object-inspect": {
@@ -7083,7 +7083,7 @@
     },
     "oidc-token-hash": {
       "version": "5.0.0",
-      "resolved": "http://localhost:4873/oidc-token-hash/-/oidc-token-hash-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.0.tgz",
       "integrity": "sha512-8Yr4CZSv+Tn8ZkN3iN2i2w2G92mUKClp4z7EGUfdsERiYSbj7P4i/NHm72ft+aUdsiFx9UdIPSTwbyzQ6C4URg=="
     },
     "on-finished": {
@@ -7120,7 +7120,7 @@
     },
     "openid-client": {
       "version": "4.2.1",
-      "resolved": "http://localhost:4873/openid-client/-/openid-client-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.2.1.tgz",
       "integrity": "sha512-07eOcJeMH3ZHNvx5DVMZQmy3vZSTQqKSSunbtM1pXb+k5LBPi5hMum1vJCFReXlo4wuLEqZ/OgbsZvXPhbGRtA==",
       "requires": {
         "base64url": "^3.0.1",
@@ -7135,7 +7135,7 @@
       "dependencies": {
         "got": {
           "version": "11.8.0",
-          "resolved": "http://localhost:4873/got/-/got-11.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/got/-/got-11.8.0.tgz",
           "integrity": "sha512-k9noyoIIY9EejuhaBNLyZ31D5328LeqnyPNXJQb2XlJZcKakLqN5m6O/ikhq/0lw56kUYS54fVm+D1x57YC9oQ==",
           "requires": {
             "@sindresorhus/is": "^4.0.0",
@@ -7199,7 +7199,7 @@
     },
     "p-any": {
       "version": "3.0.0",
-      "resolved": "http://localhost:4873/p-any/-/p-any-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
       "integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
       "requires": {
         "p-cancelable": "^2.0.0",
@@ -7271,7 +7271,7 @@
     },
     "p-some": {
       "version": "5.0.0",
-      "resolved": "http://localhost:4873/p-some/-/p-some-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
       "integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
       "requires": {
         "aggregate-error": "^3.0.0",
@@ -7452,7 +7452,7 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "http://localhost:4873/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
@@ -7743,7 +7743,7 @@
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "http://localhost:4873/psl/-/psl-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "public-encrypt": {
@@ -7807,7 +7807,7 @@
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "http://localhost:4873/qs/-/qs-6.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
@@ -7830,7 +7830,7 @@
     },
     "quick-lru": {
       "version": "5.1.1",
-      "resolved": "http://localhost:4873/quick-lru/-/quick-lru-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "randombytes": {
@@ -8184,7 +8184,7 @@
     },
     "request": {
       "version": "2.88.2",
-      "resolved": "http://localhost:4873/request/-/request-2.88.2.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -8211,7 +8211,7 @@
       "dependencies": {
         "form-data": {
           "version": "2.3.3",
-          "resolved": "http://localhost:4873/form-data/-/form-data-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "requires": {
             "asynckit": "^0.4.0",
@@ -8250,7 +8250,7 @@
     },
     "resolve-alpn": {
       "version": "1.0.0",
-      "resolved": "http://localhost:4873/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
       "integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA=="
     },
     "resolve-cwd": {
@@ -8342,12 +8342,12 @@
     },
     "rfc4648": {
       "version": "1.4.0",
-      "resolved": "http://localhost:4873/rfc4648/-/rfc4648-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
       "integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
     },
     "rimraf": {
       "version": "3.0.2",
-      "resolved": "http://localhost:4873/rimraf/-/rimraf-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
@@ -9021,7 +9021,7 @@
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "http://localhost:4873/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
@@ -9083,7 +9083,7 @@
     },
     "stream-buffers": {
       "version": "3.0.2",
-      "resolved": "http://localhost:4873/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
       "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ=="
     },
     "stream-each": {
@@ -9338,7 +9338,7 @@
     },
     "tar": {
       "version": "6.0.5",
-      "resolved": "http://localhost:4873/tar/-/tar-6.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
       "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
       "requires": {
         "chownr": "^2.0.0",
@@ -9351,7 +9351,7 @@
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "http://localhost:4873/mkdirp/-/mkdirp-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
@@ -9550,7 +9550,7 @@
     },
     "tmp-promise": {
       "version": "3.0.2",
-      "resolved": "http://localhost:4873/tmp-promise/-/tmp-promise-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.2.tgz",
       "integrity": "sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==",
       "requires": {
         "tmp": "^0.2.0"
@@ -9558,7 +9558,7 @@
       "dependencies": {
         "tmp": {
           "version": "0.2.1",
-          "resolved": "http://localhost:4873/tmp/-/tmp-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
           "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
           "requires": {
             "rimraf": "^3.0.0"
@@ -9626,7 +9626,7 @@
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "http://localhost:4873/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
         "psl": "^1.1.28",
@@ -9741,7 +9741,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "http://localhost:4873/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -9749,7 +9749,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "http://localhost:4873/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
@@ -9804,7 +9804,7 @@
     },
     "underscore": {
       "version": "1.11.0",
-      "resolved": "http://localhost:4873/underscore/-/underscore-1.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
       "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw=="
     },
     "union-value": {
@@ -10052,7 +10052,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "http://localhost:4873/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -11109,7 +11109,7 @@
     },
     "ws": {
       "version": "7.3.1",
-      "resolved": "http://localhost:4873/ws/-/ws-7.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
       "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     },
     "xml": {
@@ -11132,8 +11132,13 @@
     },
     "yallist": {
       "version": "4.0.0",
-      "resolved": "http://localhost:4873/yallist/-/yallist-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "http://localhost:4873/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "tree-kill": "^1.2.2",
     "validator": "^12.2.0",
     "vscode-kubernetes-tools-api": "1.2.0",
-    "wait-port": "^0.2.7"
+    "wait-port": "^0.2.7",
+    "yaml": "^1.10.0"
   },
   "devDependencies": {
     "@material-ui/core": "^4.11.0",

--- a/src/odo.ts
+++ b/src/odo.ts
@@ -354,7 +354,7 @@ export interface Odo {
     createApplication(application: OpenShiftObject): Promise<OpenShiftObject>;
     deleteApplication(application: OpenShiftObject): Promise<OpenShiftObject>;
     createComponentFromGit(application: OpenShiftObject, type: string, version: string, name: string, repoUri: string, context: Uri, ref: string): Promise<OpenShiftObject>;
-    createComponentFromFolder(application: OpenShiftObject, type: string, version: string, name: string, path: Uri, starter?: boolean): Promise<OpenShiftObject>;
+    createComponentFromFolder(application: OpenShiftObject, type: string, version: string, name: string, path: Uri, starter?: boolean, useExistingDevfile?: boolean): Promise<OpenShiftObject>;
     createComponentFromBinary(application: OpenShiftObject, type: string, version: string, name: string, path: Uri, context: Uri): Promise<OpenShiftObject>;
     deleteComponent(component: OpenShiftObject): Promise<OpenShiftObject>;
     undeployComponent(component: OpenShiftObject): Promise<OpenShiftObject>;
@@ -883,14 +883,14 @@ export class OdoImpl implements Odo {
         return application;
     }
 
-    public async createComponentFromFolder(application: OpenShiftObject, type: string, version: string, name: string, location: Uri, starter = false): Promise<OpenShiftObject> {
-        await this.execute(Command.createLocalComponent(application.getParent().getName(), application.getName(), type, version, name, location.fsPath, starter), location.fsPath);
+    public async createComponentFromFolder(application: OpenShiftObject, type: string, version: string, name: string, location: Uri, starter = false, useExistingDevfile = false): Promise<OpenShiftObject> {
+        await this.execute(Command.createLocalComponent(application.getParent().getName(), application.getName(), type, version, name, location.fsPath, starter, useExistingDevfile), location.fsPath);
         if (workspace.workspaceFolders) {
             const targetApplication = (await this.getApplications(application.getParent())).find((value) => value === application);
             if (!targetApplication) {
                 await this.insertAndReveal(application);
             }
-            await this.insertAndReveal(new OpenShiftComponent(application, name, ContextType.COMPONENT, location, 'local', version ? ComponentKind.S2I : ComponentKind.DEVFILE, {name: type, tag: version}));
+            await this.insertAndReveal(new OpenShiftComponent(application, name, ContextType.COMPONENT, location, 'local', version ? ComponentKind.S2I : ComponentKind.DEVFILE, {name: type? type : name , tag: version}));
         }
         let wsFolder: WorkspaceFolder;
         if (workspace.workspaceFolders) {

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -212,13 +212,14 @@ export class Command {
     static createLocalComponent(
         project: string,
         app: string,
-        type: string,
+        type = '', // will use empty string in case of undefined type passed in
         version: string,
         name: string,
         folder: string,
         starter: boolean,
+        useExistingDevfile = false
     ): string {
-        return `odo create ${type}${version?':':''}${version?version:''} ${name} ${version?'--s2i':''} --context ${folder} --app ${app} --project ${project} ${starter ? '--starter' : ''}`;
+        return `odo create ${type}${version?':':''}${version?version:''} ${name} ${version?'--s2i':''} --context ${folder} --app ${app} --project ${project}${starter ? ' --starter' : ''}${useExistingDevfile ? ' --devfile devfile.yaml' : ''}`;
     }
 
     @verbose

--- a/src/openshift/openshiftItem.ts
+++ b/src/openshift/openshiftItem.ts
@@ -43,9 +43,9 @@ export default class OpenShiftItem {
         return openshiftObject && `This name is already used, please enter different name.`;
     }
 
-    static async getName(message: string, data: Promise<Array<OpenShiftObject>>, offset?: string, value = ''): Promise<string> {
+    static async getName(message: string, data: Promise<Array<OpenShiftObject>>, offset?: string, defaultValue = ''): Promise<string> {
         return window.showInputBox({
-            value,
+            value: defaultValue,
             prompt: `Provide ${message}`,
             ignoreFocusOut: true,
             validateInput: async (value: string) => {

--- a/src/openshift/openshiftItem.ts
+++ b/src/openshift/openshiftItem.ts
@@ -43,8 +43,9 @@ export default class OpenShiftItem {
         return openshiftObject && `This name is already used, please enter different name.`;
     }
 
-    static async getName(message: string, data: Promise<Array<OpenShiftObject>>, offset?: string): Promise<string> {
+    static async getName(message: string, data: Promise<Array<OpenShiftObject>>, offset?: string, value = ''): Promise<string> {
         return window.showInputBox({
+            value,
             prompt: `Provide ${message}`,
             ignoreFocusOut: true,
             validateInput: async (value: string) => {


### PR DESCRIPTION
This PR fixes #1815.

Wnen devfile is present in the root of the project, there
is no reason to ask for component type, because devfile is
component type. All is required is to call odo command
without type name and pass `--devfile devfile.yaml` option.
That slashes new component workflow - when ran from
Application View -  to just two steps. Selecting workspace
folder as context and typing in the component's name.
Default value for component name input is set as a name from
devfile.yaml.

Signed-off-by: Denis Golovin dgolovin@redhat.com