### PR TITLE
Workaround for odo issue #4144

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -609,7 +609,7 @@ export class OdoImpl implements Odo {
         const result: cliInstance.CliExitData = await this.execute(Command.listComponents(application.getParent().getName(), application.getName()), Platform.getUserHomePath());
         const componentsJson = this.loadJSON<ComponentsJson>(result.stdout);
         const components = [
-            ...componentsJson?.s2iComponents ? componentsJson.s2iComponents.map((item) => new S2iComponentAdapter(item)) : [],
+            ...componentsJson?.s2iComponents ? componentsJson.s2iComponents.filter(item => !!item?.spec?.sourceType).map((item) => new S2iComponentAdapter(item)) : [],
             ...componentsJson?.devfileComponents ? componentsJson.devfileComponents.map((item) => new DevfileComponentAdapter(item)) : []
         ];
 

--- a/test/unit/odo.test.ts
+++ b/test/unit/odo.test.ts
@@ -371,7 +371,8 @@ suite("odo", () => {
                             namespace: 'project'
                         },
                         spec: {
-                            source: 'https://'
+                            source: 'https://',
+                            sourceType: 'git'
                         }
                     }
                 ]


### PR DESCRIPTION
This PR fixes effects of https://github.com/openshift/odo/issues/4144
in Application Explorer View by filtering s2i components without
spec.sourceType.

Signed-off-by: Denis Golovin dgolovin@redhat.com