### PR TITLE
Command wrapper should show error message and rethrow original error

### DIFF
--- a/src/vscommand.ts
+++ b/src/vscommand.ts
@@ -43,6 +43,7 @@ async function execute(command: VsCommandFunction, ...params: any[]): Promise<an
         } else {
             window.showErrorMessage(err);
         }
+        throw err;
     }
 }
 

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -157,7 +157,13 @@ suite('openshift connector Extension', () => {
         sandbox.stub(vscode.window, 'showInformationMessage');
         const semStub = sandbox.stub(vscode.window, 'showErrorMessage');
         sandbox.stub(Progress, 'execFunctionWithProgress').rejects(Error('message'));
-        await vscode.commands.executeCommand('openshift.app.delete', appItem);
+        let error;
+        try {
+            await vscode.commands.executeCommand('openshift.app.delete', appItem);
+        } catch (err) {
+            error = err;
+        }
+        expect(error).not.null;
         expect(semStub).calledWith('Failed to delete Application with error \'Error: message\'');
     });
 });


### PR DESCRIPTION
Rethrowing original error would tell a client that command execution
weren't successful.

Signed-off-by: Denis Golovin dgolovin@redhat.com