### PR TITLE
Update integrated terminal shellPath for windows only

### DIFF
--- a/src/util/windowUtils.ts
+++ b/src/util/windowUtils.ts
@@ -9,9 +9,11 @@ export class WindowUtil {
     static createTerminal(name: string, cwd?: string): Terminal {
         const options: TerminalOptions = {
             cwd,
-            name,
-            shellPath: process.platform === 'win32' ? process.env.ComSpec : '/bin/bash',
+            name
         };
+        if (process.platform === 'win32') {
+            options.shellPath = process.env.ComSpec;
+        }
         return window.createTerminal(options);
     }
 }


### PR DESCRIPTION
This fix changes the logic slightly. It lets vscode to decide
what shell to use on linux and does not set it explicitly like
it was done before. For windows it always changes shellPath to
cmd to avoid handling powerShell command execution differences.

Signed-off-by: Denis Golovin dgolovin@redhat.com