### PR TITLE
Remove global window declaration

### DIFF
--- a/src/view/@types/windows/index.d.ts
+++ b/src/view/@types/windows/index.d.ts
@@ -5,4 +5,5 @@
 
 interface Window {
     acquireVsCodeApi(): any;
+    cmdText: string;
 }

--- a/src/view/describe/app/describeView.tsx
+++ b/src/view/describe/app/describeView.tsx
@@ -39,14 +39,6 @@ const theme = createMuiTheme({
     },
   });
 
-declare global {
-    interface Window {
-        acquireVsCodeApi(): any;
-    }
-}
-
-// s
-
 // Do not change any type, that would lead to props validation error
 // during the compile:views
 export default function describeView(props: any): JSX.Element {

--- a/src/view/log/app/index.tsx
+++ b/src/view/log/app/index.tsx
@@ -9,12 +9,6 @@ import Spinner from './spinner';
 import Log from './log';
 import { LogViewContext } from './context';
 
-declare global {
-    interface Window {
-        cmdText: string;
-    }
-}
-
 class LogView extends React.Component {
     private toggleAutoScroll = () => {
         console.log('toggling autoscroll')

--- a/src/view/log/app/log.tsx
+++ b/src/view/log/app/log.tsx
@@ -10,7 +10,7 @@ export interface LogProps extends LazyLogProps {
 }
 
 export default class Log extends LazyLog {
-    private wholeLog;
+    private wholeLog: string;
     constructor(props: any) {
         super(props);
         this.wholeLog = `${this.props.text}\n`;


### PR DESCRIPTION
It does not needed anymore, because it was moved
to @types folder d.ts definition.

Signed-off-by: Denis Golovin dgolovin@redhat.com