### PR TITLE
Replace starter:boolean to starter:string in `odo create` command

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -354,7 +354,7 @@ export interface Odo {
     createApplication(application: OpenShiftObject): Promise<OpenShiftObject>;
     deleteApplication(application: OpenShiftObject): Promise<OpenShiftObject>;
     createComponentFromGit(application: OpenShiftObject, type: string, version: string, name: string, repoUri: string, context: Uri, ref: string): Promise<OpenShiftObject>;
-    createComponentFromFolder(application: OpenShiftObject, type: string, version: string, name: string, path: Uri, starter?: boolean, useExistingDevfile?: boolean): Promise<OpenShiftObject>;
+    createComponentFromFolder(application: OpenShiftObject, type: string, version: string, name: string, path: Uri, starterName?: string, useExistingDevfile?: boolean): Promise<OpenShiftObject>;
     createComponentFromBinary(application: OpenShiftObject, type: string, version: string, name: string, path: Uri, context: Uri): Promise<OpenShiftObject>;
     deleteComponent(component: OpenShiftObject): Promise<OpenShiftObject>;
     undeployComponent(component: OpenShiftObject): Promise<OpenShiftObject>;
@@ -894,7 +894,7 @@ export class OdoImpl implements Odo {
         return application;
     }
 
-    public async createComponentFromFolder(application: OpenShiftObject, type: string, version: string, name: string, location: Uri, starter = false, useExistingDevfile = false): Promise<OpenShiftObject> {
+    public async createComponentFromFolder(application: OpenShiftObject, type: string, version: string, name: string, location: Uri, starter: string = undefined, useExistingDevfile = false): Promise<OpenShiftObject> {
         await this.execute(Command.createLocalComponent(application.getParent().getName(), application.getName(), type, version, name, location.fsPath, starter, useExistingDevfile), location.fsPath);
         if (workspace.workspaceFolders) {
             const targetApplication = (await this.getApplications(application.getParent())).find((value) => value === application);

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -220,10 +220,10 @@ export class Command {
         version: string,
         name: string,
         folder: string,
-        starter: boolean,
+        starter: string = undefined,
         useExistingDevfile = false
     ): string {
-        return `odo create ${type}${version?':':''}${version?version:''} ${name} ${version?'--s2i':''} --context ${folder} --app ${app} --project ${project}${starter ? ' --starter' : ''}${useExistingDevfile ? ' --devfile devfile.yaml' : ''}`;
+        return `odo create ${type}${version?':':''}${version?version:''} ${name} ${version?'--s2i':''} --context ${folder} --app ${app} --project ${project}${starter ? ` --starter=${starter}` : ''}${useExistingDevfile ? ' --devfile devfile.yaml' : ''}`;
     }
 
     @verbose

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -591,7 +591,7 @@ export class Component extends OpenShiftItem {
 
         if (!componentName) return null;
 
-        let createStarter = false;
+        let createStarter: string;
         let componentType: ComponentTypeAdapter;
         if (!useExistingDevfile) {
             const componentTypes = Component.odo.getComponentTypes();
@@ -611,8 +611,10 @@ export class Component extends OpenShiftItem {
                     const descr = await this.odo.execute(Command.describeCatalogComponent(componentType.name));
                     const starterProjects: StarterProjectDescription[] =this.odo.loadItems<StarterProjectDescription>(descr,(data:{Data:ComponentDescription})=>data.Data.starterProjects);
                     if(starterProjects?.length && starterProjects?.length > 0) {
-                        const create = await window.showQuickPick(['Yes', 'No'] , {placeHolder: 'Initialize Component using default Starter Project?'});
-                        createStarter = create === 'Yes';
+                        const create = await window.showQuickPick(['Yes', 'No'] , {placeHolder: `Initialize Component using '${starterProjects[0].name}' Starter Project?`});
+                        if (create === 'Yes') {
+                            createStarter = starterProjects[0].name;
+                        };
                     }
                 }
             }
@@ -907,7 +909,7 @@ export class Component extends OpenShiftItem {
                     const gitRef = bcJson.spec.source.git.ref || 'master';
                     await Component.odo.execute(Command.createGitComponent(prjName, appName, compTypeName, compTypeVersion, compName, gitUrl, gitRef), workspaceFolder.fsPath);
                 } else { // componentType === ComponentType.Local
-                    await Component.odo.execute(Command.createLocalComponent(prjName, appName, componentJson.metadata.labels['app.kubernetes.io/name'], componentJson.metadata.labels['app.openshift.io/runtime-version'], compName, workspaceFolder.fsPath, false));
+                    await Component.odo.execute(Command.createLocalComponent(prjName, appName, componentJson.metadata.labels['app.kubernetes.io/name'], componentJson.metadata.labels['app.openshift.io/runtime-version'], compName, workspaceFolder.fsPath));
                 }
                 // import storage if present
                 if (componentJson.spec.template.spec.containers[0].volumeMounts) {

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -142,7 +142,7 @@ suite('OpenShift/Component', () => {
                 expect(result).equals(`Component '${componentItem.getName()}' successfully created. To deploy it on cluster, perform 'Push' action.`);
                 expect(progressFunctionStub).calledOnceWith(
                     `Creating new Component '${componentItem.getName()}'`);
-                expect(execStub).calledWith(Command.createLocalComponent(appItem.getParent().getName(), appItem.getName(), componentType.name, version, componentItem.getName(), folder.uri.fsPath, false));
+                expect(execStub).calledWith(Command.createLocalComponent(appItem.getParent().getName(), appItem.getName(), componentType.name, version, componentItem.getName(), folder.uri.fsPath));
             });
 
             test('returns null when no option is selected from quick pick', async () => {


### PR DESCRIPTION
This PR related to #1855. It allows to create component with specific
starter project if there are many for selected devfile component type

Signed-off-by: Denis Golovin dgolovin@redhat.com