### PR TITLE
Add redhat.vscode-commons extension dependency to enable telemetry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ node('rhel8'){
   def packageJson = readJSON file: 'package.json'
 
   stage('Package') {
-    packageJson.extensionDependencies = ["ms-kubernetes-tools.vscode-kubernetes-tools"]
+    packageJson.extensionDependencies = ["ms-kubernetes-tools.vscode-kubernetes-tools", "redhat.vscode-commons"]
     writeJSON file: 'package.json', json: packageJson, pretty: 4
     sh "vsce package -o openshift-connector-${packageJson.version}-${env.BUILD_NUMBER}.vsix"
     sh "sha256sum *.vsix > openshift-connector-${packageJson.version}-${env.BUILD_NUMBER}.vsix.sha256"


### PR DESCRIPTION
This PR fixes #1868, fixes #169.

Signed-off-by: Denis Golovin dgolovin@redhat.com