### PR TITLE
Fix initialization of error prop in telemetry event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-openshift-connector",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9343,6 +9343,21 @@
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
+      }
+    },
+    "stacktrace-parser": {
+      "version": "0.1.10",
+      "resolved": "http://localhost:4873/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
+      "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
+      "requires": {
+        "type-fest": "^0.7.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.7.1",
+          "resolved": "http://localhost:4873/type-fest/-/type-fest-0.7.1.tgz",
+          "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
+        }
       }
     },
     "static-extend": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "rxjs": "^6.5.3",
     "semver": "^6.3.0",
     "shelljs": "^0.8.3",
+    "stacktrace-parser": "^0.1.10",
     "string-format": "^2.0.0",
     "tree-kill": "^1.2.2",
     "validator": "^12.2.0",

--- a/src/k8s/build.ts
+++ b/src/k8s/build.ts
@@ -82,7 +82,7 @@ export class Build {
         if (buildName) {
             result = Progress.execFunctionWithProgress('Starting build', () => Build.odo.execute(Build.command.startBuild(buildName)))
                 .then(() => `Build '${buildName}' successfully started`)
-                .catch((err) => Promise.reject(new VsCommandError(`Failed to start build with error '${err}'`)));
+                .catch((err) => Promise.reject(new VsCommandError(`Failed to start build with error '${err}'`, 'Failed to start build')));
         }
         return result;
     }
@@ -129,7 +129,7 @@ export class Build {
         if (build) {
             result = Progress.execFunctionWithProgress('Deleting build', () => Build.odo.execute(Build.command.delete(build)))
                 .then(() => `Build '${build}' successfully deleted`)
-                .catch((err) => Promise.reject(new VsCommandError(`Failed to delete build with error '${err}'`)));
+                .catch((err) => Promise.reject(new VsCommandError(`Failed to delete build with error '${err}'`, 'Failed to delete build')));
         }
         return result;
     }

--- a/src/k8s/deployment.ts
+++ b/src/k8s/deployment.ts
@@ -62,7 +62,7 @@ export class DeploymentConfig {
         if (deployName) {
             result = Progress.execFunctionWithProgress(`Creating Deployment for '${deployName}'.`, () => DeploymentConfig.odo.execute(DeploymentConfig.command.deploy(deployName)))
                 .then(() => `Deployment successfully created for '${deployName}'.`)
-                .catch((err) => Promise.reject(new VsCommandError(`Failed to create Deployment with error '${err}'.`)));
+                .catch((err) => Promise.reject(new VsCommandError(`Failed to create Deployment with error '${err}'.`, 'Failed to create Deployment')));
         }
         return result;
     }
@@ -118,7 +118,7 @@ export class DeploymentConfig {
         if (replica) {
             result = Progress.execFunctionWithProgress('Deleting replica', () => DeploymentConfig.odo.execute(DeploymentConfig.command.delete(replica)))
                 .then(() => `Replica '${replica}' successfully deleted`)
-                .catch((err) => Promise.reject(new VsCommandError(`Failed to delete replica with error '${err}'`)));
+                .catch((err) => Promise.reject(new VsCommandError(`Failed to delete replica with error '${err}'`, 'Failed to delete replica')));
         }
         return result;
     }

--- a/src/k8s/route.ts
+++ b/src/k8s/route.ts
@@ -20,7 +20,7 @@ import { asJson } from './common';
         return asJson(Route.command.getRoute(namespace, name)).then((response: any) => {
             const hostName = response?.spec.host;
             if (hostName === undefined) {
-                throw new VsCommandError(`Cannot identify host name for Route '${name}'`);
+                throw new VsCommandError(`Cannot identify host name for Route '${name}'`, 'Cannot identify host name for Route');
             }
             return response.spec.tls ? `https://${hostName}` : `http://${hostName}`;
         });

--- a/src/odo.ts
+++ b/src/odo.ts
@@ -743,12 +743,13 @@ export class OdoImpl implements Odo {
     }
 
     public async getServiceTemplates(): Promise<string[]> {
+        // TODO: error reporting does not look right
         let items: any[] = [];
         const result: cliInstance.CliExitData = await this.execute(Command.listCatalogServicesJson(), Platform.getUserHomePath(), false);
         try {
             items = JSON.parse(result.stdout).services.items;
         } catch (err) {
-            throw new VsCommandError(JSON.parse(result.stderr).message);
+            throw new VsCommandError(JSON.parse(result.stderr).message, 'Error when parsing command\'s stdout output');
         }
         if (!Array.isArray(items) || Array.isArray(items) && items.length === 0) {
             throw new VsCommandError('No deployable services found.');

--- a/src/openshift/application.ts
+++ b/src/openshift/application.ts
@@ -29,7 +29,7 @@ export class Application extends OpenShiftItem {
             if (value === 'Yes') {
                 return Progress.execFunctionWithProgress(`Deleting the Application '${appName}'`, () => Application.odo.deleteApplication(application))
                     .then(() => `Application '${appName}' successfully deleted`)
-                    .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Application with error '${err}'`)));
+                    .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Application with error '${err}'`, 'Failed to delete Application')));
             }
         }
         return null;

--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -24,7 +24,7 @@ export class Cluster extends OpenShiftItem {
         const value = await window.showWarningMessage('Do you want to logout of cluster?', 'Logout', 'Cancel');
         if (value === 'Logout') {
             return Cluster.odo.execute(Command.odoLogout())
-            .catch((error) => Promise.reject(new VsCommandError(`Failed to logout of the current cluster with '${error}'!`)))
+            .catch((error) => Promise.reject(new VsCommandError(`Failed to logout of the current cluster with '${error}'!`, 'Failed to logout of the current cluster')))
             .then(async (result) => {
                 if (result.stderr === '') {
                     Cluster.explorer.refresh();
@@ -35,7 +35,7 @@ export class Cluster extends OpenShiftItem {
                     }
                     return null;
                 }
-                throw new VsCommandError(`Failed to logout of the current cluster with '${result.stderr}'!`);
+                throw new VsCommandError(`Failed to logout of the current cluster with '${result.stderr}'!`, 'Failed to logout of the current cluster');
             });
         }
         return null;
@@ -239,7 +239,7 @@ export class Cluster extends OpenShiftItem {
             await Cluster.save(username, passwd, password, result);
             return await Cluster.loginMessage(clusterURL, result);
         } catch (error) {
-            throw new VsCommandError(`Failed to login to cluster '${clusterURL}' with '${Filters.filterPassword(error.message)}'!`);
+            throw new VsCommandError(`Failed to login to cluster '${clusterURL}' with '${Filters.filterPassword(error.message)}'!`, 'Failed to login to cluster');
         }
     }
 
@@ -293,7 +293,7 @@ export class Cluster extends OpenShiftItem {
         return Progress.execFunctionWithProgress(`Login to the cluster: ${clusterURL}`,
             () => Cluster.odo.execute(Command.odoLoginWithToken(clusterURL, ocToken.trim()))
             .then((result) => Cluster.loginMessage(clusterURL, result))
-            .catch((error) => Promise.reject(new VsCommandError(`Failed to login to cluster '${clusterURL}' with '${Filters.filterToken(error.message)}'!`)))
+            .catch((error) => Promise.reject(new VsCommandError(`Failed to login to cluster '${clusterURL}' with '${Filters.filterToken(error.message)}'!`, 'Failed to login to cluster')))
         );
     }
 
@@ -303,6 +303,6 @@ export class Cluster extends OpenShiftItem {
             await commands.executeCommand('setContext', 'isLoggedIn', true);
             return `Successfully logged in to '${clusterURL}'`;
         }
-        throw new VsCommandError(result.stderr);
+        throw new VsCommandError(result.stderr, 'Failed to login to cluster with output in stderror');
     }
 }

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -124,7 +124,7 @@ export class Component extends OpenShiftItem {
         } else if (componentSource.label === SourceTypeChoice.LOCAL.label) {
             command = Component.createFromLocal(application);
         }
-        return command.catch((err) => Promise.reject(new VsCommandError(`Failed to create Component with error '${err}'`)));
+        return command.catch((err) => Promise.reject(new VsCommandError(`Failed to create Component with error '${err}'`, 'Failed to create Component with error')));
     }
 
     @vsCommand('openshift.component.delete', true)
@@ -147,7 +147,7 @@ export class Component extends OpenShiftItem {
                 await Component.odo.deleteComponent(component);
 
             }).then(() => `Component '${name}' successfully deleted`)
-            .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Component with error '${err}'`)));
+            .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Component with error '${err}'`, 'Failed to delete Component with error')));
         }
     }
 
@@ -167,7 +167,7 @@ export class Component extends OpenShiftItem {
                 Component.stopWatchSession(component);
                 await Component.odo.undeployComponent(component);
             }).then(() => `Component '${name}' successfully undeployed`)
-            .catch((err) => Promise.reject(new VsCommandError(`Failed to undeploy Component with error '${err}'`)));
+            .catch((err) => Promise.reject(new VsCommandError(`Failed to undeploy Component with error '${err}'`, 'Failed to undeploy Component with error')));
         }
     }
 
@@ -322,7 +322,7 @@ export class Component extends OpenShiftItem {
         return Progress.execFunctionWithProgress('Unlinking Component',
             () => Component.odo.execute(Command.unlinkComponents(component.getParent().getParent().getName(), component.getParent().getName(), component.getName(), compName, port), component.contextPath.fsPath)
                 .then(() => `Component '${compName}' has been successfully unlinked from the Component '${component.getName()}'`)
-                .catch((err) => Promise.reject(new VsCommandError(`Failed to unlink Component with error '${err}'`)))
+                .catch((err) => Promise.reject(new VsCommandError(`Failed to unlink Component with error '${err}'`, 'Failed to unlink Component with error')))
         );
     }
 
@@ -349,7 +349,7 @@ export class Component extends OpenShiftItem {
         return Progress.execFunctionWithProgress('Unlinking Service',
             () => Component.odo.execute(Command.unlinkService(component.getParent().getParent().getName(), component.getParent().getName(), serviceName, component.getName()), component.contextPath.fsPath)
                 .then(() => `Service '${serviceName}' has been successfully unlinked from the Component '${component.getName()}'`)
-                .catch((err) => Promise.reject(new VsCommandError(`Failed to unlink Service with error '${err}'`)))
+                .catch((err) => Promise.reject(new VsCommandError(`Failed to unlink Service with error '${err}'`, 'Failed to unlink Service with error')))
         );
     }
 
@@ -380,13 +380,13 @@ export class Component extends OpenShiftItem {
         } else if (ports.length > 1) {
             port = await window.showQuickPick(ports, {placeHolder: 'Select Port to link', ignoreFocusOut: true});
         } else {
-            return Promise.reject(new VsCommandError(`Component '${component.getName()}' has no Ports declared.`));
+            return Promise.reject(new VsCommandError(`Component '${component.getName()}' has no Ports declared.`, 'Component has no Ports declared'));
         }
 
         return Progress.execFunctionWithProgress(`Link Component '${componentToLink.getName()}' with Component '${component.getName()}'`,
             () => Component.odo.execute(Command.linkComponentTo(component.getParent().getParent().getName(), component.getParent().getName(), component.getName(), componentToLink.getName(), port), component.contextPath.fsPath)
                 .then(() => `Component '${componentToLink.getName()}' successfully linked with Component '${component.getName()}'`)
-                .catch((err) => Promise.reject(new VsCommandError(`Failed to link component with error '${err}'`)))
+                .catch((err) => Promise.reject(new VsCommandError(`Failed to link component with error '${err}'`,'Failed to link component')))
         );
     }
 
@@ -414,7 +414,7 @@ export class Component extends OpenShiftItem {
         return Progress.execFunctionWithProgress(`Link Service '${serviceToLink.getName()}' with Component '${component.getName()}'`,
             () => Component.odo.execute(Command.linkServiceTo(component.getParent().getParent().getName(), component.getParent().getName(), component.getName(), serviceToLink.getName()), component.contextPath.fsPath)
                 .then(() => `Service '${serviceToLink.getName()}' successfully linked with Component '${component.getName()}'`)
-                .catch((err) => Promise.reject(new VsCommandError(`Failed to link Service with error '${err}'`)))
+                .catch((err) => Promise.reject(new VsCommandError(`Failed to link Service with error '${err}'`, 'Failed to link Service')))
         );
     }
 
@@ -899,7 +899,7 @@ export class Component extends OpenShiftItem {
         if (componentType === SourceType.BINARY) {
             return 'Import for binary OpenShift Components is not supported.';
         } if (componentType !== SourceType.GIT && componentType !== SourceType.LOCAL) {
-            throw new VsCommandError(`Cannot import unknown Component type '${componentType}'.`);
+            throw new VsCommandError(`Cannot import unknown Component type '${componentType}'.`, 'Cannot import unknown Component type');
         }
 
         const workspaceFolder = await selectWorkspaceFolder();
@@ -980,7 +980,7 @@ export class Component extends OpenShiftItem {
                 }
                 return `Component '${compName}' was successfully imported.`;
             } catch (errGetCompJson) {
-                throw new VsCommandError(`Component import failed with error '${errGetCompJson.message}'.`);
+                throw new VsCommandError(`Component import failed with error '${errGetCompJson.message}'.`,'Component import failed');
             }
         }); // create component with the same name
     }

--- a/src/openshift/project.ts
+++ b/src/openshift/project.ts
@@ -44,7 +44,7 @@ export class Project extends OpenShiftItem {
         projectName = projectName.trim();
         return Project.odo.createProject(projectName)
             .then(() => `Project '${projectName}' successfully created`)
-            .catch((error) => Promise.reject(new VsCommandError(`Failed to create Project with error '${error}'`)));
+            .catch((error) => Promise.reject(new VsCommandError(`Failed to create Project with error '${error}'`, 'Failed to create Project')));
     }
 
     @vsCommand('openshift.project.delete', true)
@@ -65,7 +65,7 @@ export class Project extends OpenShiftItem {
                             }
                         })
                         .then(() => `Project '${project.getName()}' successfully deleted`)
-                        .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Project with error '${err}'`)))
+                        .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Project with error '${err}'`,'Failed to delete Project')))
                 );
             }
         }

--- a/src/openshift/service.ts
+++ b/src/openshift/service.ts
@@ -42,7 +42,7 @@ export class Service extends OpenShiftItem {
         if (!serviceName) return null;
         return Progress.execFunctionWithProgress(`Creating a new Service '${serviceName}'`, () => Service.odo.createService(application, serviceTemplateName, serviceTemplatePlanName, serviceName.trim()))
             .then(() => `Service '${serviceName}' successfully created`)
-            .catch((err) => Promise.reject(new VsCommandError(`Failed to create Service with error '${err}'`)));
+            .catch((err) => Promise.reject(new VsCommandError(`Failed to create Service with error '${err}'`, 'Failed to create Service')));
     }
 
     @vsCommand('openshift.service.delete', true)
@@ -63,7 +63,7 @@ export class Service extends OpenShiftItem {
             if (answer === 'Yes') {
                 return Progress.execFunctionWithProgress(`Deleting Service '${service.getName()}' from Application '${service.getParent().getName()}'`, () => Service.odo.deleteService(service))
                     .then(() => `Service '${service.getName()}' successfully deleted`)
-                    .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Service with error '${err}'`)));
+                    .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Service with error '${err}'`, 'Failed to delete Service')));
             }
         }
         return null;
@@ -86,7 +86,7 @@ export class Service extends OpenShiftItem {
             if (template) {
                 Service.odo.executeInTerminal(Command.describeService(template), Platform.getUserHomePath(), `OpenShift: Describe '${service.getName()}' Service`);
             } else {
-                throw new VsCommandError(`Cannot get Service Type name for Service '${service.getName()}'`);
+                throw new VsCommandError(`Cannot get Service Type name for Service '${service.getName()}'`, 'Cannot get Service Type name for Service');
             }
         }
     }

--- a/src/openshift/storage.ts
+++ b/src/openshift/storage.ts
@@ -42,7 +42,7 @@ export class Storage extends OpenShiftItem {
 
         return Progress.execFunctionWithProgress(`Creating the Storage '${component.getName()}'`, () => Storage.odo.createStorage(component, storageName, mountPath, storageSize))
             .then(() => `Storage '${storageName}' successfully created for Component '${component.getName()}'`)
-            .catch((err) => Promise.reject(new VsCommandError(`New Storage command failed with error: '${err}'!`)));
+            .catch((err) => Promise.reject(new VsCommandError(`New Storage command failed with error: '${err}'!`, 'New Storage command failed')));
     }
 
     @vsCommand('openshift.storage.delete', true)
@@ -57,7 +57,7 @@ export class Storage extends OpenShiftItem {
             if (value === 'Yes') {
                 return Progress.execFunctionWithProgress(`Deleting Storage ${storage.getName()} from Component ${storage.getParent().getName()}`, () => Storage.odo.deleteStorage(storage))
                     .then(() => `Storage '${storage.getName()}' from Component '${storage.getParent().getName()}' successfully deleted`)
-                    .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Storage with error '${err}'`)));
+                    .catch((err) => Promise.reject(new VsCommandError(`Failed to delete Storage with error '${err}'`, 'Failed to delete Storage')));
             }
         }
         return null;

--- a/src/openshift/url.ts
+++ b/src/openshift/url.ts
@@ -38,7 +38,7 @@ export class Url extends OpenShiftItem{
                     const selectedPort = await window.showQuickPick(portItems, {placeHolder: 'Select port to expose'});
                     port = selectedPort ? (selectedPort as unknown as Port).number.toString() : undefined;
                 } else {
-                    throw new VsCommandError(`Component '${component.getName()}' has no ports declared.`);
+                    throw new VsCommandError(`Component '${component.getName()}' has no ports declared.`, 'Component has no ports declared');
                 }
             } else {
                 port = await window.showInputBox({
@@ -70,7 +70,7 @@ export class Url extends OpenShiftItem{
                 return Progress.execFunctionWithProgress(`Creating a URL '${urlName}' for the Component '${component.getName()}'`,
                     () => Url.odo.createComponentCustomUrl(component, `${urlName}`, `${parsedNumber}`, secure === 'Yes')
                         .then(() => `URL '${urlName}' for component '${component.getName()}' successfully created`)
-                        .catch((err) => Promise.reject(new VsCommandError(`Failed to create URL '${urlName}' for component '${component.getName()}'. ${err.message}`)))
+                        .catch((err) => Promise.reject(new VsCommandError(`Failed to create URL '${urlName}' for component '${component.getName()}'. ${err.message}`, 'Failed to create URL')))
                 );
             }
         }
@@ -91,7 +91,7 @@ export class Url extends OpenShiftItem{
             if (value === 'Yes') {
                 return Progress.execFunctionWithProgress(`Deleting URL ${url.getName()} from Component ${url.getParent().getName()}`, () => Url.odo.deleteURL(url))
                     .then(() => `URL '${url.getName()}' from Component '${url.getParent().getName()}' successfully deleted`)
-                    .catch((err) => Promise.reject(new VsCommandError(`Failed to delete URL with error '${err}'`)));
+                    .catch((err) => Promise.reject(new VsCommandError(`Failed to delete URL with error '${err}'`, 'Failed to delete URL')));
             }
         }
         return null;

--- a/src/vscommand.ts
+++ b/src/vscommand.ts
@@ -70,6 +70,7 @@ export async function registerCommands(...modules: string[]): Promise<Disposable
                     // TODO: Wrap view title commands in try/catch and re-throw as VsCommandError
                     // TODO: telemetry cannot send not known exception stacktrace or message
                     // because it can contain user's sensitive information
+                    telemetryProps.error = 'Unexpected error';
                     throw err;
                 }
             } finally {


### PR DESCRIPTION
This PR fixes #1959. It fixes error property initialization
for command telemetry event and introduces telemetryMessage
to VsCommandException class to provide messages without
user sensitive information. When VsCommandException is
triggered the exception's message shown in vscode Error
message notification and telemetryMessage sent in telemetry
event `error` property. All unknown exceptions are always
reported to user by vscode and as 'Unknown exception happened'
in telemetry event error property. The fix also introduces
'cancelled' property to indicate if command was cancelled
by user.

Signed-off-by: Denis Golovin dgolovin@redhat.com