### PR TITLE
New Component called from App Explorer creates local component

### DIFF
--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -111,21 +111,7 @@ export class Component extends OpenShiftItem {
     static async create(application: OpenShiftApplication): Promise<string> {
         if (!application) return null;
 
-        const componentSource = await window.showQuickPick(SourceTypeChoice.asArray(), {
-            placeHolder: 'Select source type for Component',
-            ignoreFocusOut: true
-        });
-        if (!componentSource) return null;
-
-        let command: Promise<string>;
-        if (componentSource.label === SourceTypeChoice.GIT.label) {
-            command = Component.createFromGit(application);
-        } else if (componentSource.label === SourceTypeChoice.BINARY.label) {
-            command = Component.createFromBinary(application);
-        } else if (componentSource.label === SourceTypeChoice.LOCAL.label) {
-            command = Component.createFromLocal(application);
-        }
-        return command.catch((err) => Promise.reject(new VsCommandError(`Failed to create Component with error '${err}'`, 'Failed to create Component with error')));
+        return Component.createFromLocal(application).catch((err) => Promise.reject(new VsCommandError(`Failed to create Component with error '${err}'`, 'Failed to create Component with error')));
     }
 
     @vsCommand('openshift.component.delete', true)

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -17,7 +17,6 @@ import { Progress } from '../../../src/util/progress';
 import * as Util from '../../../src/util/async';
 import { Refs } from '../../../src/util/refs';
 import OpenShiftItem from '../../../src/openshift/openshiftItem';
-import { SourceTypeChoice } from '../../../src/openshift/component';
 import { SourceType } from '../../../src/odo/config';
 import { ComponentKind, ComponentTypeAdapter } from '../../../src/odo/componentType';
 import { AddWorkspaceFolder } from '../../../src/util/workspace';


### PR DESCRIPTION
This PR fixes #2027.

To create GIT and Binary components use command from palette.

Signed-off-by: Denis Golovin dgolovin@redhat.com
