### PR TITLE
Represent commands as objects

### DIFF
--- a/src/k8s/build.ts
+++ b/src/k8s/build.ts
@@ -9,33 +9,50 @@ import { OdoImpl, Odo } from '../odo';
 import { Progress } from '../util/progress';
 import * as common from './common';
 import { vsCommand, VsCommandError } from '../vscommand';
+import { CommandOption, CommandText } from '../odo/command';
 
 export class Build {
 
     public static command = {
-      getAllBuilds(parent: ClusterExplorerV1.ClusterExplorerNode): string {
-          return `get build -o jsonpath="{range .items[?(.metadata.labels.buildconfig=='${(parent as any).name}')]}{.metadata.namespace}{','}{.metadata.name}{','}{.metadata.annotations.openshift\\.io/build\\.number}{\\"\\n\\"}{end}"`;
+      getAllBuilds(parent: ClusterExplorerV1.ClusterExplorerNode): CommandText {
+          return new CommandText('get build',
+            undefined, [
+                new CommandOption('-o', `jsonpath="{range .items[?(.metadata.labels.buildconfig=='${(parent as any).name}')]}{.metadata.namespace}{','}{.metadata.name}{','}{.metadata.annotations.openshift\\.io/build\\.number}{\\"\\n\\"}{end}"`)
+            ]
+          );
       },
-      startBuild(buildConfig: string): string {
-          return `oc start-build ${buildConfig}`;
+      startBuild(buildConfig: string): CommandText {
+          return new CommandText('oc start-build', buildConfig);
       },
-      getBuilds(build: string): string {
-          return `oc get build -l buildconfig=${build} -o json`;
+      getBuilds(build: string): CommandText {
+          return new CommandText('oc get build',
+            undefined, [
+                new CommandOption('-l', `buildconfig=${build}`),
+                new CommandOption('-o', 'json', false)
+            ]
+        );
       },
-      showLog(build: string, text: string): string {
-          return `oc logs ${build}${text}`;
+      showLog(build: string, text: string): CommandText {
+          return new CommandText('oc logs', `${build}${text}`);
       },
-      rebuildFrom(resourceId: string): string {
-          return `oc start-build --from-build ${resourceId}`;
+      rebuildFrom(resourceId: string): CommandText {
+          return new CommandText('oc start-build',
+            undefined, [
+                new CommandOption('--from-build', resourceId)
+            ]
+        );
       },
-      followLog(build: string, text: string): string {
-          return `oc logs ${build}${text} -f`;
+      followLog(build: string, text: string): CommandText {
+          return new CommandText('oc logs', `${build}${text}`, [
+              new CommandOption('-f')
+          ]
+        );
       },
-      delete(build: string): string {
-          return `oc delete build ${build}`;
+      delete(build: string): CommandText {
+          return new CommandText('oc delete build',build);
       },
-      getBuildConfigs(): string {
-          return 'oc get buildConfig -o json';
+      getBuildConfigs(): CommandText {
+          return new CommandText('oc get buildConfig -o json');
       }
   };
 

--- a/src/k8s/common.ts
+++ b/src/k8s/common.ts
@@ -7,6 +7,7 @@ import { QuickPickItem, window } from 'vscode';
 
 import * as k8s from 'vscode-kubernetes-tools-api';
 import * as Odo from '../odo';
+import { CommandText } from '../odo/command';
 import { VsCommandError } from '../vscommand';
 import { Node } from './node';
 
@@ -16,7 +17,7 @@ function convertItemToQuickPick(item: any): QuickPickItem {
     return qp;
 }
 
-export async function getQuickPicks(cmd: string, errorMessage: string, converter: (item: any) => QuickPickItem = convertItemToQuickPick): Promise<QuickPickItem[]> {
+export async function getQuickPicks(cmd: CommandText, errorMessage: string, converter: (item: any) => QuickPickItem = convertItemToQuickPick): Promise<QuickPickItem[]> {
     const result = await Odo.getInstance().execute(cmd);
     const json = JSON.parse(result.stdout);
     if (json.items.length === 0) {
@@ -30,7 +31,7 @@ export async function selectResourceByName(config: Promise<QuickPickItem[]> | Qu
     return resource ? resource.label : null;
 }
 
-export async function getChildrenNode(command: string, kind: string, abbreviation: string): Promise<k8s.ClusterExplorerV1.Node[]> {
+export async function getChildrenNode(command: CommandText, kind: string, abbreviation: string): Promise<k8s.ClusterExplorerV1.Node[]> {
     const kubectl = await k8s.extension.kubectl.v1;
     if (kubectl.available) {
         const result = await kubectl.api.invokeCommand(`${command}`);

--- a/src/odo.ts
+++ b/src/odo.ts
@@ -747,7 +747,7 @@ export class OdoImpl implements Odo {
         const [cmd] = command.split(' ');
         const toolLocation = await ToolsConfig.detect(cmd);
         const terminal: Terminal = WindowUtil.createTerminal(name, cwd);
-        terminal.sendText(toolLocation === cmd ? command : command.replace(cmd, `"${toolLocation}"`).replace(new RegExp(`&& ${cmd}`, 'g'), `&& "${toolLocation}"`), true);
+        terminal.sendText(toolLocation === cmd ? command : command.replace(cmd, `"${toolLocation}"`), true);
         terminal.show();
     }
 

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -33,14 +33,13 @@ export class CommandOption {
 
     toString(): string {
         if (this.privacy) {
-            this.toPrivateString();
-        } else {
-            return `${this.name}${this.value ? ` ${this.quote}${this.value}${this.quote}` : '' }`;
+            return this.toPrivateString();
         }
+        return `${this.name}${this.value ? ` ${this.quote}${this.value}${this.quote}` : '' }`;
     }
 
     toPrivateString(): string {
-        return `${this.name}${this.value && this.redacted? 'REDACTED' : '' }`
+        return `${this.name}${this.value && this.redacted? ' REDACTED' : '' }`
     }
 
     privacyMode(set: boolean): void {

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -103,7 +103,7 @@ export class Command {
             'odo application list',
             undefined, [
                 new CommandOption('--project', project),
-                new CommandOption('-o', 'json')
+                new CommandOption('-o', 'json', false)
             ]
         );
     }
@@ -296,7 +296,7 @@ export class Command {
 
     static describeComponentNoContextJson(project: string, app: string, component: string): CommandText {
         return this.describeComponentNoContext(project, app, component)
-            .addOption(new CommandOption('-o', 'json'));
+            .addOption(new CommandOption('-o', 'json', false));
     }
 
     static describeComponent(): CommandText {
@@ -304,7 +304,7 @@ export class Command {
     }
 
     static describeComponentJson(): CommandText {
-        return Command.describeComponent().addOption(new CommandOption('-o', 'json'));
+        return Command.describeComponent().addOption(new CommandOption('-o', 'json', false));
     }
 
     static describeService(service: string): CommandText {
@@ -315,7 +315,7 @@ export class Command {
     static describeCatalogComponent(component: string): CommandText {
         return new CommandText('odo catalog describe component',
             component, [
-                new CommandOption('-o', 'json')
+                new CommandOption('-o', 'json', false)
             ]
         );
     }
@@ -336,7 +336,7 @@ export class Command {
         return new CommandText('oc get service',
             `${component}-${app}`, [
                 new CommandOption('--namespace', project),
-                new CommandOption('-o', 'jsonpath="{range .spec.ports[*]}{.port}{\',\'}{end}"')
+                new CommandOption('-o', 'jsonpath="{range .spec.ports[*]}{.port}{\',\'}{end}"', false)
             ]
         );
     }
@@ -415,7 +415,7 @@ export class Command {
             cTxt.addOption(new CommandOption('--starter', starter, false));
         }
         if (useExistingDevfile) {
-            cTxt.addOption(new CommandOption('--devfile', 'devfile.yaml'));
+            cTxt.addOption(new CommandOption('--devfile', 'devfile.yaml', false));
         }
         return cTxt;
     }
@@ -497,7 +497,7 @@ export class Command {
         return new CommandText('oc get ServiceInstance',
             service, [
                 new CommandOption('--namespace', project),
-                new CommandOption('-o', 'jsonpath="{$.metadata.labels.app\\.kubernetes\\.io/name}"')
+                new CommandOption('-o', 'jsonpath="{$.metadata.labels.app\\.kubernetes\\.io/name}"', false)
             ]
         );
     }
@@ -505,7 +505,7 @@ export class Command {
     static waitForServiceToBeGone(project: string, service: string): CommandText {
         return new CommandText('oc wait',
             `ServiceInstance/${service}`, [
-                new CommandOption('--for', 'delete'),
+                new CommandOption('--for', 'delete', false),
                 new CommandOption('--namespace', project)
             ]
         );
@@ -569,7 +569,7 @@ export class Command {
     }
 
     static getclusterVersion(): CommandText {
-        return new CommandText('oc get clusterversion -ojson');
+        return new CommandText('oc get clusterversion -o json');
     }
 
     static showServerUrl(): CommandText {

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { workspace } from 'vscode';
+import { commands, workspace } from 'vscode';
 import { Platform } from '../util/platform';
 
 function verbose(_target: any, key: string, descriptor: any): void {
@@ -20,170 +20,326 @@ function verbose(_target: any, key: string, descriptor: any): void {
     descriptor[fnKey] = function(...args: any[]): any {
         const v = workspace.getConfiguration('openshiftConnector').get('outputVerbosityLevel');
         const command = fn.apply(this, args);
-        return command + (v > 0 ? ` -v ${v}` : '');
+        return v > 0 ? command.addOption('-v', v): command;
     };
+}
+
+const QUOTE = Platform.OS === 'win32' ? '"' : '\'';
+
+export class CommandOption {
+    protected privacy = false;
+    constructor(public readonly name: string, public readonly value?: string, public readonly redacted = true, public readonly quoted = false) {
+    }
+
+    toString(): string {
+        if (this.privacy) {
+            this.toPrivateString();
+        } else {
+            return `${this.name}${this.value ? ` ${this.quote}${this.value}${this.quote}` : '' }`;
+        }
+    }
+
+    toPrivateString(): string {
+        return `${this.name}${this.value && this.redacted? 'REDACTED' : '' }`
+    }
+
+    privacyMode(set: boolean): void {
+        this.privacy = set;
+    }
+
+    get quote(): string {
+        return this.quoted? QUOTE : '';
+    }
+}
+
+export class CommandText {
+    private privacy = false;
+    constructor(public readonly command: string, public readonly parameter?: string, public readonly options: CommandOption[] = []) {
+    }
+
+    toString(): string {
+        return `${this.command}${this.parameter? ` ${this.privacy? 'REDACTED' : this.parameter}`: ''}${this.options? ` ${this.options.join(' ')}`: ''}`;
+    }
+
+    privacyMode(set: boolean): CommandText {
+        this.privacy = set;
+        this.options.forEach(element => element.privacyMode(true));
+        return this;
+    }
+
+    addOption(option: CommandOption): CommandText {
+       this.options.push(option);
+       return this;
+    }
 }
 
 export class Command {
 
-    static viewEnv(): string {
-        return 'odo env view -o json';
+    static viewEnv(): CommandText {
+        return new CommandText(
+            'odo env view',
+            undefined, [
+                new CommandOption('-o', 'json', false)
+            ]
+        );
     }
 
-    static printCatalogComponentImageStreamRefJson(name: string, namespace: string): string {
-        return `oc get imagestream ${name} -n ${namespace} -o json`;
+    static printCatalogComponentImageStreamRefJson(name: string, namespace: string): CommandText {
+        return new CommandText(
+            'oc get imagestream',
+            name, [
+                new CommandOption('-n', namespace),
+                new CommandOption('-o', 'json', false)
+            ]
+        );
     }
 
-    static listProjects(): string {
-        return 'odo project list -o json';
+    static listProjects(): CommandText {
+        return new CommandText('odo project list -o json');
     }
 
     @verbose
-    static listApplications(project: string): string {
-        return `odo application list --project ${project} -o json`;
+    static listApplications(project: string): CommandText {
+        return new CommandText(
+            'odo application list',
+            undefined, [
+                new CommandOption('--project', project),
+                new CommandOption('-o', 'json')
+            ]
+        );
     }
 
-    static deleteProject(name: string): string {
-        return `odo project delete ${name} -w -o json`;
+    static deleteProject(name: string): CommandText {
+        return new CommandText(
+            'odo project delete',
+            name, [
+                new CommandOption('-w'),
+                new CommandOption('-o', 'json', false)
+            ]
+        );
     }
 
     @verbose
-    static createProject(name: string): string {
-        return `odo project create ${name} -w`;
+    static createProject(name: string): CommandText {
+        return new CommandText('odo project create',
+            name, [
+                new CommandOption('-w')
+            ]
+        );
     }
 
-    static listComponents(project: string, app: string): string {
-        return `odo list --app ${app} --project ${project} -o json`;
+    static listComponents(project: string, app: string): CommandText {
+        return new CommandText('odo list',
+            undefined, [
+                new CommandOption('--app', app),
+                new CommandOption('--project', project),
+                new CommandOption('-o', 'json', false)
+            ]
+        );
     }
 
-    static listRegistries(): string {
-        return 'odo registry list -o json';
+    static listRegistries(): CommandText {
+        return new CommandText('odo registry list -o json');
     }
 
-    static listCatalogComponents(): string {
-        return 'odo catalog list components';
+    static listCatalogComponents(): CommandText {
+        return new CommandText('odo catalog list components');
     }
 
-    static listCatalogComponentsJson(): string {
-        return `${Command.listCatalogComponents()} -o json`;
+    static listCatalogComponentsJson(): CommandText {
+        return new CommandText(`${Command.listCatalogComponents()} -o json`);
     }
 
-    static listCatalogServices(): string {
-        return 'odo catalog list services';
+    static listCatalogServices(): CommandText {
+        return new CommandText('odo catalog list services');
     }
 
-    static listCatalogServicesJson(): string {
-        return `${Command.listCatalogServices()} -o json`;
+    static listCatalogServicesJson(): CommandText {
+        return new CommandText(`${Command.listCatalogServices()} -o json`);
     }
 
-    static listStorageNames(): string {
-        return 'odo storage list -o json';
+    static listStorageNames(): CommandText {
+        return new CommandText('odo storage list -o json');
     }
 
-    static printOcVersion(): string {
-        return 'oc version';
+    static printOcVersion(): CommandText {
+        return new CommandText('oc version');
     }
 
-    static listServiceInstances(project: string, app: string): string {
-        return `odo service list -o json --project ${project} --app ${app}`;
+    static listServiceInstances(project: string, app: string): CommandText {
+        return new CommandText('odo service list',
+            undefined, [
+                new CommandOption('-o', 'json', false),
+                new CommandOption('--project', project),
+                new CommandOption('--app', app)
+            ]
+        );
     }
 
-    static describeApplication(project: string, app: string): string {
-        return `odo app describe ${app} --project ${project}`;
+    static describeApplication(project: string, app: string): CommandText {
+        return new CommandText('odo app describe',
+            app, [
+                new CommandOption('--project', project)
+            ]
+        );
     }
 
-    static deleteApplication(project: string, app: string): string {
-        return `odo app delete ${app} --project ${project} -f`;
+    static deleteApplication(project: string, app: string): CommandText {
+        return new CommandText ('odo app delete',
+            app, [
+                new CommandOption('--project', project),
+                new CommandOption('-f')
+            ]
+        );
     }
 
-    static printOdoVersion(): string {
-        return 'odo version';
+    static printOdoVersion(): CommandText {
+        return new CommandText('odo version');
     }
 
-    static odoLogout(): string {
-        return 'odo logout';
+    static odoLogout(): CommandText {
+        return new CommandText('odo logout');
     }
 
-    static setOpenshiftContext(context: string): string {
-        return `oc config use-context ${context}`;
+    static setOpenshiftContext(context: string): CommandText {
+        return new CommandText('oc config use-context',
+            context
+        );
     }
 
     static odoLoginWithUsernamePassword(
         clusterURL: string,
         username: string,
         passwd: string,
-    ): string {
-        const quote = Platform.OS === 'win32' ? '"' : '\'';
-        return `odo login ${clusterURL} -u ${quote}${username}${quote} -p ${quote}${passwd}${quote} --insecure-skip-tls-verify`;
+    ): CommandText {
+        return new CommandText('odo login',
+            clusterURL, [
+                new CommandOption('-u', username, true, true),
+                new CommandOption('-p', passwd, true, true),
+                new CommandOption('--insecure-skip-tls-verify')
+            ]
+        );
     }
 
-    static odoLoginWithToken(clusterURL: string, ocToken: string): string {
-        return `odo login ${clusterURL} --token=${ocToken} --insecure-skip-tls-verify`;
+    static odoLoginWithToken(clusterURL: string, ocToken: string): CommandText {
+        return new CommandText('odo login',
+            clusterURL, [
+                new CommandOption('--token',ocToken),
+                new CommandOption('--insecure-skip-tls-verify')
+            ]
+        );
     }
 
     @verbose
-    static createStorage(storageName: string, mountPath: string, storageSize: string): string {
-        return `odo storage create ${storageName} --path=${mountPath} --size=${storageSize}`;
+    static createStorage(storageName: string, mountPath: string, storageSize: string): CommandText {
+        return new CommandText('odo storage create',
+            storageName, [
+                new CommandOption('--path', mountPath),
+                new CommandOption('--size', storageSize)
+            ]
+        );
     }
 
-    static deleteStorage(storage: string): string {
-        return `odo storage delete ${storage} -f`;
+    static deleteStorage(storage: string): CommandText {
+        return new CommandText('odo storage delete',
+            storage, [
+                new CommandOption('-f')
+            ]
+        );
     }
 
-    static describeStorage(storage: string): string {
-        return `odo storage describe ${storage}`;
+    static describeStorage(storage: string): CommandText {
+        return new CommandText('odo storage describe', storage);
     }
 
-    static waitForStorageToBeGone(project: string, app: string, storage: string): string {
-        return `oc wait pvc/${storage}-${app}-pvc --for=delete --namespace ${project}`;
+    static waitForStorageToBeGone(project: string, app: string, storage: string): CommandText {
+        return new CommandText('oc wait',
+            `pvc/${storage}-${app}-pvc`, [
+                new CommandOption('--for=delete'),
+                new CommandOption('--namespace', project)
+            ]
+        );
     }
 
-    static undeployComponent(project: string, app: string, component: string): string {
-        return `odo delete ${component} -f --app ${app} --project ${project}`;
+    static undeployComponent(project: string, app: string, component: string): CommandText {
+        return new CommandText('odo delete',
+            component, [
+                new CommandOption('-f'),
+                new CommandOption('--app', app),
+                new CommandOption('--project', project)
+            ]
+        );
     }
 
-    static deleteComponent(project: string, app: string, component: string, s2i = false): string {
-        return `odo delete ${component} -f --app ${app} --project ${project} --all ${s2i? ' --s2i' : ''}`;
+    static deleteComponent(project: string, app: string, component: string, s2i = false): CommandText {
+        const ct = new CommandText('odo delete',
+            component, [
+                new CommandOption('-f'),
+                new CommandOption('--app', app),
+                new CommandOption('--project',project),
+                new CommandOption('--all')
+            ]
+        );
+        if (s2i) {
+            ct.addOption(new CommandOption('--s2i'));
+        }
+        return ct;
     }
 
-    static describeComponentNoContext(project: string, app: string, component: string): string {
-        return `odo describe ${component} --app ${app} --project ${project}`;
+    static describeComponentNoContext(project: string, app: string, component: string): CommandText {
+        return new CommandText('odo describe',
+            component, [
+                new CommandOption('--app', app),
+                new CommandOption('--project', project)
+            ]
+        );
     }
 
-    static describeComponentNoContextJson(project: string, app: string, component: string): string {
-        return `${this.describeComponentNoContext(project, app, component)} -o json`;
+    static describeComponentNoContextJson(project: string, app: string, component: string): CommandText {
+        return this.describeComponentNoContext(project, app, component)
+            .addOption(new CommandOption('-o', 'json'));
     }
 
-    static describeComponent(): string {
-        return 'odo describe';
+    static describeComponent(): CommandText {
+        return new CommandText('odo describe');
     }
 
-    static describeComponentJson(): string {
-        return `${Command.describeComponent()} -o json`;
+    static describeComponentJson(): CommandText {
+        return Command.describeComponent().addOption(new CommandOption('-o', 'json'));
     }
 
-    static describeService(service: string): string {
-        return `odo catalog describe service ${service}`;
+    static describeService(service: string): CommandText {
+        return new CommandText('odo catalog describe service', service);
+
     }
 
-    static describeCatalogComponent(component: string): string {
-        return `odo catalog describe component ${component} -o json`;
+    static describeCatalogComponent(component: string): CommandText {
+        return new CommandText('odo catalog describe component',
+            component, [
+                new CommandOption('-o', 'json')
+            ]
+        );
     }
 
-    static describeUrl(url: string): string {
-        return `odo url describe ${url}`;
+    static describeUrl(url: string): CommandText {
+        return new CommandText('odo url describe', url);
     }
 
-    static showLog(): string {
-        return 'odo log';
+    static showLog(): CommandText {
+        return new CommandText('odo log');
     }
 
-    static showLogAndFollow(): string {
-        return 'odo log -f';
+    static showLogAndFollow(): CommandText {
+        return Command.showLog().addOption(new CommandOption('-f'));
     }
 
-    static listComponentPorts(project: string, app: string, component: string): string {
-        return `oc get service ${component}-${app} --namespace ${project} -o jsonpath="{range .spec.ports[*]}{.port}{','}{end}"`;
+    static listComponentPorts(project: string, app: string, component: string): CommandText {
+        return new CommandText('oc get service',
+            `${component}-${app}`, [
+                new CommandOption('--namespace', project),
+                new CommandOption('-o', 'jsonpath="{range .spec.ports[*]}{.port}{\',\'}{end}"')
+            ]
+        );
     }
 
     static linkComponentTo(
@@ -192,10 +348,16 @@ export class Command {
         component: string,
         componentToLink: string,
         port?: string,
-    ): string {
-        return `odo link ${componentToLink} --project ${project} --app ${app} --component ${component} --wait${
-            port ? ` --port ${port}` : ''
-        }`;
+    ): CommandText {
+        const cTxt = new CommandText('odo link', componentToLink);
+        cTxt.addOption(new CommandOption('--project',project))
+            .addOption(new CommandOption('--app',app))
+            .addOption(new CommandOption('--component', component))
+            .addOption(new CommandOption('--wait'));
+        if (port) {
+            cTxt.addOption(new CommandOption('--port', port));
+        }
+        return cTxt;
     }
 
     static linkServiceTo(
@@ -203,18 +365,33 @@ export class Command {
         app: string,
         component: string,
         serviceToLink: string,
-    ): string {
-        return `odo link ${serviceToLink} --project ${project} --app ${app} --component ${component} --wait --wait-for-target`;
+    ): CommandText {
+        return new CommandText('odo link',
+            serviceToLink, [
+                new CommandOption('--project', project),
+                new CommandOption('--app', app),
+                new CommandOption('--component', component),
+                new CommandOption('--wait'),
+                new CommandOption('--wait-for-target')
+            ]
+        );
     }
 
     @verbose
-    static pushComponent(configOnly = false, debug = false): string {
-        return `odo push${debug ? ' --debug' : ''}${configOnly ? ' --config' : ''}`;
+    static pushComponent(configOnly = false, debug = false): CommandText {
+        const cTxt = new CommandText('odo push');
+        if (debug) {
+            cTxt.addOption(new CommandOption('--debug'));
+        }
+        if (configOnly) {
+            cTxt.addOption(new CommandOption('--config'));
+        }
+        return cTxt;
     }
 
     @verbose
-    static watchComponent(): string {
-        return 'odo watch';
+    static watchComponent(): CommandText {
+        return new CommandText('odo watch');
     }
 
     @verbose
@@ -227,8 +404,21 @@ export class Command {
         folder: string,
         starter: string = undefined,
         useExistingDevfile = false
-    ): string {
-        return `odo create ${type}${version?':':''}${version?version:''} ${name} ${version?'--s2i':''} --context ${folder} --app ${app} --project ${project}${starter ? ` --starter=${starter}` : ''}${useExistingDevfile ? ' --devfile devfile.yaml' : ''}`;
+    ): CommandText {
+        const cTxt = new CommandText('odo create', `${type}${version?':':''}${version?version:''} ${name}`);
+        if (version) {
+            cTxt.addOption(new CommandOption('--s2i'));
+        }
+        cTxt.addOption(new CommandOption('--context', folder))
+            .addOption(new CommandOption('--app', app))
+            .addOption(new CommandOption('--project', project));
+        if (starter) {
+            cTxt.addOption(new CommandOption('--starter', starter, false));
+        }
+        if (useExistingDevfile) {
+            cTxt.addOption(new CommandOption('--devfile', 'devfile.yaml'));
+        }
+        return cTxt;
     }
 
     @verbose
@@ -240,8 +430,15 @@ export class Command {
         name: string,
         git: string,
         ref: string,
-    ): string {
-        return `odo create ${type}${version?':':''}${version?version:''} ${name} ${version?'--s2i':''} --git ${git} --ref ${ref} --app ${app} --project ${project}`;
+    ): CommandText {
+        const cTxt = new CommandText('odo create', `${type}${version?':':''}${version?version:''} ${name}`);
+        if (version) {
+            cTxt.addOption(new CommandOption('--s2i'));
+        }
+        return cTxt.addOption(new CommandOption('--git', git))
+            .addOption(new CommandOption('--ref', ref))
+            .addOption(new CommandOption('--app', app))
+            .addOption(new CommandOption('--project', project));
     }
 
     @verbose
@@ -253,12 +450,20 @@ export class Command {
         name: string,
         binary: string,
         context: string,
-    ): string {
-        return `odo create ${type}:${version} ${name} ${version?'--s2i':''} --binary ${binary} --app ${app} --project ${project} --context ${context}`;
+    ): CommandText {
+        const cTxt = new CommandText('odo create', `${type}:${version} ${name}`);
+        if (version) {
+            cTxt.addOption(new CommandOption('--s2i'));
+        }
+        cTxt.addOption(new CommandOption('--binary', binary))
+            .addOption(new CommandOption('--app', app))
+            .addOption(new CommandOption('--project', project))
+            .addOption(new CommandOption('--context',context));
+        return cTxt;
     }
 
-    static testComponent() {
-        return 'odo test --show-log';
+    static testComponent(): CommandText {
+        return new CommandText('odo test --show-log');
     };
 
     @verbose
@@ -268,37 +473,73 @@ export class Command {
         template: string,
         plan: string,
         name: string,
-    ): string {
-        return `odo service create ${template} --plan ${plan} ${name} --app ${app} --project ${project} -w`;
+    ): CommandText {
+        return new CommandText('odo service create',
+            `${template} ${name}`, [
+                new CommandOption('--plan', plan),
+                new CommandOption('--app', app),
+                new CommandOption('--project', project),
+                new CommandOption('-w')
+            ]
+        );
     }
 
-    static deleteService(project: string, app: string, name: string): string {
-        return `odo service delete ${name} -f --project ${project} --app ${app}`;
+    static deleteService(project: string, app: string, name: string): CommandText {
+        return new CommandText('odo service delete',
+            name, [
+                new CommandOption('-f'),
+                new CommandOption('--project', project),
+                new CommandOption('--app', app)
+            ]
+        );
     }
 
-    static getServiceTemplate(project: string, service: string): string {
-        return `oc get ServiceInstance ${service} --namespace ${project} -o jsonpath="{$.metadata.labels.app\\.kubernetes\\.io/name}"`;
+    static getServiceTemplate(project: string, service: string): CommandText {
+        return new CommandText('oc get ServiceInstance',
+            service, [
+                new CommandOption('--namespace', project),
+                new CommandOption('-o', 'jsonpath="{$.metadata.labels.app\\.kubernetes\\.io/name}"')
+            ]
+        );
     }
 
-    static waitForServiceToBeGone(project: string, service: string): string {
-        return `oc wait ServiceInstance/${service} --for delete --namespace ${project}`;
+    static waitForServiceToBeGone(project: string, service: string): CommandText {
+        return new CommandText('oc wait',
+            `ServiceInstance/${service}`, [
+                new CommandOption('--for', 'delete'),
+                new CommandOption('--namespace', project)
+            ]
+        );
     }
 
     @verbose
-    static createComponentCustomUrl(name: string, port: string, secure = false): string {
-        return `odo url create ${name} --port ${port} ${secure ? '--secure' : ''}`;
+    static createComponentCustomUrl(name: string, port: string, secure = false): CommandText {
+        const cTxt = new CommandText('odo url create',
+            name, [
+                new CommandOption('--port', port)
+            ]
+        );
+        if (secure) {
+            cTxt.addOption(new CommandOption('--secure'));
+        }
+        return cTxt;
     }
 
-    static getComponentUrl(): string {
-        return 'odo url list -o json';
+    static getComponentUrl(): CommandText {
+        return new CommandText('odo url list -o json');
     }
 
-    static deleteComponentUrl(name: string): string {
-        return `odo url delete -f ${name} --now`;
+    static deleteComponentUrl(name: string): CommandText {
+        return new CommandText('odo url delete',
+            name, [
+                new CommandOption('-f'),
+                new CommandOption('--now')
+            ]
+        );
     }
 
-    static getComponentJson(): string {
-        return 'odo describe -o json';
+    static getComponentJson(): CommandText {
+        return new CommandText('odo describe -o json');
     }
 
     static unlinkComponents(
@@ -307,23 +548,36 @@ export class Command {
         comp1: string,
         comp2: string,
         port: string,
-    ): string {
-        return `odo unlink --project ${project} --app ${app} ${comp2} --port ${port} --component ${comp1}`;
+    ): CommandText {
+        return new CommandText('odo unlink',
+            comp2, [
+                new CommandOption('--project', project),
+                new CommandOption('--app', app),
+                new CommandOption('--port', port),
+                new CommandOption('--component', comp1)
+            ]
+        );
     }
 
-    static unlinkService(project: string, app: string, service: string, comp: string): string {
-        return `odo unlink --project ${project} --app ${app} ${service} --component ${comp}`;
+    static unlinkService(project: string, app: string, service: string, comp: string): CommandText {
+        return new CommandText('odo unlink',
+            service, [
+                new CommandOption('--project', project),
+                new CommandOption('--app', app),
+                new CommandOption('--component', comp)
+            ]
+        );
     }
 
-    static getclusterVersion(): string {
-        return 'oc get clusterversion -ojson';
+    static getclusterVersion(): CommandText {
+        return new CommandText('oc get clusterversion -ojson');
     }
 
-    static showServerUrl(): string {
-        return 'oc whoami --show-server';
+    static showServerUrl(): CommandText {
+        return new CommandText('oc whoami --show-server');
     }
 
-    static showConsoleUrl(): string {
-        return 'oc get configmaps console-public -n openshift-config-managed -o json';
+    static showConsoleUrl(): CommandText {
+        return new CommandText('oc get configmaps console-public -n openshift-config-managed -o json');
     }
 }

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { commands, workspace } from 'vscode';
+import { workspace } from 'vscode';
 import { Platform } from '../util/platform';
 
 function verbose(_target: any, key: string, descriptor: any): void {

--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -241,7 +241,11 @@ export class Cluster extends OpenShiftItem {
             await Cluster.save(username, passwd, password, result);
             return await Cluster.loginMessage(clusterURL, result);
         } catch (error) {
-            throw new VsCommandError(`Failed to login to cluster '${clusterURL}' with '${Filters.filterPassword(error.message)}'!`, 'Failed to login to cluster');
+            if (error instanceof VsCommandError) {
+                throw new VsCommandError(`Failed to login to cluster '${clusterURL}' with '${Filters.filterPassword(error.message)}'!`, `Failed to login to cluster. ${error.telemetryMessage}`);
+            } else {
+                throw new VsCommandError(`Failed to login to cluster '${clusterURL}' with '${Filters.filterPassword(error.message)}'!`, 'Failed to login to cluster');
+            }
         }
     }
 

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -12,7 +12,7 @@ import { EventEmitter } from 'events';
 import * as YAML from 'yaml'
 import OpenShiftItem, { clusterRequired, selectTargetApplication, selectTargetComponent } from './openshiftItem';
 import { OpenShiftObject, ContextType, OpenShiftObjectImpl, OpenShiftComponent, OpenShiftApplication } from '../odo';
-import { Command } from '../odo/command';
+import { Command, CommandOption, CommandText } from '../odo/command';
 import { Progress } from '../util/progress';
 import { CliExitData } from '../cli';
 import { Refs, Type } from '../util/refs';
@@ -415,7 +415,7 @@ export class Component extends OpenShiftItem {
         );
     }
 
-    static getPushCmd(): Thenable<{pushCmd: string; contextPath: string; name: string}> {
+    static getPushCmd(): Thenable<{pushCmd: CommandText; contextPath: string; name: string}> {
         return this.extensionContext.globalState.get('PUSH');
     }
 
@@ -479,7 +479,7 @@ export class Component extends OpenShiftItem {
                 commands.executeCommand('openshift.component.watch.showLog', component.contextPath.fsPath);
             }
         } else {
-            const process: ChildProcess = await Component.odo.spawn(Command.watchComponent(), component.contextPath.fsPath);
+            const process: ChildProcess = await Component.odo.spawn(Command.watchComponent().toString(), component.contextPath.fsPath);
             Component.addWatchSession(component, process);
             process.on('exit', () => {
                 Component.removeWatchSession(component);
@@ -495,7 +495,7 @@ export class Component extends OpenShiftItem {
     @vsCommand('openshift.component.watch.showLog')
     @clusterRequired()
     static showWatchSessionLog(context: string): void {
-        LogViewLoader.loadView(`${context} Watch Log`,  () => `odo watch --context ${context}`, Component.odo.getOpenShiftObjectByContext(context), Component.watchSessions.get(context));
+        LogViewLoader.loadView(`${context} Watch Log`,  () => new CommandText('odo watch').addOption(new CommandOption('--context', context)), Component.odo.getOpenShiftObjectByContext(context), Component.watchSessions.get(context));
     }
 
     @vsCommand('openshift.component.openUrl', true)
@@ -975,7 +975,14 @@ export class Component extends OpenShiftItem {
         const appName = component.getParent().getName();
         const compName = component.getName();
         // get pvcs and urls based on label selector
-        const componentResult = await Component.odo.execute(`oc get dc -l app.kubernetes.io/instance=${compName} --namespace ${prjName} -o json`, Platform.getUserHomePath(), false);
+        const componentResult = await Component.odo.execute(
+            new CommandText('oc get dc', undefined, [
+                new CommandOption('-l', `app.kubernetes.io/instance=${compName}`),
+                new CommandOption('--namespace', prjName),
+                new CommandOption('-o', 'json')
+            ]),
+            Platform.getUserHomePath(),
+            false);
         const componentJson = JSON.parse(componentResult.stdout).items[0];
         const componentType = componentJson.metadata.annotations['app.kubernetes.io/component-source-type'];
         if (componentType === SourceType.BINARY) {
@@ -1006,7 +1013,7 @@ export class Component extends OpenShiftItem {
                 //      app.kubernetes.io/url: 'https://github.com/dgolovin/nodejs-ex'
 
                 if (componentType === SourceType.GIT) {
-                    const bcResult = await Component.odo.execute(`oc get bc/${componentJson.metadata.name} --namespace ${prjName} -o json`);
+                    const bcResult = await Component.odo.execute(new CommandText('oc get', `bc/${componentJson.metadata.name}`, [new CommandOption('--namespace', prjName), new CommandOption('-o', 'json', false)]));
                     const bcJson = JSON.parse(bcResult.stdout);
                     const compTypeName = componentJson.metadata.labels['app.kubernetes.io/name'];
                     const compTypeVersion = componentJson.metadata.labels['app.openshift.io/runtime-version'];
@@ -1031,7 +1038,7 @@ export class Component extends OpenShiftItem {
                     for (const storage of storageData) {
                         try {
                             // eslint-disable-next-line no-await-in-loop
-                            const pvcResult = await Component.odo.execute(`oc get pvc/${storage.pvcName} --namespace ${prjName} -o json`, Platform.getUserHomePath(), false);
+                            const pvcResult = await Component.odo.execute(new CommandText('oc get', `pvc/${storage.pvcName}`, [new CommandOption('--namespace', prjName), new CommandOption('-o', 'json')]), Platform.getUserHomePath(), false);
                             const pvcJson = JSON.parse(pvcResult.stdout);
                             const storageName = pvcJson.metadata.labels['app.kubernetes.io/storage-name'];
                             const size = pvcJson.spec.resources.requests.storage;
@@ -1044,7 +1051,7 @@ export class Component extends OpenShiftItem {
                 }
                 // import routes if present
                 try {
-                    const routeResult = await Component.odo.execute(`oc get route -l app.kubernetes.io/instance=${compName},app.kubernetes.io/part-of=${appName} --namespace ${prjName} -o json`, Platform.getUserHomePath(), false);
+                    const routeResult = await Component.odo.execute(new CommandText('oc get route', undefined, [ new CommandOption('-l', `app.kubernetes.io/instance=${compName},app.kubernetes.io/part-of=${appName}`), new CommandOption('--namespace', prjName), new CommandOption('-o', 'json')]), Platform.getUserHomePath(), false);
                     const routeJson = JSON.parse(routeResult.stdout);
                     const routeData: Partial<{name: string; port: string}>[] = routeJson.items.map((element: any) => ({name: element.metadata.labels['odo.openshift.io/url-name'], port: element.spec.port.targetPort}));
                     // eslint-disable-next-line no-restricted-syntax

--- a/src/openshift/project.ts
+++ b/src/openshift/project.ts
@@ -8,6 +8,7 @@ import OpenShiftItem, { clusterRequired } from './openshiftItem';
 import { OpenShiftObject, OpenShiftProject, getInstance as getOdoInstance } from '../odo';
 import { Progress } from '../util/progress';
 import { vsCommand, VsCommandError } from '../vscommand';
+import { CommandText } from '../odo/command';
 
 export class Project extends OpenShiftItem {
 
@@ -30,7 +31,7 @@ export class Project extends OpenShiftItem {
             await commands.executeCommand('openshift.project.create');
         } else {
             const project = selectedItem as OpenShiftObject;
-            await Project.odo.execute(`odo project set ${project.getName()}`);
+            await Project.odo.execute(new CommandText('odo project set', project.getName()));
             Project.explorer.refresh();
             message = `Project '${project.getName()}' set as active.`;
         }
@@ -64,7 +65,7 @@ export class Project extends OpenShiftItem {
                             if (p.length>0) {
                                 // this changes kubeconfig and that triggers full tree refresh
                                 // there is no need to call explorer.refresh() manully
-                                await Project.odo.execute(`odo project set ${p[0].getName()}`);
+                                await Project.odo.execute(new CommandText('odo project set', p[0].getName()));
                             }
                         })
                         .then(() => `Project '${project.getName()}' successfully deleted`)

--- a/src/vscommand.ts
+++ b/src/vscommand.ts
@@ -51,7 +51,7 @@ export async function registerCommands(...modules: string[]): Promise<Disposable
                 displayResult(result);
             } catch (err) {
                 if (err.stack) {
-                    const stack = stackTraceParser.parse(err.stack);
+                    const stack = stackTraceParser.parse(err.stack); // TODO: add recursive stacktrace parsing for parent errors
                     if (stack.length > 0) {
                         const files = stack.map((value) => `${value.file.substring(value.file.lastIndexOf(ExtenisonID)-1)}:${value.lineNumber}:${value.column}`);
                         stackTrace = {

--- a/src/webview/describe/describeViewLoader.ts
+++ b/src/webview/describe/describeViewLoader.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import { ExtenisonID } from '../../util/constants';
 import { OpenShiftObject } from '../../odo';
 import * as odo from '../../odo';
+import { CommandText } from '../../odo/command';
 
 export default class DescribeViewLoader {
 
@@ -15,7 +16,7 @@ export default class DescribeViewLoader {
         return extensions.getExtension(ExtenisonID).extensionPath
     }
 
-    static async loadView(title: string, cmdFunction: (prj, app, comp) => string, target: OpenShiftObject): Promise<WebviewPanel> {
+    static async loadView(title: string, cmdFunction: (prj, app, comp) => CommandText, target: OpenShiftObject): Promise<WebviewPanel> {
         const localResourceRoot = Uri.file(path.join(DescribeViewLoader.extensionPath, 'out', 'describeViewer'));
 
         const panel = window.createWebviewPanel('describeView', title, ViewColumn.One, {
@@ -28,9 +29,9 @@ export default class DescribeViewLoader {
         const cmd = cmdFunction(target.getParent().getParent().getName(), target.getParent().getName(), target.getName());
 
         // TODO: When webview is going to be ready?
-        panel.webview.html = DescribeViewLoader.getWebviewContent(DescribeViewLoader.extensionPath, cmd);
+        panel.webview.html = DescribeViewLoader.getWebviewContent(DescribeViewLoader.extensionPath, `${cmd}`);
 
-        const process = await odo.getInstance().spawn(cmd, target.contextPath.fsPath);
+        const process = await odo.getInstance().spawn(`${cmd}`, target.contextPath.fsPath);
         process.stdout.on('data', (data) => {
             panel.webview.postMessage({action: 'describe', data: `${data}`.trim().split('\n')});
         });

--- a/src/webview/log/LogViewLoader.ts
+++ b/src/webview/log/LogViewLoader.ts
@@ -10,6 +10,7 @@ import { OpenShiftObject } from '../../odo';
 import * as odo from '../../odo';
 import treeKill = require('tree-kill');
 import { ChildProcess } from 'child_process';
+import { CommandText } from '../../odo/command';
 
 export default class LogViewLoader {
 
@@ -17,7 +18,7 @@ export default class LogViewLoader {
         return extensions.getExtension(ExtenisonID).extensionPath
     }
 
-    static async loadView(title: string, cmdFunction: (prj, app, comp) => string, target: OpenShiftObject, existingProcess?: ChildProcess): Promise<WebviewPanel> {
+    static async loadView(title: string, cmdFunction: (prj, app, comp) => CommandText, target: OpenShiftObject, existingProcess?: ChildProcess): Promise<WebviewPanel> {
         const localResourceRoot = Uri.file(path.join(LogViewLoader.extensionPath, 'out', 'logViewer'));
 
         const panel = window.createWebviewPanel('logView', title, ViewColumn.One, {
@@ -30,9 +31,9 @@ export default class LogViewLoader {
         const cmd = cmdFunction(target.getParent().getParent().getName(), target.getParent().getName(), target.getName());
 
         // TODO: When webview is going to be ready?
-        panel.webview.html = LogViewLoader.getWebviewContent(LogViewLoader.extensionPath, cmd.replace(/\\/g, '\\\\'));
+        panel.webview.html = LogViewLoader.getWebviewContent(LogViewLoader.extensionPath, `${cmd}`.replace(/\\/g, '\\\\'));
 
-        const process = existingProcess? existingProcess : await odo.getInstance().spawn(cmd, target.contextPath.fsPath);
+        const process = existingProcess? existingProcess : await odo.getInstance().spawn(`${cmd}`, target.contextPath.fsPath);
         process.stdout.on('data', (data) => {
             panel.webview.postMessage({action: 'add', data: `${data}`.trim().split('\n')});
         }).on('close', ()=>{

--- a/test/integration/odo.test.ts
+++ b/test/integration/odo.test.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import { Uri, window, commands, extensions } from 'vscode';
 import * as odo from '../../src/odo';
 import { Cluster } from '../../src/openshift/cluster';
-import { Command } from '../../src/odo/command';
+import { Command, CommandText } from '../../src/odo/command';
 import { Component } from '../../src/openshift/component';
 import { AddWorkspaceFolder } from '../../src/util/workspace';
 import { ComponentKind, ComponentTypeAdapter } from '../../src/odo/componentType';
@@ -183,7 +183,7 @@ suite('odo integration', () => {
             await oi.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
         }
         if (!openshiftVersion) {
-            const version = await oi.execute('oc version');
+            const version = await oi.execute(new CommandText('oc version'));
             const match = version.stdout.match(/Server Version:\s*(\d+\.\d+\.\d+).*/);
             if (match && match.length > 1) {
                 openshiftVersion = match[1];

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -18,6 +18,7 @@ import { Progress } from '../../src/util/progress';
 import path = require('path');
 
 import packagejson = require('../../package.json');
+import { CommandText } from '../../src/odo/command';
 
 const {expect} = chai;
 chai.use(sinonChai);
@@ -64,18 +65,18 @@ suite('openshift connector Extension', () => {
             uri: comp2Uri, index: 1, name: 'comp2'
         }]);
         // eslint-disable-next-line @typescript-eslint/require-await
-        sandbox.stub(OdoImpl.prototype, 'execute').callsFake(async (cmd: string, cwd: string)=> {
-            if (cmd.includes('version')) {
+        sandbox.stub(OdoImpl.prototype, 'execute').callsFake(async (cmd: CommandText, cwd: string)=> {
+            if (`${cmd}`.includes('version')) {
                 return { error: undefined, stdout: 'Server: https://api.crc.testing:6443', stderr: '' };
             }
 
-            if(cmd.includes('describe')) {
-                const args = cmd.split(' ');
+            if(`${cmd}`.includes('describe')) {
+                const args = `${cmd}`.split(' ');
                 const name = args[3].substr(args[3].lastIndexOf(path.sep)+1);
                 return { error: undefined, stdout: genComponentJson('myproject', 'app1', name, args[3]), stderr: '', cwd  };
             }
 
-            if (cmd.includes('list --app')) {
+            if (`${cmd}`.includes('list --app')) {
                 return { error: undefined, stdout: `
                 {
                     "kind": "List",

--- a/test/unit/openshift/cluster.test.ts
+++ b/test/unit/openshift/cluster.test.ts
@@ -302,7 +302,7 @@ suite('Openshift/Cluster', () => {
             const status = await Cluster.logout();
 
             expect(status).null;
-            expect(execStub).calledOnceWith('odo logout');
+            expect(execStub).calledOnceWith(Command.odoLogout());
             expect(commandStub).calledWith('setContext', 'isLoggedIn', false);
         });
 

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -1168,14 +1168,14 @@ suite('OpenShift/Component', () => {
             const cpStub = {on: sinon.stub()} as any as ChildProcess;
             spawnStub.resolves(cpStub);
             await Component.watch(componentItem);
-            expect(spawnStub).calledOnceWith(Command.watchComponent());
+            expect(spawnStub).calledOnceWith(`${Command.watchComponent()}`);
         });
 
         test('calls the correct odo command w/o context', async () => {
             const cpStub = {on: sinon.stub()} as any as ChildProcess;
             spawnStub.resolves(cpStub);
             await Component.watch(null);
-            expect(spawnStub).calledOnceWith(Command.watchComponent());
+            expect(spawnStub).calledOnceWith(`${Command.watchComponent()}`);
         });
 
         test('adds process to Watch Sessions view and removes it when process exits', async () => {

--- a/test/unit/openshift/project.test.ts
+++ b/test/unit/openshift/project.test.ts
@@ -8,7 +8,7 @@ import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
 import { OdoImpl, ContextType } from '../../../src/odo';
-import { Command } from '../../../src/odo/command';
+import { Command, CommandText } from '../../../src/odo/command';
 import { TestItem } from './testOSItem';
 import { Project } from '../../../src/openshift/project';
 import OpenShiftItem from '../../../src/openshift/openshiftItem';
@@ -148,14 +148,14 @@ suite('OpenShift/Project', () => {
             const result = await Project.del(projectItem);
 
             expect(result).equals(`Project '${projectItem.getName()}' successfully deleted`);
-            expect(execStub.getCall(0).args[0]).equals(Command.deleteProject(projectItem.getName()));
+            expect(`${execStub.getCall(0).args[0]}`).equals(`${Command.deleteProject(projectItem.getName())}`);
         });
 
         test('works without context', async () => {
             const result = await Project.del(null);
 
             expect(result).equals(`Project '${projectItem.getName()}' successfully deleted`);
-            expect(execStub.getCall(0).args[0]).equals(Command.deleteProject(projectItem.getName()));
+            expect(`${execStub.getCall(0).args[0]}`).equals(`${Command.deleteProject(projectItem.getName())}`);
         });
 
         test('returns null when cancelled', async () => {
@@ -181,8 +181,8 @@ suite('OpenShift/Project', () => {
         test('makes selected project active', async () => {
             sandbox.stub(vscode.window, 'showQuickPick').resolves(projectItem);
             const result = await Project.set();
-            expect(execStub).calledWith(`odo project set ${projectItem.getName()}`)
-            expect(result).equals(`Project '${projectItem.getName()}' set as active.`)
+            expect(execStub).calledWith(new CommandText('odo project set', projectItem.getName()));
+            expect(result).equals(`Project '${projectItem.getName()}' set as active.`);
         });
 
         test('exits without action if project selection was canceled', async () => {

--- a/test/unit/openshift/service.test.ts
+++ b/test/unit/openshift/service.test.ts
@@ -290,16 +290,16 @@ suite('OpenShift/Service', () => {
             const result = await Service.del(serviceItem);
 
             expect(result).equals(`Service '${serviceItem.getName()}' successfully deleted`);
-            expect(execStub.getCall(0).args[0]).equals(Command.deleteService(projectItem.getName(), appItem.getName(), serviceItem.getName()));
-            expect(execStub.getCall(1).args[0]).equals(Command.waitForServiceToBeGone(projectItem.getName(), serviceItem.getName()));
+            expect(`${execStub.getCall(0).args[0]}`).equals(`${Command.deleteService(projectItem.getName(), appItem.getName(), serviceItem.getName())}`);
+            expect(`${execStub.getCall(1).args[0]}`).equals(`${Command.waitForServiceToBeGone(projectItem.getName(), serviceItem.getName())}`);
         });
 
         test('works without context item', async () => {
             const result = await Service.del(null);
 
             expect(result).equals(`Service '${serviceItem.getName()}' successfully deleted`);
-            expect(execStub.getCall(0).args[0]).equals(Command.deleteService(projectItem.getName(), appItem.getName(), serviceItem.getName()));
-            expect(execStub.getCall(1).args[0]).equals(Command.waitForServiceToBeGone(projectItem.getName(), serviceItem.getName()));
+            expect(`${execStub.getCall(0).args[0]}`).equals(`${Command.deleteService(projectItem.getName(), appItem.getName(), serviceItem.getName())}`);
+            expect(`${execStub.getCall(1).args[0]}`).equals(`${Command.waitForServiceToBeGone(projectItem.getName(), serviceItem.getName())}`);
         });
 
         test('returns null with no application selected', async () => {

--- a/test/unit/openshift/storage.test.ts
+++ b/test/unit/openshift/storage.test.ts
@@ -301,18 +301,18 @@ suite('OpenShift/Storage', () => {
             const result = await Storage.del(storageItem);
 
             expect(result).equals(`Storage '${storageItem.getName()}' from Component '${componentItem.getName()}' successfully deleted`);
-            expect(execStub.getCall(0).args[0]).equals(Command.deleteStorage(storageItem.getName()));
-            expect(execStub.getCall(1).args[0]).equals(Command.pushComponent(true));
-            expect(execStub.getCall(2).args[0]).equals(Command.waitForStorageToBeGone(projectItem.getName(), appItem.getName(), storageItem.getName()));
+            expect(`${execStub.getCall(0).args[0]}`).equals(`${Command.deleteStorage(storageItem.getName())}`);
+            expect(`${execStub.getCall(1).args[0]}`).equals(`${Command.pushComponent(true)}`);
+            expect(`${execStub.getCall(2).args[0]}`).equals(`${Command.waitForStorageToBeGone(projectItem.getName(), appItem.getName(), storageItem.getName())}`);
         });
 
         test('works without set tree item', async () => {
             const result = await Storage.del(null);
 
             expect(result).equals(`Storage '${storageItem.getName()}' from Component '${componentItem.getName()}' successfully deleted`);
-            expect(execStub.getCall(0).args[0]).equals(Command.deleteStorage(storageItem.getName()));
-            expect(execStub.getCall(1).args[0]).equals(Command.pushComponent(true));
-            expect(execStub.getCall(2).args[0]).equals(Command.waitForStorageToBeGone(projectItem.getName(), appItem.getName(), storageItem.getName()));
+            expect(`${execStub.getCall(0).args[0]}`).equals(`${Command.deleteStorage(storageItem.getName())}`);
+            expect(`${execStub.getCall(1).args[0]}`).equals(`${Command.pushComponent(true)}`);
+            expect(`${execStub.getCall(2).args[0]}`).equals(`${Command.waitForStorageToBeGone(projectItem.getName(), appItem.getName(), storageItem.getName())}`);
         });
 
         test('returns null with no storage selected', async () => {

--- a/test/unit/openshift/url.test.ts
+++ b/test/unit/openshift/url.test.ts
@@ -345,14 +345,14 @@ suite('OpenShift/URL', () => {
             const result = await Url.del(routeItem);
 
             expect(result).equals(`URL '${routeItem.getName()}' from Component '${componentItem.getName()}' successfully deleted`);
-            expect(execStub.getCall(0).args[0]).equals(Command.deleteComponentUrl(routeItem.getName()));
+            expect(`${execStub.getCall(0).args[0]}`).equals(`${Command.deleteComponentUrl(routeItem.getName())}`);
         });
 
         test('works without set tree item', async () => {
             const result = await Url.del(null);
 
             expect(result).equals(`URL '${routeItem.getName()}' from Component '${componentItem.getName()}' successfully deleted`);
-            expect(execStub.getCall(0).args[0]).equals(Command.deleteComponentUrl(routeItem.getName()));
+            expect(`${execStub.getCall(0).args[0]}`).equals(`${Command.deleteComponentUrl(routeItem.getName())}`);
         });
 
         test('returns null with no URL selected', async () => {


### PR DESCRIPTION
This PR is related to #2078.
- Remove processing for commands with '&&' when running in terminal
- Represent commands as objects
