### PR TITLE
Fix TextCommand.toString() method for no options use case

### DIFF
--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -57,7 +57,7 @@ export class CommandText {
     }
 
     toString(): string {
-        return `${this.command}${this.parameter? ` ${this.privacy? 'REDACTED' : this.parameter}`: ''}${this.options? ` ${this.options.join(' ')}`: ''}`;
+        return `${this.command}${this.parameter? ` ${this.privacy? 'REDACTED' : this.parameter}`: ''}${this.options && this.options.length > 0? ` ${this.options.join(' ')}`: ''}`;
     }
 
     privacyMode(set: boolean): CommandText {


### PR DESCRIPTION
This PR fixes #2137.

Signed-off-by: Denis Golovin dgolovin@redhat.com
