### PR TITLE
Don't exit creating component workflow when not using starter project

### DIFF
--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -703,8 +703,6 @@ export class Component extends OpenShiftItem {
                                     if (!selectedStarter) return null;
                                     createStarter = selectedStarter.label;
                                 }
-                            } else if (!create) {
-                                return null;
                             }
                         }
                     }


### PR DESCRIPTION
This PR fixes #2150.

Signed-off-by: Denis Golovin dgolovin@redhat.com
