### PR TITLE
Do not use app and project name for components without context

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -949,6 +949,7 @@ export class OdoImpl implements Odo {
             Command.deleteComponent(
                 app.getParent().getName(),
                 app.getName(), component.getName(),
+                !!component.contextPath,
                 component.kind === ComponentKind.S2I
             ),
             component.contextPath ? component.contextPath.fsPath : Platform.getUserHomePath()

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -270,15 +270,18 @@ export class Command {
         );
     }
 
-    static deleteComponent(project: string, app: string, component: string, s2i = false): CommandText {
+    static deleteComponent(project: string, app: string, component: string, context: boolean, s2i = false): CommandText {
         const ct = new CommandText('odo delete',
-            component, [
+            context ? undefined : component, [ // if there is not context name is required
                 new CommandOption('-f'),
-                new CommandOption('--app', app),
-                new CommandOption('--project',project),
-                new CommandOption('--all')
             ]
         );
+        if (!context) { // if there is no context state app and project name
+            ct.addOption(new CommandOption('--app', app))
+                .addOption(new CommandOption('--project',project))
+        } else {
+            ct.addOption(new CommandOption('--all'));
+        }
         if (s2i) {
             ct.addOption(new CommandOption('--s2i'));
         }

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -824,7 +824,7 @@ suite('OpenShift/Component', () => {
 
         test('works with no context', async () => {
             sandbox.stub(vscode.workspace, 'onDidChangeWorkspaceFolders').callsFake(onDidFake);
-            const componentItemNoContext = new TestItem(appItem, 'comp1', ContextType.COMPONENT_PUSHED, [], undefined, 'https://host/proj/app/comp1');
+            const componentItemNoContext = new TestItem(appItem, 'comp1', ContextType.COMPONENT_PUSHED, [], null, 'https://host/proj/app/comp1');
             quickPickStub.onSecondCall().resolves(componentItemNoContext);
             const result = await Component.del(null);
 

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -819,7 +819,7 @@ suite('OpenShift/Component', () => {
             const result = await Component.del(componentItem);
 
             expect(result).equals(`Component '${componentItem.getName()}' successfully deleted`);
-            expect(execStub).calledWith(Command.deleteComponent(projectItem.getName(), appItem.getName(), componentItem.getName(), true));
+            expect(execStub).calledWith(Command.deleteComponent(projectItem.getName(), appItem.getName(), componentItem.getName(), true, true));
         });
 
         test('works with no context', async () => {
@@ -827,7 +827,7 @@ suite('OpenShift/Component', () => {
             const result = await Component.del(null);
 
             expect(result).equals(`Component '${componentItem.getName()}' successfully deleted`);
-            expect(execStub).calledWith(Command.deleteComponent(projectItem.getName(), appItem.getName(), componentItem.getName(), true));
+            expect(execStub).calledWith(Command.deleteComponent(projectItem.getName(), appItem.getName(), componentItem.getName(), false, true));
         });
 
         test('wraps errors in additional info', async () => {

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -824,6 +824,8 @@ suite('OpenShift/Component', () => {
 
         test('works with no context', async () => {
             sandbox.stub(vscode.workspace, 'onDidChangeWorkspaceFolders').callsFake(onDidFake);
+            const componentItemNoContext = new TestItem(appItem, 'comp1', ContextType.COMPONENT_PUSHED, [], undefined, 'https://host/proj/app/comp1');
+            quickPickStub.onSecondCall().resolves(componentItemNoContext);
             const result = await Component.del(null);
 
             expect(result).equals(`Component '${componentItem.getName()}' successfully deleted`);


### PR DESCRIPTION
This PR fixes #2191.

Signed-off-by: Denis Golovin dgolovin@redhat.com
