### PR TITLE
Do not remove wsfolders when deleting app

### DIFF
--- a/src/openshift/application.ts
+++ b/src/openshift/application.ts
@@ -42,9 +42,9 @@ export class Application extends OpenShiftItem {
                     await Progress.execFunctionWithProgress(`Deleting the Application '${appName}'`, () => Application.odo.deleteApplication(application));
                     return `Application '${appName}' successfully deleted`
                 } catch (err) {
-                    const telemetryMessage = err instanceof VsCommandError ? err.telemetryMessage : err.message;
+                    const telemetryMessage = err instanceof VsCommandError ? ` ${err.telemetryMessage}` : '';
                     throw new VsCommandError(`Failed to delete Application with error '${err.message}'`,
-                            `Failed to delete Application with error ${telemetryMessage}`, err);
+                            `Failed to delete Application with error${telemetryMessage}`, err);
                 }
             }
         }

--- a/test/unit/openshift/application.test.ts
+++ b/test/unit/openshift/application.test.ts
@@ -21,10 +21,11 @@ suite('OpenShift/Application', () => {
     let quickPickStub: sinon.SinonStub;
     let sandbox: sinon.SinonSandbox;
     let execStub: sinon.SinonStub;
+    let getProjectsStub: sinon.SinonStub;
     const clusterItem = new TestItem(null, 'cluster', ContextType.CLUSTER);
     const projectItem = new TestItem(clusterItem, 'project', ContextType.PROJECT);
     const appItem = new TestItem(projectItem, 'app', ContextType.APPLICATION);
-    const compItem = new TestItem(appItem, 'app', ContextType.COMPONENT_NO_CONTEXT, [], null);
+    const compItem = new TestItem(appItem, 'component', ContextType.COMPONENT_NO_CONTEXT, [], null);
     compItem.path = 'path/to/component';
     appItem.getChildren().push(compItem);
 
@@ -32,6 +33,7 @@ suite('OpenShift/Application', () => {
         sandbox = sinon.createSandbox();
         execStub = sandbox.stub(OdoImpl.prototype, 'execute').resolves({error: null, stdout: '', stderr: ''});
         sandbox.stub(OdoImpl.prototype, 'getClusters').resolves([clusterItem]);
+        getProjectsStub = sandbox.stub(OdoImpl.prototype, 'getProjects').resolves([projectItem]);
         sandbox.stub(OdoImpl.prototype, 'getApplications').resolves([appItem]);
         sandbox.stub(OpenShiftItem, 'getApplicationNames').resolves([appItem]);
         sandbox.stub(vscode.window, 'showInputBox');
@@ -60,7 +62,7 @@ suite('OpenShift/Application', () => {
         suite('called from command palette', () => {
 
             test('calls the appropriate error message when no project found', async () => {
-                sandbox.stub(OdoImpl.prototype, 'getProjects').resolves([]);
+                getProjectsStub.onFirstCall().resolves([]);
                 try {
                     await Application.describe(null);
                 } catch (err) {
@@ -72,7 +74,6 @@ suite('OpenShift/Application', () => {
             });
 
             test('asks to select a project and an application', async () => {
-                sandbox.stub(OdoImpl.prototype, 'getProjects').resolves([projectItem]);
                 const apps = [appItem];
                 quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
                 quickPickStub.onFirstCall().resolves(appItem);
@@ -83,7 +84,6 @@ suite('OpenShift/Application', () => {
             });
 
             test('skips odo command execution if canceled by user', async () => {
-                sandbox.stub(OdoImpl.prototype, 'getProjects').resolves([projectItem]);
                 quickPickStub = sandbox.stub(vscode.window, 'showQuickPick').resolves(null);
                 await Application.describe(null);
                 expect(termStub).not.called;
@@ -96,8 +96,9 @@ suite('OpenShift/Application', () => {
 
         setup(() => {
             warnStub = sandbox.stub(vscode.window, 'showWarningMessage');
-            sandbox.stub(OdoImpl.prototype, 'getProjects').resolves([projectItem]);
-            sandbox.stub(OdoImpl.prototype, 'getComponents').resolves([compItem]);
+            getProjectsStub.onFirstCall().resolves([projectItem]);
+            const pushedCompItem = new TestItem(appItem, 'app', ContextType.COMPONENT_PUSHED, []);
+            sandbox.stub(OdoImpl.prototype, 'getApplicationChildren').resolves([pushedCompItem]);
         });
 
         test('calls the appropriate odo command if confirmed', async () => {
@@ -105,7 +106,7 @@ suite('OpenShift/Application', () => {
 
             await Application.del(appItem);
 
-            expect(execStub).calledOnceWith(Command.deleteApplication(projectItem.getName(), appItem.getName()));
+            expect(execStub).calledWith(Command.deleteApplication(projectItem.getName(), appItem.getName()));
         });
 
         test('returns a confirmation message text when successful', async () => {


### PR DESCRIPTION
- File structure for Create Service View
- Do not remove context folders from workspace when deleting app
- Delete Application command update
- Remove create-service branch changes
- Update application deletion logic
- Fix application deletion to avoid removing folders from workspace
