### PR TITLE
Fix buttons to open external links in addCluster editor

### DIFF
--- a/src/webview/cluster/app/cluster.tsx
+++ b/src/webview/cluster/app/cluster.tsx
@@ -111,7 +111,7 @@ export default function Header() {
           <CardActions className={classes.cardButton}>
             <Tooltip title={list.tooltip} placement="top">
               <div>
-                <a onClick={() => handleView(index)} style={{ textDecoration: 'none'}}>
+                <a onClick={() => handleView(index)} style={{ textDecoration: 'none'}} href={clusterTypes[index].redirectLink}>
                   <Button
                     variant="contained"
                     color="default"

--- a/src/webview/cluster/clusterViewLoader.ts
+++ b/src/webview/cluster/clusterViewLoader.ts
@@ -83,12 +83,12 @@ export default class ClusterViewLoader {
 
     @vsCommand('openshift.explorer.addCluster.openLaunchSandboxPage')
     static async openLaunchSandboxPage(url: string) {
-        await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+        // fake command to report crc selection through telemetry
     }
 
     @vsCommand('openshift.explorer.addCluster.openCreateClusterPage')
     static async openCreateClusterPage(url: string) {
-        await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+        // fake command to report crc selection through telemetry
     }
 
     @vsCommand('openshift.explorer.addCluster.openCrcAddClusterPage')


### PR DESCRIPTION
Fix to repace 'vscode.open' to actual links in webview based editor.

This PR fixes #2213.

Signed-off-by: Denis Golovin dgolovin@redhat.com
