### PR TITLE
Update to nodejs 15 for build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node('rhel8'){
   }
 
   stage('Install requirements') {
-    def nodeHome = tool 'nodejs-lts'
+    def nodeHome = tool 'nodejs-15.14.0'
     env.PATH="${env.PATH}:${nodeHome}/bin"
     sh "npm install"
     sh "npm install -g vsce"


### PR DESCRIPTION
Builds are red with the following error:
```
Module not found: Error: Can't resolve '@rjsf/core'
```
Looks like just running `npm i && npm run build` is now only possible on nodejs 15+. Since lts is currently still in the 14 stream, updating the build tool to 15.