### PR TITLE
Fix Component Debug command

### DIFF
--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -34,7 +34,7 @@ import treeKill = require('tree-kill');
 import fs = require('fs-extra');
 import { NewComponentCommandProps } from '../telemetry';
 
-const waitPort = require('wait-port');
+import waitPort = require('wait-port');
 
 export class SourceTypeChoice {
     public static readonly GIT: QuickPickItem = {
@@ -972,18 +972,30 @@ export class Component extends OpenShiftItem {
 
     static async startOdoAndConnectDebugger(toolLocation: string, component: OpenShiftObject, config: DebugConfiguration): Promise<string> {
         await Component.odo.execute(Command.pushComponent(true, true), component.contextPath.fsPath);
-        const debugCmd = `'${toolLocation}' debug port-forward`;
+        const debugCmd = `${toolLocation}' debug port-forward`;
         const cp = exec(debugCmd, {cwd: component.contextPath.fsPath});
-        return new Promise<string>((resolve) => {
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            cp.stdout.on('data', async (data: string) => {
+        return new Promise<string>((resolve,reject) => {
+            cp.stdout.on('data', (data: string) => {
                 const parsedPort = data.trim().match(/- (?<localPort>\d+):\d+$/);
                 if (parsedPort?.groups?.localPort) {
-                    await waitPort({
+                    void waitPort({
                          host: 'localhost',
                          port: parseInt(parsedPort.groups.localPort, 10)
-                    });
-                    resolve(parsedPort.groups.localPort);
+                    })
+                    .then((success) => {
+                        success ? resolve(parsedPort.groups.localPort) : reject(new VsCommandError('Connection attempt timed out.'));
+                    })
+                    .catch(reject);
+                }
+            });
+            let stderrText = '';
+            cp.stderr.on('data', (data: string) => {
+                stderrText = stderrText.concat(data);
+            });
+            cp.on('error', reject);
+            cp.on('exit', (code) => {
+                if (code > 0) {
+                    reject(new VsCommandError(`Port forwarding request failed. CODE: ${code}', STDERR: ${stderrText}.`));
                 }
             });
         }).then((result) => {
@@ -995,9 +1007,12 @@ export class Component extends OpenShiftItem {
             }
             config.odoPid = cp.pid;
             return debug.startDebugging(workspace.getWorkspaceFolder(component.contextPath), config);
-        }).then((result: boolean) =>
-            result ? 'Debugger session has successfully started.' : Promise.reject(new VsCommandError('Debugger session failed to start.'))
-        );
+        }).then((result: boolean) => {
+            if (!result) {
+                return Promise.reject(new VsCommandError('Debugger session failed to start.'));
+            }
+            return 'Debugger session has successfully started.';
+        });
     }
 
     @vsCommand('openshift.component.test', true)

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -1530,7 +1530,7 @@ suite('OpenShift/Component', () => {
 
         test('starts java debugger for devfile component with java in builder image', async () => {
             const startDebugging = sandbox.stub().resolves(true);
-            const waitPort = sandbox.stub().resolves()
+            const waitPort = sandbox.stub().resolves(true);
             Component = pq('../../../src/openshift/component', {
                 vscode: {
                     debug: {
@@ -1543,6 +1543,14 @@ suite('OpenShift/Component', () => {
                             on: async (event: string, cb: (data: string) => Promise<void>) => {
                                 await cb('- 8888:7777');
                             }
+                        },
+                        stderr: {
+                            on: async (event: string, cb: (data: string) => Promise<void>) => {
+                                await cb('Error stream output');
+                            }
+                        },
+                        on: (event: string, cb: () => Promise<void>) => {
+                            if (event !== 'error') cb();
                         },
                     }),
                 },
@@ -1564,7 +1572,7 @@ suite('OpenShift/Component', () => {
 
         test('starts python debugger for devfile component with python in builder image', async () => {
             const startDebugging = sandbox.stub().resolves(true);
-            const waitPort = sandbox.stub().resolves()
+            const waitPort = sandbox.stub().resolves(true)
             Component = pq('../../../src/openshift/component', {
                 vscode: {
                     debug: {
@@ -1577,6 +1585,14 @@ suite('OpenShift/Component', () => {
                             on: async (event: string, cb: (data: string) => Promise<void>) => {
                                 await cb('- 8888:7777');
                             }
+                        },
+                        stderr: {
+                            on: async (event: string, cb: (data: string) => Promise<void>) => {
+                                await cb('Error stream output');
+                            }
+                        },
+                        on: (event: string, cb: () => Promise<void>) => {
+                            if (event !== 'error') cb();
                         },
                     }),
                 },


### PR DESCRIPTION
- Suppress opening new window for Add/Refresh cluster button
- Add out folder to .eslintignore
- Add Operators/ClusterServiceVersion/ownedCRDs to k8s clusters view (#2223)
- Update odo to v2.3.0
- Remove 'Import' command for components without context
- Fix unit tests errors
- Get current component based on window's active editor
- Show name/version for CRD when displayName is missing
- Change debugger type from node2 to pwa-node
- Update odo to v2.3.1
- Enable App Explorer welcome screen buttons after content is loaded
- Disable Components View welcome button until extension is activated
- Fix eslint errors
- Fix unit test errors
- Update extension version to 0.2.10
- Make the vsix buildable again
- Update telemetry to v0.4.2
- Update to nodejs 15 for build
- Publishing platform specific packages
- Use different engines.vscode version for tests
- Fix Jenkins file errror
- Fix platform names
- Remove smoke test from Jenkinsfile
- Fix bundle-tools.js script to include correct binaries for platform
- Publish platform specific vsix files
- Update oc to v4.8.15
- Update changelog.MD for v0.2.10
- Enable publishing for platform specific packages
- Remove not needed files from .vsix archive
- Remove npm from dependencies list
- Fix Welcome view button activation
- Fix stuck Component Debug command
