### PR TITLE
Remove s2i components from Component Types View

### DIFF
--- a/src/componentTypesView.ts
+++ b/src/componentTypesView.ts
@@ -26,41 +26,24 @@ import {
     ComponentTypeDescription,
     ComponentTypesJson,
     DevfileComponentType,
-    ImageStreamTag,
-    isCluster,
     isDevfileComponent,
-    isImageStreamTag,
     isRegistry,
-    isS2iComponent,
-    isSampleProject,
     Registry,
-    S2iComponentType,
-    SampleProject
 } from './odo/componentType';
 import {
     isStarterProject,
     StarterProject
 } from './odo/componentTypeDescription';
 import { vsCommand, VsCommandError } from './vscommand';
-import { Cluster } from '@kubernetes/client-node/dist/config_types';
-import { KubeConfig } from '@kubernetes/client-node';
 import { Platform } from './util/platform';
 import * as validator from 'validator';
 
-type ExampleProject = SampleProject | StarterProject;
-type ComponentType = DevfileComponentType | ImageStreamTag | ExampleProject | Cluster | Registry;
+type ComponentType = DevfileComponentType | StarterProject | Registry;
 
 export enum ContextType {
-    S2I_COMPONENT_TYPE = 's2iComponentType',
     DEVFILE_COMPONENT_TYPE = 'devfileComponentType',
-    S2I_IMAGE_STREAM_TAG = 's2iImageStreamTag',
-    S2I_SAMPLE_PROJECT = 's2iSampleProject',
     DEVFILE_STARTER_PROJECT = 'devfileStarterProject',
     DEVFILE_REGISTRY = 'devfileRegistry',
-    OFFLINE_CLUSTER = 'clusterOffline',
-    ONLINE_LOGGEDOFF_CLUSER = 'clusterLoggedoffOnline',
-    ONLINE_LOOGEDIN_CLUSER = 'clusterLoggedinOnline',
-    OFFLINE_OR_LOGGEDOUT_CLUSTER = 'clusterOfflineOrLoggedout',
 }
 
 export class ComponentTypesView implements TreeDataProvider<ComponentType> {
@@ -96,57 +79,12 @@ export class ComponentTypesView implements TreeDataProvider<ComponentType> {
 
     // eslint-disable-next-line class-methods-use-this
     getTreeItem(element: ComponentType): TreeItem | Thenable<TreeItem> {
-        if(isCluster(element)) {
-            return {
-                label: `${element.server}`,
-                collapsibleState: TreeItemCollapsibleState.Collapsed,
-                tooltip: `Current Cluster\n Server: ${element.server}`,
-            }
-        }
         if (isRegistry(element)) {
             return {
                 label: element.Name,
                 contextValue: ContextType.DEVFILE_REGISTRY,
                 tooltip: `Devfile Registry\nName: ${element.Name}\nURL: ${element.URL}`,
                 collapsibleState: TreeItemCollapsibleState.Collapsed,
-            }
-        }
-        if(isS2iComponent(element)) {
-            return {
-                label: `${element.metadata.name} (s2i)`,
-                contextValue: ContextType.S2I_COMPONENT_TYPE,
-                iconPath: {
-                    dark: Uri.file(path.join(__dirname, '..','..','images', 'component', 'component-type-dark.png')),
-                    light: Uri.file(path.join(__dirname, '..','..','images', 'component', 'component-type-light.png'))
-                },
-                collapsibleState: TreeItemCollapsibleState.Collapsed,
-            };
-        }
-        if (isSampleProject(element)) {
-            const to = element.sampleRepo.lastIndexOf('.git');
-            const from = element.sampleRepo.lastIndexOf('/');
-            const projectName = element.sampleRepo.substring(from+1,to >0? to : undefined);
-            return {
-                label: projectName,
-                contextValue: ContextType.S2I_SAMPLE_PROJECT,
-                tooltip: `Sample Project\nName: ${projectName}\nRepository: ${element.sampleRepo}`,
-                iconPath: {
-                    dark: Uri.file(path.join(__dirname, '..','..','images', 'component', 'start-project-dark.png')),
-                    light: Uri.file(path.join(__dirname, '..','..','images', 'component', 'start-project-light.png'))
-                },
-            }
-        }
-        if(isImageStreamTag(element)) {
-            return {
-                label: element.annotations['openshift.io/display-name']? element.annotations['openshift.io/display-name'] : element.name,
-                contextValue: ContextType.S2I_IMAGE_STREAM_TAG,
-                tooltip: `Component Type\nName: ${element.name}\nKind: S2I\nDescription: ${element?.annotations.description?element.annotations.description:'n/a'}`,
-                description: element.annotations.description,
-                iconPath: {
-                    dark: Uri.file(path.join(__dirname, '..','..','images', 'component', 'component-type-dark.png')),
-                    light: Uri.file(path.join(__dirname, '..','..','images', 'component', 'component-type-light.png'))
-                },
-                collapsibleState: isSampleProject(element)? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.Collapsed,
             }
         }
         if(isStarterProject(element)) {
@@ -212,32 +150,12 @@ export class ComponentTypesView implements TreeDataProvider<ComponentType> {
         let children: ComponentType[];
         const addEnv = this.odo.getKubeconfigEnv();
         if (!parent) {
-            const config = new KubeConfig();
-            config.loadFromDefault();
-            const cluster = config.getCurrentCluster();
             this.registries = await this.getRegistries();
-            children = [cluster,...this.registries];
-        } else if (isCluster(parent)) {
-            const result: CliExitData = await this.odo.execute(Command.listCatalogComponentsJson());
-            const builders = this.loadItems<ComponentTypesJson, S2iComponentType>(result, (data) => {
-                if (data.s2iItems) { // filter hidden tags
-                    data.s2iItems.forEach((s2iItem) => s2iItem.spec.imageStreamTags = s2iItem.spec.imageStreamTags.filter(tag => s2iItem.spec.nonHiddenTags.includes(tag.name)));
-                } else { // when not logged or disconnected form cluster s2i items are not available
-                    data.s2iItems = [];
-                }
-                return data.s2iItems;
-            });
-            children = [];
-            builders.forEach((builder: S2iComponentType) => children.splice(children.length,0, ...builder.spec.imageStreamTags));
+            children = this.registries;
         } else if (isRegistry(parent) ) {
             const result = await this.odo.execute(Command.listCatalogComponentsJson(),Platform.getUserHomePath(), true, addEnv);
-            children = this.loadItems<ComponentTypesJson, DevfileComponentType>(result, (data) => data.devfileItems);
+            children = this.loadItems<ComponentTypesJson, DevfileComponentType>(result, (data) => data.items);
             children = children.filter((element:DevfileComponentType) => element.Registry.Name === parent.Name);
-        } else if (isS2iComponent(parent)) {
-            children = parent.spec.imageStreamTags.map((tag:ImageStreamTag) => {
-                tag.typeName = parent.metadata.name;
-                return tag;
-            });
         } else if (isDevfileComponent(parent)){
             const result: CliExitData = await this.odo.execute(Command.describeCatalogComponent(parent.Name), Platform.getUserHomePath(), true, addEnv);
             const descriptions = this.loadItems<ComponentTypeDescription[], ComponentTypeDescription>(result, (data) => data);
@@ -246,8 +164,6 @@ export class ComponentTypesView implements TreeDataProvider<ComponentType> {
                 starter.typeName = parent.Name;
                 return starter;
             });
-        } else if (isImageStreamTag(parent)) {
-            children = [parent.annotations];
         }
         return children;
     }
@@ -273,18 +189,13 @@ export class ComponentTypesView implements TreeDataProvider<ComponentType> {
         ComponentTypesView.instance.refresh();
     }
 
-    public static getSampleRepositoryUrl(element: ExampleProject): string {
-        let url: string;
-        if(isSampleProject(element)) {
-            url = element.sampleRepo;
-        } else if(isStarterProject(element)) {
-            url = Object.values(element.git.remotes).find((prop) => typeof prop === 'string');
-        }
+    public static getSampleRepositoryUrl(element: StarterProject): string {
+        const url =  Object.values(element.git.remotes).find((prop) => typeof prop === 'string');
         return url;
     }
 
     @vsCommand('openshift.componentType.openStarterProjectRepository')
-    public static async openRepositoryURL(element: ExampleProject): Promise<void | string> {
+    public static async openRepositoryURL(element: StarterProject): Promise<void | string> {
         const url: string = ComponentTypesView.getSampleRepositoryUrl(element);
         if (url) {
             try {
@@ -299,7 +210,7 @@ export class ComponentTypesView implements TreeDataProvider<ComponentType> {
     }
 
     @vsCommand('openshift.componentType.cloneStarterProjectRepository')
-    public static async cloneRepository(element: ExampleProject): Promise<void | string> {
+    public static async cloneRepository(element: StarterProject): Promise<void | string> {
         const url: string = ComponentTypesView.getSampleRepositoryUrl(element);
         if (url) {
             try {

--- a/src/odo.ts
+++ b/src/odo.ts
@@ -643,29 +643,12 @@ export class OdoImpl implements Odo {
         const result: cliInstance.CliExitData = await this.execute(Command.listCatalogComponentsJson(), undefined, true, this.getKubeconfigEnv());
         const compTypesJson: ComponentTypesJson = this.loadJSON(result.stdout);
         const devfileItems: ComponentTypeAdapter[] = [];
-        const s2iItems: ComponentTypeAdapter[] = [];
 
-        if (compTypesJson?.devfileItems) {
-            compTypesJson.devfileItems.map((item) => devfileItems.push(new ComponentTypeAdapter(ComponentKind.DEVFILE, item.Name, undefined, item.Description, undefined, item.Registry.Name)));
+        if (compTypesJson?.items) {
+            compTypesJson.items.map((item) => devfileItems.push(new ComponentTypeAdapter(ComponentKind.DEVFILE, item.Name, undefined, item.Description, undefined, item.Registry.Name)));
         }
 
-        if (compTypesJson?.s2iItems) {
-            compTypesJson.s2iItems.forEach(element => {
-                if (element?.spec?.nonHiddenTags) {
-                    element.spec.nonHiddenTags.forEach(tag => {
-                        const foundTag = element.spec.imageStreamTags.find(imageTag => imageTag.name === tag);
-                        if (foundTag) {
-                            s2iItems.push(new ComponentTypeAdapter(ComponentKind.S2I, element.metadata.name, tag, foundTag?.annotations?.description, foundTag?.annotations.tags));
-                        }
-                    });
-                }
-            });
-        }
-
-        return [
-            ...devfileItems,
-            ...s2iItems
-        ];
+        return devfileItems;
     }
 
     public async getComponentChildren(component: OpenShiftObject): Promise<OpenShiftObject[]> {

--- a/src/odo/componentType.ts
+++ b/src/odo/componentType.ts
@@ -3,10 +3,8 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { Cluster } from '@kubernetes/client-node/dist/config_types';
 import { Url } from 'url';
 import { Data } from './componentTypeDescription';
-import { ComponentMetadata } from './config';
 
 export enum ComponentKind {
     S2I = 's2i',
@@ -43,49 +41,13 @@ export function ascDevfileFirst(c1: ComponentType, c2: ComponentType): number {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isS2iComponent(comp: any): comp is S2iComponentType {
-    return comp.kind && (typeof comp.kind) === 'string';
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isDevfileComponent(comp: any): comp is DevfileComponentType {
     return comp.Registry;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isImageStreamTag(tag: any): tag is ImageStreamTag {
-    return tag.name && tag.annotations;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isSampleProject(repo: any): repo is SampleProject {
-    return repo?.sampleRepo;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isCluster(cluster: any): cluster is Cluster {
-    return cluster.name && cluster.server;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isRegistry(registry: any): registry is Registry {
     return registry.Name && registry.URL && registry.Secure !== undefined;
-}
-
-export interface S2iComponentType {
-    kind: 'ComponentType';
-    apiVersion: string;
-    metadata: ComponentMetadata;
-    spec: {
-        allTags: string[];
-        nonHiddenTags: string[];
-        supportedTags: string[];
-        imageStreamTags: ImageStreamTag[];
-    },
-}
-
-export interface SampleProject {
-    sampleRepo: string;
 }
 
 export interface RegistryRef {
@@ -107,8 +69,7 @@ export interface ComponentTypesJson {
 	metadata: {
 		creationTimestamp: string;
     },
-    s2iItems: S2iComponentType[];
-    devfileItems: DevfileComponentType[];
+    items: DevfileComponentType[];
 }
 
 export interface ComponentType {
@@ -137,6 +98,6 @@ export class ComponentTypeAdapter implements ComponentType {
 
     get label(): string {
         const versionSuffix = this.version? `/${this.version}` : `/${this.registryName}` ;
-        return `${this.name}${versionSuffix} (${this.kind})`;
+        return `${this.name}${versionSuffix}`;
     }
 }

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -21,7 +21,7 @@ import LogViewLoader from '../webview/log/LogViewLoader';
 import DescribeViewLoader from '../webview/describe/describeViewLoader';
 import { vsCommand, VsCommandError } from '../vscommand';
 import { SourceType } from '../odo/config';
-import { ascDevfileFirst, ComponentKind, ComponentTypeAdapter, ComponentTypeDescription, DevfileComponentType, ImageStreamTag, isDevfileComponent, isImageStreamTag } from '../odo/componentType';
+import { ascDevfileFirst, ComponentKind, ComponentTypeAdapter, ComponentTypeDescription, DevfileComponentType, isDevfileComponent } from '../odo/componentType';
 import { Url } from '../odo/url';
 import { StarterProjectDescription } from '../odo/catalog';
 import { isStarterProject, StarterProject } from '../odo/componentTypeDescription';
@@ -541,7 +541,7 @@ export class Component extends OpenShiftItem {
     }
 
     @vsCommand('openshift.componentType.newComponent')
-    public static async createComponentFromCatalogEntry(context: DevfileComponentType | StarterProject | ImageStreamTag): Promise<string> {
+    public static async createComponentFromCatalogEntry(context: DevfileComponentType | StarterProject): Promise<string> {
         const application = await Component.getOpenShiftCmdData(undefined,
             'Select an Application where you want to create a Component'
         );
@@ -553,9 +553,6 @@ export class Component extends OpenShiftItem {
             starterProjectName:string;
         if (isDevfileComponent(context)) {
             componentTypeName = context.Name;
-        } else if (isImageStreamTag(context)) {
-            componentTypeName = context.typeName;
-            version = context.name;
         } else if (isStarterProject(context)){
             componentTypeName = context.typeName;
             starterProjectName = context.name;


### PR DESCRIPTION
This PR related to #2285.

Fix removes cluster and s2i components under it from
Component Types View. It also fixes 'odo list' json
output parsing, because now in returns components array
as 'items' property. Not used anymore s2i related types
also removed.

Signed-off-by: Denis Golovin dgolovin@redhat.com
