### PR TITLE
Fix for CRC commands not working wihout Red Hat Account login

### DIFF
--- a/src/webview/cluster/clusterViewLoader.ts
+++ b/src/webview/cluster/clusterViewLoader.ts
@@ -21,10 +21,13 @@ const sandboxAPI = createSandboxAPI();
 
 async function clusterEditorMessageListener (event: any ): Promise<any> {
 
-    const sessionCheck: vscode.AuthenticationSession = await vscode.authentication.getSession('redhat-account-auth', ['openid'], { createIfNone: false });
-    if(!sessionCheck && event.action !== 'sandboxLoginRequest') {
-        panel.webview.postMessage({action: 'sandboxPageLoginRequired'});
-        return;
+    let sessionCheck: vscode.AuthenticationSession;
+    if (event.action?.startsWith('sandbox')) {
+        sessionCheck = await vscode.authentication.getSession('redhat-account-auth', ['openid'], { createIfNone: false });
+        if(!sessionCheck && event.action !== 'sandboxLoginRequest') {
+            panel.webview.postMessage({action: 'sandboxPageLoginRequired'});
+            return;
+        }
     }
 
     switch (event.action) {


### PR DESCRIPTION
The problem was introduced by Developer Sandbox povisioning
implementatiion in Add Cluster Editor. This fix ask to login
to Devdlopers Redhat account only for commands related to
Sandbox provisioning page.

Related to #2236.

Signed-off-by: Denis Golovin dgolovin@redhat.com
