### PR TITLE
Use 'npm ci' instead of 'npm install' in CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -34,7 +34,7 @@ jobs:
 
       # Run install dependencies
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       # Run tests
       - name: Build and Test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ node('rhel8'){
   stage('Install requirements') {
     def nodeHome = tool 'nodejs-lts'
     env.PATH="${env.PATH}:${nodeHome}/bin"
-    sh "npm install"
+    sh "npm ci"
     sh "npm install -g vsce"
   }
 


### PR DESCRIPTION
According to https://nodejs.dev/learn/the-package-lock-json-file
that will use package-lock.json file with fixed dependencies.

Signed-off-by: Denis Golovin dgolovin@redhat.com
