### PR TITLE
Remove not used context menu items form Registries View

### DIFF
--- a/package.json
+++ b/package.json
@@ -1541,21 +1541,6 @@
 					"group": "inline"
 				},
 				{
-					"command": "openshift.componentType.openStarterProjectRepository",
-					"when": "view == openshiftComponentTypesView && viewItem == s2iSampleProject || viewItem == devfileStarterProject",
-					"group": "1@0"
-				},
-				{
-					"command": "openshift.componentType.cloneStarterProjectRepository",
-					"when": "view == openshiftComponentTypesView && viewItem == s2iSampleProject || viewItem == devfileStarterProject",
-					"group": "1@1"
-				},
-				{
-					"command": "openshift.componentType.newComponent",
-					"when": "view == openshiftComponentTypesView && viewItem == s2iImageStreamTag || viewItem == devfileStarterProject || viewItem == devfileComponentType",
-					"group": "0@0"
-				},
-				{
 					"command": "openshift.component.revealInExplorer",
 					"when": "view == openshiftComponentsView && viewItem == openshift.component"
 				},


### PR DESCRIPTION
Registries View has no starter projects and component types anymore.
Thant means all context menu items declared for them in package.json
are never shown. The commands are still called form registry viewer.

Signed-off-by: Denis Golovin dgolovin@redhat.com
