### PR TITLE
Change remoteRoot to /projects when starting nodejs debugging session

### DIFF
--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -842,7 +842,7 @@ export class Component extends OpenShiftItem {
                     request: 'attach',
                     address: 'localhost',
                     localRoot: component.contextPath.fsPath,
-                    remoteRoot: '/project'
+                    remoteRoot: '/projects'
                 });
             }
         } else {


### PR DESCRIPTION
This PR fixes #2462.

Signed-off-by: Denis Golovin dgolovin@redhat.com
