### PR TITLE
`OpenShift: Weclome` command should always open Welcome page

### DIFF
--- a/src/welcomePage.ts
+++ b/src/welcomePage.ts
@@ -11,10 +11,14 @@ import { vsCommand } from './vscommand';
 
 export class WelcomePage {
 
-    @vsCommand('openshift.welcome')
     static createOrShow(): void {
         if(workspace.getConfiguration('openshiftConnector').get('showWelcomePage')) {
-            WelcomeWebview.createOrShow(ExtenisonID, path.resolve(__dirname, '..', '..'), path.join('welcome', 'app', 'assets'), 'openshiftConnector.showWelcomePage');
+            WelcomePage.createOrShowCmd();
         }
+    }
+
+    @vsCommand('openshift.welcome')
+    static createOrShowCmd(): void {
+        WelcomeWebview.createOrShow(ExtenisonID, path.resolve(__dirname, '..', '..'), path.join('welcome', 'app', 'assets'), 'openshiftConnector.showWelcomePage');
     }
 }


### PR DESCRIPTION
This PR fixes #2510.

Signed-off-by: Denis Golovin dgolovin@redhat.com
