### PR TITLE
Use oc 4.9.5 to login to cluster to avoid x509 sert issue in odo login

### DIFF
--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -204,7 +204,7 @@ export class Command {
         username: string,
         passwd: string,
     ): CommandText {
-        return new CommandText('odo login',
+        return new CommandText('oc login',
             clusterURL, [
             new CommandOption('-u', username, true, true),
             new CommandOption('-p', passwd, true, true),
@@ -214,7 +214,7 @@ export class Command {
     }
 
     static odoLoginWithToken(clusterURL: string, ocToken: string): CommandText {
-        return new CommandText('odo login',
+        return new CommandText('oc login',
             clusterURL, [
             new CommandOption('--token', ocToken),
             new CommandOption('--insecure-skip-tls-verify')


### PR DESCRIPTION
Fix #2693.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>