### PR TITLE
Use proxyURL to log into sandbox using Red Hat auth token

### DIFF
--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -451,15 +451,15 @@ export class Cluster extends OpenShiftItem {
     @vsCommand('openshift.explorer.login.clipboard')
     static async loginUsingClipboardToken(apiEndpointUrl: string, oauthRequestTokenUrl: string): Promise<string | null> {
         const clipboard = await Cluster.readFromClipboard();
-        if(!clipboard) {
-            const choice = await window.showErrorMessage('Cannot parse token in clipboard. Please click `Get token` button below, copy token into clipboard and press `Login to Sandbox` button again.',
-                'Get token');
-            if (choice === 'Get token') {
-                await commands.executeCommand('vscode.open', Uri.parse(oauthRequestTokenUrl));
-            }
-            return;
-        }
-        return Cluster.tokenLogin(apiEndpointUrl, true, clipboard);
+        // if(!clipboard) {
+        //     const choice = await window.showErrorMessage('Cannot parse token in clipboard. Please click `Get token` button below, copy token into clipboard and press `Login to Sandbox` button again.',
+        //         'Get token');
+        //     if (choice === 'Get token') {
+        //         await commands.executeCommand('vscode.open', Uri.parse(oauthRequestTokenUrl));
+        //     }
+        //     return;
+        // }
+        return Cluster.tokenLogin(apiEndpointUrl, true, oauthRequestTokenUrl);
     }
 
     static async loginUsingClipboardInfo(dashboardUrl: string): Promise<string | null> {

--- a/src/openshift/sandbox.ts
+++ b/src/openshift/sandbox.ts
@@ -29,6 +29,7 @@ export interface SBSignupResponse {
   givenName: string;
   status: SBStatus;
   username: string;
+  proxyURL: string;
 }
 
 export interface SBResponseData {

--- a/src/webview/cluster/app/sandboxView.tsx
+++ b/src/webview/cluster/app/sandboxView.tsx
@@ -59,7 +59,8 @@ export default function addSandboxView(props): JSX.Element {
         consoleDashboard: '',
         apiEndpoint: '',
         oauthTokenEndpoint: '',
-        errorCode: undefined
+        errorCode: undefined,
+        proxyUrl: ''
     });
 
     const messageListener = (event) => {
@@ -151,7 +152,8 @@ export default function addSandboxView(props): JSX.Element {
                 statusInfo: currentState.statusInfo,
                 apiEndpoint: '',
                 oauthTokenEndpoint: '',
-                errorCode: undefined
+                errorCode: undefined,
+                proxyUrl: ''
             });
             postMessage('sandboxDetectStatus');
         }
@@ -302,7 +304,8 @@ export default function addSandboxView(props): JSX.Element {
                 consoleDashboard: '',
                 apiEndpoint: '',
                 oauthTokenEndpoint: '',
-                errorCode: undefined
+                errorCode: undefined,
+                proxyUrl: ''
             });
         }
 
@@ -379,7 +382,7 @@ export default function addSandboxView(props): JSX.Element {
     const Provisioned = () => {
 
         const handleLoginButton = () => {
-            postMessage('sandboxLoginUsingDataInClipboard', {apiEndpointUrl: currentState.apiEndpoint, oauthRequestTokenUrl: `${currentState.oauthTokenEndpoint}/request`});
+            postMessage('sandboxLoginUsingDataInClipboard', {apiEndpointUrl: currentState.apiEndpoint, oauthRequestTokenUrl: `${currentState.oauthTokenEndpoint}/request`, proxyUrl: currentState.proxyUrl});
         };
 
         return (

--- a/src/webview/cluster/clusterViewLoader.ts
+++ b/src/webview/cluster/clusterViewLoader.ts
@@ -109,7 +109,7 @@ async function clusterEditorMessageListener (event: any ): Promise<any> {
                 } else {
                     if (signupStatus.status.ready) {
                         const oauthInfo = await sandboxAPI.getOauthServerInfo(signupStatus.apiEndpoint);
-                        panel.webview.postMessage({action: 'sandboxPageProvisioned', statusInfo: signupStatus.username, consoleDashboard: signupStatus.consoleURL, apiEndpoint: signupStatus.apiEndpoint, oauthTokenEndpoint: oauthInfo.token_endpoint });
+                        panel.webview.postMessage({action: 'sandboxPageProvisioned', statusInfo: signupStatus.username, consoleDashboard: signupStatus.consoleURL, apiEndpoint: signupStatus.apiEndpoint, oauthTokenEndpoint: oauthInfo.token_endpoint, proxyUrl: signupStatus.proxyURL });
                     } else {
                         // cluster is not ready and the reason is
                         if (signupStatus.status.verificationRequired) {
@@ -173,7 +173,7 @@ async function clusterEditorMessageListener (event: any ): Promise<any> {
         case 'sandboxLoginUsingDataInClipboard':
             const telemetryEventLoginToSandbox = new ExtCommandTelemetryEvent('openshift.explorer.addCluster.sandboxLoginUsingDataInClipboard');
             try {
-                const result = await Cluster.loginUsingClipboardToken(event.payload.apiEndpointUrl, event.payload.oauthRequestTokenUrl);
+                const result = await Cluster.loginUsingClipboardToken(event.payload.proxyUrl, (sessionCheck as any).idToken);
                 if (result) vscode.window.showInformationMessage(`${result}`);
                 telemetryEventLoginToSandbox.send();
             } catch (err) {


### PR DESCRIPTION
Getting resources seems to work fine through the proxy, but there are two problems to solve:
1. idToken lives 900 seconds and then have to be refreshed in kubeconfig (that probably affects live connections through the proxy that already exists at the moment when refresh happens)
2. odo dev cannot sync files through the proxy

Fix #2519.

Signed-off-by: Denis Golovin dgolovin@redhat.com
