### PR TITLE
Move Components view at the top of OpenShift activity views

### DIFF
--- a/package.json
+++ b/package.json
@@ -829,12 +829,12 @@
 		"views": {
 			"openshiftView": [
 				{
-					"id": "openshiftProjectExplorer",
-					"name": "Application Explorer"
-				},
-				{
 					"id": "openshiftComponentsView",
 					"name": "Components"
+				},
+				{
+					"id": "openshiftProjectExplorer",
+					"name": "Application Explorer"
 				},
 				{
 					"id": "openshiftComponentTypesView",


### PR DESCRIPTION
Fix #2756.

Signed-off-by: Denis Golovin dgolovin@redhat.com
