### PR TITLE
Hide commands that require selecting a component

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,7 @@ insert_final_newline     = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[./package.json]
+indent_style = tab
+indent_size = 4

--- a/package.json
+++ b/package.json
@@ -59,14 +59,14 @@
 		"dev:compile:devfile-registry-view": "webpack --mode development --config src/webview/devfile-registry/webpack.config.js",
 		"dev:compile:welcome-view": "webpack --mode development --config src/webview/welcome/webpack.config.js",
 		"dev:compile:git-import-view": "webpack --mode development --config src/webview/git-import/webpack.config.js",
-        "dev:compile:helm-chart-view": "webpack --mode development --config src/webview/helm-chart/webpack.config.js",
+		"dev:compile:helm-chart-view": "webpack --mode development --config src/webview/helm-chart/webpack.config.js",
 		"dev:run:log-view": "webpack-dev-server --mode development --config src/webview/log/webpack.config.js",
 		"dev:run:describe-view": "webpack-dev-server --mode development --config src/webview/describe/webpack.config.js",
 		"dev:run:cluster-view": "webpack-dev-server --port 9222 --mode development --config src/webview/cluster/webpack.config.js",
 		"dev:run:devfile-registry-view": "webpack-dev-server --port 9222 --mode development --config src/webview/devfile-registry/webpack.config.js",
 		"dev:run:welcome-view": "webpack-dev-server --port 9222 --mode development --config src/webview/welcome/webpack.config.js",
 		"dev:run:git-import-view": "webpack-dev-server --port 9222 --mode development --config src/webview/git-import/webpack.config.js",
-        "dev:run:helm-chart-view": "webpack-dev-server --port 9222 --mode development --config src/webview/helm-chart/webpack.config.js",
+		"dev:run:helm-chart-view": "webpack-dev-server --port 9222 --mode development --config src/webview/helm-chart/webpack.config.js",
 		"dev:run:create-service-view": "webpack-dev-server --mode development --config src/webview/create-service/webpack.config.js",
 		"watch": "tsc -watch -p ./",
 		"clean": "shx rm -rf out/build out/coverage out/src out/test out/tools out/test-resources out/logViewer",
@@ -83,7 +83,7 @@
 		"coverage:upload": "codecov -f coverage/coverage-final.json",
 		"build": "npm run clean && npm run lint && npm run compile && npm run bundle-tools",
 		"smoke-test": "npm run compile:ext && extest setup-and-run out/test/ui/smoke-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -c max",
-        "public-ui-test": "npm run compile:ext && extest setup-and-run out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -c max"
+		"public-ui-test": "npm run compile:ext && extest setup-and-run out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -c max"
 	},
 	"dependencies": {
 		"@kubernetes/client-node": "^0.16.1",
@@ -263,7 +263,7 @@
 		"onCommand:openshift.component.debug",
 		"onCommand:openshift.component.debug.palette",
 		"onCommand:openshift.resource.load",
-        "onCommand:openshift.resource.unInstall",
+		"onCommand:openshift.resource.unInstall",
 		"onCommand:openshift.service.create",
 		"onCommand:openshift.service.delete",
 		"onCommand:openshift.component.folder.create",
@@ -289,7 +289,7 @@
 		"onCommand:clusters.openshift.deployment.openConsole",
 		"onCommand:clusters.openshift.imagestream.openConsole",
 		"onCommand:openshift.componentTypesView.registry.openInView",
-        "onCommand:openshift.componentTypesView.registry.openHelmChartsInView",
+		"onCommand:openshift.componentTypesView.registry.openHelmChartsInView",
 		"onWalkthrough:openshiftWalkthrough"
 	],
 	"contributes": {
@@ -399,7 +399,7 @@
 				"title": "New Project",
 				"category": "OpenShift"
 			},
-            {
+			{
 				"command": "openshift.componentTypesView.registry.openHelmChartsInView",
 				"title": "Open Helm Charts",
 				"category": "OpenShift"
@@ -787,7 +787,7 @@
 				"title": "Load",
 				"category": "OpenShift"
 			},
-            {
+			{
 				"command": "openshift.resource.unInstall",
 				"title": "Uninstall",
 				"category": "OpenShift"
@@ -806,21 +806,21 @@
 				"title": "Import Component from git repository",
 				"category": "OpenShift"
 			},
-            {
-                "command": "openshift.experimental.mode.enable",
-                "title": "Experimental Features",
-                "category": "OpenShift"
-            },
-            {
-                "command": "openshift.experimental.mode.disable",
-                "title": "✓ Experimental Features",
-                "category": "OpenShift"
-            },
-            {
-                "command": "openshift.component.dev.onPodman",
-                "title": "Start Dev on Podman",
-                "category": "OpenShift"
-            }
+			{
+				"command": "openshift.experimental.mode.enable",
+				"title": "Experimental Features",
+				"category": "OpenShift"
+			},
+			{
+				"command": "openshift.experimental.mode.disable",
+				"title": "✓ Experimental Features",
+				"category": "OpenShift"
+			},
+			{
+				"command": "openshift.component.dev.onPodman",
+				"title": "Start Dev on Podman",
+				"category": "OpenShift"
+			}
 		],
 		"keybindings": [
 			{
@@ -1012,6 +1012,34 @@
 					"when": "false"
 				},
 				{
+					"command": "openshift.component.dev",
+					"when": "false"
+				},
+				{
+					"command": "openshift.component.dev.onPodman",
+					"when": "false"
+				},
+				{
+					"command": "openshift.component.deploy",
+					"when": "false"
+				},
+				{
+					"command": "openshift.component.undeploy",
+					"when": "false"
+				},
+				{
+					"command": "openshift.component.describe.palette",
+					"when": "false"
+				},
+				{
+					"command": "openshift.component.followLog.palette",
+					"when": "false"
+				},
+				{
+					"command": "openshift.component.log.palette",
+					"when": "false"
+				},
+				{
 					"command": "openshift.componentType.newComponent",
 					"when": "false"
 				},
@@ -1035,10 +1063,10 @@
 					"command": "openshift.componentTypesView.registry.openInView",
 					"when": "false"
 				},
-                {
-                    "command": "openshift.componentTypesView.registry.openHelmChartsInView",
-                    "when": "false"
-                },
+				{
+					"command": "openshift.componentTypesView.registry.openHelmChartsInView",
+					"when": "false"
+				},
 				{
 					"command": "openshift.componentTypesView.registry.openInBrowser",
 					"when": "false"
@@ -1051,7 +1079,7 @@
 					"command": "openshift.resource.load",
 					"when": "false"
 				},
-                {
+				{
 					"command": "openshift.resource.unInstall",
 					"when": "false"
 				},
@@ -1124,14 +1152,14 @@
 					"when": "view == openshiftComponentsView",
 					"group": "navigation"
 				},
-                {
-                    "command": "openshift.experimental.mode.enable",
-                    "when": "view == openshiftComponentsView && !config.openshiftToolkit.experimentalFeatures"
-                },
-                {
-                    "command": "openshift.experimental.mode.disable",
-                    "when": "view == openshiftComponentsView && config.openshiftToolkit.experimentalFeatures"
-                }
+				{
+					"command": "openshift.experimental.mode.enable",
+					"when": "view == openshiftComponentsView && !config.openshiftToolkit.experimentalFeatures"
+				},
+				{
+					"command": "openshift.experimental.mode.disable",
+					"when": "view == openshiftComponentsView && config.openshiftToolkit.experimentalFeatures"
+				}
 			],
 			"view/item/context": [
 				{
@@ -1209,7 +1237,7 @@
 					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sContext && isLoggedIn",
 					"group": "c1"
 				},
-                {
+				{
 					"command": "openshift.componentTypesView.registry.openHelmChartsInView",
 					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sContext && isLoggedIn",
 					"group": "c2"
@@ -1369,7 +1397,7 @@
 					"command": "openshift.resource.load",
 					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject || viewItem == openshift.k8sObject.helm"
 				},
-                {
+				{
 					"command": "openshift.resource.unInstall",
 					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject.helm"
 				},


### PR DESCRIPTION
The commands are still accessible in the relevant right-click menus, but are no longer available in the command palette, since they don't work when invoked from the command palette.

This is a work around until we can get the commands to work from the command palette when working with OpenShift Dev Sandbox.

Fixes #2792

Signed-off-by: David Thompson <davthomp@redhat.com>
