### PR TITLE
Routinely check for a new version of odo.

### DIFF
--- a/.github/workflows/check-odo.yml
+++ b/.github/workflows/check-odo.yml
@@ -1,0 +1,44 @@
+name: check-odo
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+jobs:
+  check-odo-repo:
+    runs-on: ubuntu-latest
+    env:
+        TOOL_REPO: redhat-developer/odo
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v2
+      - name: Get latest ODO version
+        run: |
+          echo "REPO_ODO_VERSION=$(cat src/tools.json | jq -r .odo.version)" >> $GITHUB_ENV
+          LATEST_TOOL_RELEASE_RESP=$(gh release --repo ${{ env.TOOL_REPO }} view --json tagName,url)
+          echo "LATEST_TOOL_RELEASE=$(echo ${LATEST_TOOL_RELEASE_RESP} | jq -r .tagName | sed 's|v||')" >> $GITHUB_ENV
+          echo "LATEST_TOOL_URL=$(echo ${LATEST_TOOL_RELEASE_RESP} | jq -r .url)" >> $GITHUB_ENV
+      - name: Find existing PR for ODO version
+        run: |
+          echo PR_EXISTS=$(gh pr --repo ${{ github.repository }} list --state all --search "update odo ${{env.LATEST_TOOL_RELEASE}} in:title" --json url | jq length) >> $GITHUB_ENV
+      - name: Update src/tools.json with latest odo version
+        if: ${{ (env.LATEST_TOOL_RELEASE != env.REPO_ODO_VERSION) && (env.PR_EXISTS == 0) }}
+        run: |
+          jq --indent 4 '.odo.version = "${{ env.LATEST_TOOL_RELEASE }}"' src/tools.json | jq --indent 4 '.odo.versionRange = "^${{ env.LATEST_TOOL_RELEASE }}"' | jq --indent 4 '.odo.versionRangeLabel = "version >= ${{ env.LATEST_TOOL_RELEASE }}"' > src/tools.json.new
+          mv src/tools.json.new src/tools.json
+          for platform in win32 darwin linux; do
+            old_url=`jq -r .odo.platform.${platform}.url src/tools.json`
+            new_url=`echo ${old_url} | sed "s|${{ env.REPO_ODO_VERSION }}|${{ env.LATEST_TOOL_RELEASE }}|"`
+            checksum=`curl -s ${new_url}.sha256`
+            jq --indent 4 ".odo.platform.${platform}.url = \"${new_url}\"" src/tools.json | jq --indent 4 ".odo.platform.${platform}.sha256sum = \"${checksum}\"" > src/tools.json.new
+            mv src/tools.json.new src/tools.json
+          done
+      - name: Create pull request
+        if: ${{ (env.LATEST_TOOL_RELEASE != env.REPO_ODO_VERSION) && (env.PR_EXISTS == 0) }}
+        run: |
+          git config --global user.email "openshifttools-bot@users.noreply.github.com"
+          git config --global user.name "openshifttools-bot"
+          git checkout -b "odo-${{ env.LATEST_TOOL_RELEASE }}"
+          git commit -am "Update odo to ${{ env.LATEST_TOOL_RELEASE }}"
+          git push origin "odo-${{ env.LATEST_TOOL_RELEASE }}"
+          gh pr create --title "Update odo to ${{ env.LATEST_TOOL_RELEASE }}" --body "See ${{ env.LATEST_TOOL_URL }}"


### PR DESCRIPTION
- Fixes #2797 
- Fixes #2798

**Todo** :
- [x] Change build trigger from `workflow_dispatch` (easier to test) to a schedule (daily?)
- [x] Confirm required permissions are in place
- [ ] Adapt the script to also handle oc ? Though we're already pretty far behind from the latest

**How to test this** :
You can create a fork of vscode-openshift-tools, and push this PR onto the `main` branch (so that GH Actions reads the workflow file from there)

Apply something similar to the following patch (can be a separate commit on top of this PR) :

<details>
<summary>diff</summary>

```diff
diff --git a/.github/workflows/check-odo.yml b/.github/workflows/check-odo.yml
index c168612..14d007b 100644
--- a/.github/workflows/check-odo.yml
+++ b/.github/workflows/check-odo.yml
@@ -19,9 +19,9 @@ jobs:
           echo "LATEST_TOOL_URL=$(echo ${LATEST_TOOL_RELEASE_RESP} | jq -r .url)" >> $GITHUB_ENV
       - name: Find existing PR for ODO version
         run: |
-          echo PR_URL=$(gh pr --repo ${{ github.repository }} list --state all --search "update odo ${{env.LATEST_TOOL_RELEASE}} in:title" --json url) >> $GITHUB_ENV
+          echo PR_URL=$(gh pr --repo rgrunber/vscode-openshift-tools list --state all --search "update odo ${{env.LATEST_TOOL_RELEASE}} in:title" --json url) >> $GITHUB_ENV
       - name: Update src/tools.json with latest odo version
-        if: ${{ (env.LATEST_TOOL_RELEASE != env.REPO_ODO_VERSION) && (env.PR_URL == '') }}
+        if: ${{ (env.LATEST_TOOL_RELEASE != env.REPO_ODO_VERSION) && (env.PR_URL != '') }}
         run: |
           jq --indent 4 '.odo.version = "${{ env.LATEST_TOOL_RELEASE }}"' src/tools.json | jq --indent 4 '.odo.versionRange = "^${{ env.LATEST_TOOL_RELEASE }}"' | jq --indent 4 '.odo.versionRangeLabel = "version >= ${{ env.LATEST_TOOL_RELEASE }}"' > src/tools.json.new
           mv src/tools.json.new src/tools.json
@@ -33,7 +33,7 @@ jobs:
             mv src/tools.json.new src/tools.json
           done
       - name: Create pull request
-        if: ${{ (env.LATEST_TOOL_RELEASE != env.REPO_ODO_VERSION) && (env.PR_URL == '') }}
+        if: ${{ (env.LATEST_TOOL_RELEASE != env.REPO_ODO_VERSION) && (env.PR_URL != '') }}
         run: |
           git config --global user.email "openshifttools-bot@users.noreply.github.com"
           git config --global user.name "openshifttools-bot"
diff --git a/src/tools.json b/src/tools.json
index 9bb4c29..814947e 100644
--- a/src/tools.json
+++ b/src/tools.json
@@ -3,27 +3,27 @@
         "description": "odo CLI",
         "vendor": "Red Hat, Inc.",
         "name": "odo",
-        "version": "3.8.0",
-        "versionRange": "^3.8.0",
-        "versionRangeLabel": "version >= 3.8.0",
+        "version": "3.7.0",
+        "versionRange": "^3.7.0",
+        "versionRangeLabel": "version >= 3.7.0",
         "dlFileName": "odo",
         "filePrefix": "",
         "platform": {
             "win32": {
-                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/odo/v3.8.0/odo-windows-amd64.exe.zip",
-                "sha256sum": "0d33e08aa79638d306dd495ae421f9f7685acdbdcd0cc4f06ffb851c262d5437",
+                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/odo/v3.7.0/odo-windows-amd64.exe.zip",
+                "sha256sum": "0",
                 "dlFileName": "odo-windows-amd64.exe.zip",
                 "cmdFileName": "odo-windows-amd64.exe"
             },
             "darwin": {
-                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/odo/v3.8.0/odo-darwin-amd64.tar.gz",
-                "sha256sum": "cd84feb03533df0ceda3bb2e5590e7c2ec360e85f7c60a447e9ef86214171954",
+                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/odo/v3.7.0/odo-darwin-amd64.tar.gz",
+                "sha256sum": "0",
                 "dlFileName": "odo-darwin-amd64.tar.gz",
                 "cmdFileName": "odo-darwin-amd64"
             },
             "linux": {
-                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/odo/v3.8.0/odo-linux-amd64.tar.gz",
-                "sha256sum": "dc1b9e81bab3185c90e42f42e9066f298310cef5c6371242187cee9d70aa439c",
+                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/odo/v3.7.0/odo-linux-amd64.tar.gz",
+                "sha256sum": "0",
                 "dlFileName": "odo-linux-amd64.tar.gz",
                 "cmdFileName": "odo"
             }
-- 
2.39.2

```
</details>

Since the latest odo is currently adopted, this just simulated the case of a newer version. See https://github.com/rgrunber/vscode-openshift-tools/pull/14 for a sample

**Required repo permissions** :

![Screenshot from 2023-03-29 22-53-33](https://user-images.githubusercontent.com/1417342/228717315-c69fa1b4-d5a6-4e81-acc1-f34ddf2a829b.png)

Without full read/write permissions, the following error is displayed attempting to push the commit to a branch :

```
remote: Permission to rgrunber/vscode-openshift-tools.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/rgrunber/vscode-openshift-tools/': The requested URL returned error: 40
```

Without pull request approval for GH Actions, the following error is shown :

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```