### PR TITLE
disable next button until user selects the installed location of local CRC

### DIFF
--- a/src/webview/cluster/app/clusterView.tsx
+++ b/src/webview/cluster/app/clusterView.tsx
@@ -209,7 +209,7 @@ export default function addClusterView(props: ClusterViewProps) {
   };
 
   const handleDisabled = () => {
-    return (activeStep === 1 && fileName === '')
+    return ((activeStep === 0 || activeStep === 1) && fileName === '')
         || (activeStep === 2 && pullSecretPath === '');
   };
 


### PR DESCRIPTION
Signed-off-by: msivasubramaniaan [msivasub@redhat.com](mailto:msivasub@redhat.com)

`Next` button will be disabled until user selects the installation file.
![image](https://user-images.githubusercontent.com/93245779/232726360-cc2498d7-7fed-49ff-943d-2ddd00101049.png)