### PR TITLE
Integration test suite for `odo` commands we call

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,9 @@ insert_final_newline     = true
 [*.md]
 trim_trailing_whitespace = false
 
+[Jenkinsfile]
+indent_size = 2
+
 [./package.json]
 indent_style = tab
 indent_size = 4

--- a/.eslintrc
+++ b/.eslintrc
@@ -101,7 +101,8 @@
     "radix": 2,
     "no-trailing-spaces": "error",
     "@typescript-eslint/prefer-regexp-exec": 0,
-    "quotes": [ "error", "single"]
+    "quotes": [ "error", "single"],
+    "@typescript-eslint/no-unused-vars": [ "error", { "vars": "local", "args": "none" }]
   },
   "overrides": [
     {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,28 @@ There are only a few guidelines that we need contributors to follow.
 
 ![View Container OpenShift](https://github.com/redhat-developer/vscode-openshift-tools/blob/master/images/view-container-icon.png)
 
+## Running the Integration Test Suite
+
+In order to run the integration test suite, you need access to an OpenShift cluster
+where you can create and delete projects.
+Unfortunately, this means that OpenShift Developer Sandbox instances won't work.
+Also, non-OpenShift Kubernetes distributions, such as `minikube`, will not work, since we test many OpenShift-specific features.
+One way to access such a cluster is by using [crc](https://crc.dev/crc/) to run an OpenShift cluster locally on your computer.
+The tests will create and delete resources on the cluster,
+so please make sure nothing important is running on the cluster.
+
+First, set the following environment variables to point the tests to your cluster:
+- `CLUSTER_URL`: the URL pointing to the API of the cluster, defaults to `https://192.168.130.11:6443` (the default `crc` IP address)
+- `CLUSTER_USER`: the username to use to login to the cluster, defaults to `developer`
+- `CLUSTER_PASSWORD`: the password to use to login to the cluster, default to `developer`
+
+Then, run `npm run test-integration`.
+
+If you would like to generate a coverage report of the integration test suite,
+you can run `npm run test-integration:coverage`.
+
 > If you have any questions or run into any problems, please post an issue - we'll be very happy to help.
+
 ### Certificate of Origin
 
 By contributing to this project you agree to the Developer Certificate of

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
 				"@types/mocha": "^9.0.0",
 				"@types/node": "^16.11.12",
 				"@types/pify": "^5.0.1",
+				"@types/proxyquire": "^1.3.28",
 				"@types/react": "^17.0.37",
 				"@types/react-copy-to-clipboard": "^5.0.4",
 				"@types/react-dom": "^17.0.11",
@@ -5966,6 +5967,12 @@
 			"version": "15.7.5",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
 			"integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+			"dev": true
+		},
+		"node_modules/@types/proxyquire": {
+			"version": "1.3.28",
+			"resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
+			"integrity": "sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==",
 			"dev": true
 		},
 		"node_modules/@types/qs": {
@@ -26770,6 +26777,12 @@
 			"version": "15.7.5",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
 			"integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+			"dev": true
+		},
+		"@types/proxyquire": {
+			"version": "1.3.28",
+			"resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
+			"integrity": "sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==",
 			"dev": true
 		},
 		"@types/qs": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"debuggers",
 		"K8s",
 		"Cloud",
-        "podman"
+		"podman"
 	],
 	"icon": "images/openshift_extension.png",
 	"main": "./out/src/extension",
@@ -69,7 +69,7 @@
 		"dev:run:helm-chart-view": "webpack-dev-server --port 9222 --mode development --config src/webview/helm-chart/webpack.config.js",
 		"dev:run:create-service-view": "webpack-dev-server --mode development --config src/webview/create-service/webpack.config.js",
 		"watch": "tsc -watch -p ./",
-		"clean": "shx rm -rf out/build out/coverage out/src out/test out/tools out/test-resources out/logViewer",
+		"clean": "shx rm -rf out/build out/coverage out/src out/test out/tools out/test-resources out/*Viewer",
 		"lint": "eslint . --ext .ts --quiet",
 		"lint-fix": "eslint . --ext .ts --fix",
 		"lint-nic": "eslint . --ext .ts --no-inline-config",
@@ -77,6 +77,7 @@
 		"todo": "leasot **/*.ts --ignore node_modules -x",
 		"test": "npm run vscode:prepublish && node ./out/build/run-tests.js unit",
 		"test-integration": "npm run vscode:prepublish && node ./out/build/run-tests.js integration",
+		"test-integration:coverage": "npm run vscode:prepublish && npm run test:instrument && node ./out/build/run-tests.js integration",
 		"test:instrument": "shx rm -rf out/src-orig && shx mv out/src out/src-orig && istanbul instrument --complete-copy --embed-source --output out/src out/src-orig",
 		"test:coverage": "npm run build && npm run test:instrument && node ./out/build/install-vscode.js redhat.vscode-redhat-account && node ./out/build/run-tests.js unit",
 		"update-deps": "ncu --upgrade --loglevel verbose --packageFile package.json && npm update",
@@ -144,6 +145,7 @@
 		"@types/mocha": "^9.0.0",
 		"@types/node": "^16.11.12",
 		"@types/pify": "^5.0.1",
+		"@types/proxyquire": "^1.3.28",
 		"@types/react": "^17.0.37",
 		"@types/react-copy-to-clipboard": "^5.0.4",
 		"@types/react-dom": "^17.0.11",
@@ -1079,6 +1081,10 @@
 				{
 					"command": "openshift.component.deleteSourceFolder",
 					"when": "false"
+				},
+				{
+					"command": "openshift.component.openInBrowser",
+					"when": "false"
 				}
 			],
 			"view/title": [
@@ -1437,7 +1443,7 @@
 							"onCommand:openshift.componentType.newComponent"
 						]
 					},
-                    {
+					{
 						"id": "helmChart",
 						"title": "Work with Helm Charts",
 						"description": "Browse the catalog to discover and install Helm Charts.\n[Browse Helm Chart](command:openshift.componentTypesView.registry.openHelmChartsInView)",

--- a/src/odo/components.ts
+++ b/src/odo/components.ts
@@ -3,18 +3,18 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { Component } from './config';
-
-export const NotAvailable = 'Not available';
-
 export interface ComponentsJson {
-    kind: string;
-	apiVersion: string;
-	metadata: {
-		creationTimestamp: string;
-    },
-    // eslint-disable-next-line camelcase
-    otherComponents: Component[];
-    // eslint-disable-next-line camelcase
-    devfileComponents: Component[];
+    // list is not present when there are no components
+    // i.e. if there are no components the JSON is `{}`
+    components?: Component[]
+}
+
+export interface Component {
+    name: string,
+    managedBy: string,
+    managedByVersion: string,
+    runningIn: Map<string, boolean>,
+    projectType: string,
+    runningOn: string,
+    platform: string,
 }

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -9,7 +9,6 @@ import { ChildProcess, SpawnOptions } from 'child_process';
 import * as fs from 'fs/promises';
 import { DebugConfiguration, DebugSession, Disposable, EventEmitter, ProgressLocation, Terminal, Uri, commands, debug, extensions, window, workspace } from 'vscode';
 import * as YAML from 'yaml';
-import { OpenShiftComponent } from '../odo';
 import { Command } from '../odo/command';
 import { ComponentTypeAdapter, ComponentTypeDescription, DevfileComponentType, ascDevfileFirst, isDevfileComponent } from '../odo/componentType';
 import { StarterProject, isStarterProject } from '../odo/componentTypeDescription';
@@ -18,6 +17,7 @@ import { Progress } from '../util/progress';
 import { selectWorkspaceFolder } from '../util/workspace';
 import { VsCommandError, vsCommand } from '../vscommand';
 import OpenShiftItem from './openshiftItem';
+
 import path = require('path');
 import globby = require('globby');
 
@@ -439,7 +439,7 @@ export class Component extends OpenShiftItem {
         compName?: string,
         registryName?: string
         devFilePath?: string
-    }, isGitImportCall = false, notification = true): Promise<string | null> {
+    }, isGitImportCall = false): Promise<string | null> {
         let useExistingDevfile = false;
         const devFileLocation = path.join(folder.fsPath, 'devfile.yaml');
         try {
@@ -547,8 +547,7 @@ export class Component extends OpenShiftItem {
                     folder,
                     createStarter,
                     useExistingDevfile,
-                    opts?.devFilePath,
-                    notification
+                    opts?.devFilePath
                 )
             );
 
@@ -717,9 +716,8 @@ export class Component extends OpenShiftItem {
             return createStartDebuggerResult(config.type, 'Component has no ports forwarded.');
     }
 
-    // TODO: remove "openshift.component.revealContextInExplorer" command
     @vsCommand('openshift.component.revealContextInExplorer')
-    public static async revealContextInExplorer(context: OpenShiftComponent): Promise<void> {
+    public static async revealContextInExplorer(context: ComponentWorkspaceFolder): Promise<void> {
         await commands.executeCommand('workbench.view.explorer');
         await commands.executeCommand('revealInExplorer', context.contextPath);
     }

--- a/test/fixtures/components/components.code-workspace
+++ b/test/fixtures/components/components.code-workspace
@@ -1,9 +1,11 @@
 {
 	"folders": [
 		{
+			"name": "comp1",
 			"path": "comp1"
 		},
 		{
+			"name": "comp2",
 			"path": "comp2"
 		}
 	]

--- a/test/integration/activation.test.ts
+++ b/test/integration/activation.test.ts
@@ -1,0 +1,14 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+suite('extension activates', function () {
+    // required to ensure that all the source files are loaded so that coverage number is accurate.
+    // see https://github.com/gotwarlost/istanbul/issues/112
+    suiteSetup(async function () {
+        await require('../../src/extension');
+    });
+
+    test('extension activates');
+});

--- a/test/integration/command.test.ts
+++ b/test/integration/command.test.ts
@@ -4,12 +4,18 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { KubeConfig } from '@kubernetes/client-node';
+import { assert, expect } from 'chai';
+import { ChildProcess } from 'child_process';
+import * as fs from 'fs/promises';
+import * as _ from 'lodash';
+import * as path from 'path';
 import * as tmp from 'tmp';
-import { extensions } from 'vscode';
+import { promisify } from 'util';
+import { EventEmitter, window, workspace } from 'vscode';
 import { CommandText } from '../../src/base/command';
+import { CliChannel } from '../../src/cli';
 import { getInstance } from '../../src/odo';
 import { Command } from '../../src/odo/command';
-import cp = require('child_process');
 
 const ODO = getInstance();
 const kc = new KubeConfig();
@@ -17,138 +23,165 @@ const kc = new KubeConfig();
 kc.loadFromDefault();
 
 const newProjectName = `project${Math.round(Math.random() * 1000)}`;
-const newAppName = 'integration';
-// devfileTypeName = 'nodejs';
 
-async function clone(repositoryURL: string, location: string): Promise<void> {
-    const gitExtension = extensions.getExtension('vscode.git').exports;
-    const git = gitExtension.getAPI(1).git.path;
-    // run 'git clone url location' as external process and return location
-    return new Promise((resolve, reject) => cp.exec(`${git} clone ${repositoryURL} ${location}`, (error: cp.ExecException) => error ? reject(error) : resolve()));
-}
+// tests are assuming your current context is already pointing to test cluster on which you can create and delete namespaces
+suite('odo commands integration', function () {
 
-// tests are assuming your current context is already pointing to test cluster
-suite('odo commands integration', () => {
+    const clusterUrl = process.env.CLUSTER_URL || 'https://api.crc.testing:6443';
+    const username = process.env.CLUSTER_USER || 'developer';
+    const password = process.env.CLUSTER_PASSWORD || 'developer';
 
-    test('odoLoginWithUsernamePassword()', () => {
-        return ODO.execute(
+    suiteSetup(async function() {
+        try {
+            await ODO.execute(Command.odoLogout());
+        } catch (e) {
+            // do nothing
+        }
+        await ODO.execute(
             Command.odoLoginWithUsernamePassword(
-                kc.getCurrentCluster().server,
-                'developer',
-                'developer'
-            )
-        )
+                clusterUrl,
+                username,
+                password,
+            ),
+        );
     });
 
-    test('listProjects()', () => {
-        // test is assuming your current context is aready pointing to test cluster
-        return ODO.execute(
-            Command.listProjects()
-        )
-    });
+    suite('login/logout', function() {
+        let token: string;
 
-    test('listApplications()', () => {
-        // test is assuming your current context is aready pointing to test cluster
-        return ODO.execute(
-            new CommandText('odo project get -o json')
-        ).then(result => {
-            return JSON.parse(result.stdout).metadata.name;
-        }).then(project => {
-            return ODO.execute(
-                Command.listApplications(project)
-            );
+        suiteSetup(async function() {
+            // get current user token and logout
+            await ODO.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+            token = (await ODO.execute(Command.getCurrentUserToken())).stdout;
+            await ODO.execute(Command.odoLogout());
         });
+
+        suiteTeardown(async function() {
+            // log back in for the rest of the tests
+            await ODO.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+        });
+
+        teardown(async function() {
+            await ODO.execute(Command.odoLogout());
+        });
+
+        test('odoLogout()', async function() {
+            try {
+                await ODO.execute(Command.getCurrentUserName())
+                expect.fail('should be unable to get current user, since you are logged out');
+            } catch (_e) {
+                // do nothing
+            }
+        });
+
+        test('odoLoginWithUsernamePassword()', async function () {
+            await ODO.execute(
+                Command.odoLoginWithUsernamePassword(
+                    clusterUrl,
+                    username,
+                    password,
+                ),
+            );
+            const currentUserData = await ODO.execute(Command.getCurrentUserName());
+            expect(currentUserData.stdout).to.equal(username);
+        });
+
+        test('odoLoginWithToken()', async function() {
+            await ODO.execute(Command.odoLoginWithToken(clusterUrl, token));
+            const currentUserData = await ODO.execute(Command.getCurrentUserName());
+            expect(currentUserData.stdout).to.equal(username);
+        });
+
     });
 
-    test('createProject()', ()=> {
-        return ODO.execute(
-            Command.createProject(newProjectName)
-        );
+    test('showServerUrl()', async function() {
+        const cliData = await ODO.execute(Command.showServerUrl());
+        expect(cliData.stdout).to.equal(clusterUrl);
     });
 
-    test('deleteProject()', ()=> {
-        return ODO.execute(
-            Command.deleteProject(newProjectName)
-        );
+    test('getCurrentUserName()', async function() {
+        const cliData = await ODO.execute(Command.getCurrentUserName());
+        expect(cliData.stdout).to.contain(username);
     });
 
-    test('listRegistries()', ()=> {
-        return ODO.execute(
-            Command.listRegistries()
-        );
+    test('getCurrentUserToken()', async function() {
+        await ODO.execute(Command.getCurrentUserToken());
     });
 
-    test('listCatalogComponents()', ()=> {
-        return ODO.execute(
-            Command.listCatalogComponents()
-        );
+    suite('project-related commands', function() {
+
+        suiteSetup(async function() {
+            // createProject()
+            await ODO.execute(Command.createProject(newProjectName));
+        });
+
+        suiteTeardown(async function() {
+            // deleteProject()
+            await ODO.execute(Command.deleteProject(newProjectName));
+        });
+
+        test('listProjects()', function () {
+            return ODO.execute(Command.listProjects());
+        });
+
+        test('getDeployments()', async function () {
+            await ODO.execute(Command.getDeployments(newProjectName));
+        });
+
+        test('setNamespace()', async function() {
+            await ODO.execute(Command.setNamespace(newProjectName));
+        });
+
     });
 
-    test('listCatalogComponentsJson()', ()=> {
-        return ODO.execute(
-            Command.listCatalogComponentsJson()
-        );
+    test('listRegistries()', async function () {
+        return ODO.execute(Command.listRegistries());
     });
 
-    test('listCatalogServices()', ()=> {
-        return ODO.execute(
-            Command.listCatalogServices()
-        );
+    test('addRegistry()', async function() {
+        await ODO.execute(Command.addRegistry('CheRegistry', 'https://example.org', undefined));
     });
 
-    test('listCatalogServicesJson()', ()=> {
-        return ODO.execute(
-            Command.listCatalogServicesJson()
-        );
+    test('removeRegistry()', async function() {
+        await ODO.execute(Command.removeRegistry('CheRegistry'));
     });
 
-    test('printOcVersion()', ()=> {
-        return ODO.execute(
-            Command.printOcVersion()
-        );
+    test('listCatalogComponents()', async function () {
+        await ODO.execute(Command.listCatalogComponents());
     });
 
-    test('printOdoVersion()', ()=> {
-        return ODO.execute(
-            Command.printOdoVersion()
-        );
+    test('listCatalogComponentsJson()', async function () {
+        await ODO.execute(Command.listCatalogComponentsJson());
     });
 
-    test('showServerUrl()', () => {
-        return ODO.execute(
-            Command.showServerUrl()
-        );
+    test('printOcVersion()', async function () {
+        await ODO.execute(Command.printOcVersion());
     });
 
-    test('showConsoleUrl()', async function() {
+    test('printOcVersionJson()', async function() {
+        await ODO.execute(Command.printOcVersionJson());
+    });
+
+    test('printOdoVersion()', async function () {
+        await ODO.execute(Command.printOdoVersion());
+    });
+
+    test('showServerUrl()', async function () {
+        await ODO.execute(Command.showServerUrl());
+    });
+
+    test('showConsoleUrl()', async function () {
         const canI = await ODO.execute(
             new CommandText('oc auth can-i get configmap --namespace openshift-config-managed'),
             undefined,
-            false
-        ).then(result => {
-            return !result.stdout.startsWith('no')
+            false,
+        ).then((result) => {
+            return !result.stdout.startsWith('no');
         });
         if (!canI) {
             this.skip();
         } else {
-            await ODO.execute(
-                Command.showConsoleUrl()
-            );
-            }
-    });
-
-    test('getClusterVersion()', async function() {
-        const clusterVersionExists = await ODO.execute(
-            new CommandText('oc api-resources --verbs=list -o name')
-        ).then((resNames) => {
-            return resNames.stdout.includes('clusterversion');
-        });
-        if (!clusterVersionExists) {
-            this.skip();
-        } else {
-            await ODO.execute(
-                Command.getclusterVersion()
-            );
+            await ODO.execute(Command.showConsoleUrl());
         }
     });
 
@@ -158,56 +191,254 @@ suite('odo commands integration', () => {
         if (!devfileCompType) {
             this.skip();
         } else {
-            await ODO.execute(Command.describeCatalogComponent(devfileCompType.name, devfileCompType.registryName));
+            await ODO.execute(
+                Command.describeCatalogComponent(
+                    devfileCompType.name,
+                    devfileCompType.registryName,
+                ),
+            );
         }
     });
 
-    test('setOpenShiftContext', async () => {
+    test('setOpenShiftContext', async function () {
         await ODO.execute(Command.setOpenshiftContext(kc.currentContext));
     });
 
-    suite('s2i', () => {
-        const project = kc.getContextObject(kc.getCurrentContext()).namespace;
-        const newNodeJsComponent = 'nodejs-local-app';
-        const componentLocation = tmp.dirSync().name;
-        const newUrlName = 'new-url-name';
-        const newUrlNameSecure = 'new-url-name-secure';
-        const nodeJsExGitUrl = 'https://github.com/sclorg/nodejs-ex.git';
+    test.skip('deletePreviouslyPushedResources()');
+    test.skip('listCatalogOperatorBackedServices()');
+    test.skip('addHelmRepo()');
+    test.skip('updateHelmRepo()');
+    test.skip('installHelmChart()');
+    test.skip('unInstallHelmChart()');
+    test.skip('deleteComponentNoContext()');
+    test.skip('deleteContext()');
+    test.skip('deleteCluster()');
+    test.skip('deleteUser()');
+    test.skip('getClusterServiceVersionJson()');
 
-        test('createLocalComponent()', async () => {
-            await clone(nodeJsExGitUrl, componentLocation);
+    suite('services', function() {
+
+        const serviceName = 'my-test-service';
+        const projectName = `my-test-project${_.random(100)}`;
+
+        // taken from https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/kubernetes_deployments.html
+        const serviceFileYaml = //
+            'apiVersion: apps/v1\n' + //
+            'kind: Deployment\n' + //
+            'metadata:\n' + //
+            `  name: ${serviceName}\n` + //
+            'spec:\n' + //
+            '  replicas: 1\n' + //
+            '  selector:\n' + //
+            '    matchLabels:\n' + //
+            '      app: hello-openshift\n' + //
+            '  template:\n' + //
+            '    metadata:\n' + //
+            '      labels:\n' + //
+            '        app: hello-openshift\n' + //
+            '    spec:\n' + //
+            '      containers:\n' + //
+            '      - name: hello-openshift\n' + //
+            '        image: openshift/hello-openshift:latest\n' + //
+            '        ports:\n' + //
+            '        - containerPort: 80\n';
+
+        let serviceFile: string;
+
+        suiteSetup(async function () {
+            serviceFile = await promisify(tmp.file)();
+            await fs.writeFile(serviceFile, serviceFileYaml);
+            await ODO.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+            await ODO.execute(Command.createProject(projectName));
+            await ODO.execute(Command.setNamespace(projectName));
+        });
+
+        suiteTeardown(async function() {
+            await ODO.execute(new CommandText(`oc delete deployment ${serviceName}`));
+            await fs.rm(serviceFile);
+            await ODO.execute(Command.deleteProject(projectName));
+        });
+
+        test('ocCreate()', async function() {
+            await ODO.execute(Command.ocCreate(serviceFile));
+        });
+
+        test('listServiceInstances()', async function() {
+            await ODO.execute(Command.listServiceInstances(projectName));
+        });
+
+    });
+
+    suite('component', function() {
+        const componentName = 'my-test-component';
+        const componentType = 'go';
+        const componentStarterProject = 'go-starter';
+        let componentLocation: string;
+
+        suiteSetup(async function () {
+            await ODO.execute(Command.createProject(newProjectName));
+            await ODO.execute(Command.setNamespace(newProjectName));
+            componentLocation = await promisify(tmp.dir)();
+            await ODO.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+        });
+
+        suiteTeardown(async function () {
+            let toRemove = -1;
+            for (let i = 0; i < workspace.workspaceFolders.length; i++) {
+                if (workspace.workspaceFolders[i].uri.fsPath === componentLocation) {
+                    toRemove = i;
+                    break;
+                }
+            }
+            if (toRemove !== -1) {
+                workspace.updateWorkspaceFolders(toRemove, 1);
+            }
+            await fs.rm(componentLocation, { recursive: true, force: true });
+            await ODO.execute(Command.deleteProject(newProjectName));
+        });
+
+        test('createLocalComponent()', async function () {
             await ODO.execute(
                 Command.createLocalComponent(
-                    'nodejs',
+                    componentType,
+                    'DefaultDevfileRegistry',
+                    componentName,
+                    componentStarterProject,
                     undefined,
-                    newNodeJsComponent,
-                    componentLocation
-                )
+                    undefined,
+                    '2.0.0'
+                ),
+                componentLocation
             );
+            await fs.access(path.join(componentLocation, 'devfile.yaml'));
         });
-        test('listComponents()', async () => {
-            await ODO.execute(Command.listComponents(project, newAppName));
+
+        test('listComponents()', async function () {
+            await ODO.execute(Command.listComponents(newProjectName));
         });
-        test('createComponentCustomUrl(unsecure)', async () => {
-            await ODO.execute(Command.createComponentCustomUrl(newUrlName, '8080', false), componentLocation);
+
+        test('describeComponent()', async function() {
+            const res = await ODO.execute(Command.describeComponent(), componentLocation);
+            expect(res.stdout).contains(componentName);
+            expect(res.stdout).contains('Go');
         });
-        test('createComponentCustomUrl(secure)', async () => {
-            await ODO.execute(Command.createComponentCustomUrl(newUrlNameSecure, '8080', true), componentLocation);
+
+        test('describeComponentJson()', async function () {
+            const res = await ODO.execute(Command.describeComponentJson(), componentLocation);
+            expect(res.stdout).contains(componentName);
+            expect(res.stdout).contains(componentType);
         });
-        test('describeComponentJson()', async () => {
-            await ODO.execute(Command.describeComponentJson(),componentLocation);
+
+        test('analyze()', async function() {
+            const res = await ODO.execute(Command.analyze(), componentLocation);
+            const resObj = JSON.parse(res.stdout);
+            expect(resObj[0]?.name).to.equal(path.basename(componentLocation).toLocaleLowerCase());
+            expect(resObj[0]?.devfile).to.equal(componentType);
         });
-        test('describeComponentNoContextJson()', async () => {
-            await ODO.execute(Command.describeComponentNoContextJson(project, newAppName, newNodeJsComponent),tmp.dirSync().name);
+
+        suite('deploying', function() {
+            // FIXME: Deploy depends on pushing container images to a registry.
+            // The default registry it tries to push to is docker.
+            // We shouldn't try to push to Docker Hub from these tests.
+            // OpenShift comes with a registry built in to the cluster,
+            // and there is a way to set this registry as the one that
+            // odo pushes to during deploy.
+            // However, you need cluster-admin access in order to expose
+            // the registry outside of the cluster and figure out its address.
+            test('deploy(): PENDING');
+            test('undeploy(): PENDING');
         });
-        test('showLog()', async () => {
+
+        test('dev()', async function() {
+            const outputEmitter = new EventEmitter<string>();
+            let devProcess: ChildProcess;
+            function failListener(_error) {
+                assert.fail('odo dev errored before it was closed');
+            }
+            const term = window.createTerminal({
+                name: 'test terminal',
+                pty: {
+                    open: () => {
+                        void CliChannel.getInstance().spawnTool(Command.dev(false)) //
+                            .then(childProcess => {
+                                devProcess = childProcess
+                                devProcess.on('error', failListener);
+                            });
+                    },
+                    close: () => {
+                        if (devProcess) {
+                            devProcess.removeListener('error', failListener);
+                            devProcess.kill('SIGINT');
+                        }
+                    },
+                    handleInput: (data: string) => {
+                        if (data.length) {
+                            if (devProcess) {
+                                devProcess.removeListener('error', failListener);
+                                devProcess.kill('SIGINT');
+                            }
+                        }
+                    },
+                    onDidWrite: outputEmitter.event
+                }
+            });
+            await new Promise<void>(resolve => setTimeout(resolve, 3000));
+            // we instruct the pseudo terminal to close the dev session when any text is sent
+            term.sendText('a');
+            term.dispose();
+        });
+
+        test('showLog()', async function () {
             await ODO.execute(Command.showLog(), componentLocation);
         });
-        test('createComponentCustomUrl(secure)', async () => {
-            await ODO.execute(Command.createComponentCustomUrl(`${newUrlNameSecure}2`, '8080', true), componentLocation);
+
+        test('showLogAndFollow()', async function() {
+            const outputEmitter = new EventEmitter<string>();
+            let devProcess: ChildProcess;
+            function failListener(_error) {
+                assert.fail('showLogAndFollow() errored before it was closed');
+            }
+            const term = window.createTerminal({
+                name: 'test terminal',
+                pty: {
+                    open: () => {
+                        void CliChannel.getInstance().spawnTool(Command.showLogAndFollow()) //
+                            .then(childProcess => {
+                                devProcess = childProcess
+                                devProcess.on('error', failListener);
+                            });
+                    },
+                    close: () => {
+                        if (devProcess) {
+                            devProcess.removeListener('error', failListener);
+                            devProcess.kill('SIGINT');
+                        }
+                    },
+                    handleInput: (data: string) => {
+                        if (data.length) {
+                            if (devProcess) {
+                                devProcess.removeListener('error', failListener);
+                                devProcess.kill('SIGINT');
+                            }
+                        }
+                    },
+                    onDidWrite: outputEmitter.event
+                }
+            });
+            await new Promise<void>(resolve => setTimeout(resolve, 1000));
+            // we instruct the pseudo terminal to close the dev session when any text is sent
+            term.sendText('a');
+            term.dispose();
         });
-        test('deleteComponentUrl', async () => {
-            await ODO.execute(Command.deleteComponentUrl(newUrlName),componentLocation);
+
+        test('deleteComponentConfiguration', async function() {
+            await ODO.execute(Command.deleteComponentConfiguration(), componentLocation);
+            try {
+                await fs.access(path.join(componentLocation, 'devfile.yaml'));
+                this.fail();
+            } catch (_ignored) {
+                // do nothing
+            }
         });
     });
 });

--- a/test/integration/odo3.test.ts
+++ b/test/integration/odo3.test.ts
@@ -11,20 +11,20 @@ import * as Odo3 from '../../src/odo3';
 
 suite('odo 3 integration', () => {
 
-    const clusterUrl = process.env.CLUSTER_URL || 'https://192.168.42.80:8443';
+    const clusterUrl = process.env.CLUSTER_URL || 'https://api.crc.testing:6443';
     const username = process.env.CLUSTER_USER || 'developer';
     const password = process.env.CLUSTER_PASSWORD || 'developer';
 
     const odo = Odo.getInstance();
     const odo3 = Odo3.newInstance();
 
-    let project1: Odo.OpenShiftObject;
-    let project2: Odo.OpenShiftObject;
+    const project1 = 'myproject1';
+    const project2 = 'myproject2';
 
     setup(async function() {
         await odo.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
-        project1 = await odo.createProject('myproject1');
-        project2 = await odo.createProject('myproject2');
+        await odo.createProject(project1);
+        await odo.createProject(project2);
     });
 
     teardown(async function() {

--- a/test/ui/Jenkinsfile
+++ b/test/ui/Jenkinsfile
@@ -13,6 +13,12 @@ node('rhel8') {
     }
 
     withEnv(['JUNIT_REPORT_PATH=report.xml']) {
+        stage('integration tests') {
+            wrap([$class: 'Xvnc']) {
+                sh "npm run test-integration"
+                junit 'report.xml'
+            }
+        }
         stage('UI smoke test') {
             wrap([$class: 'Xvnc']) {
                 sh "npm run smoke-test"

--- a/test/unit/debug.test.ts
+++ b/test/unit/debug.test.ts
@@ -5,10 +5,10 @@
 
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
-import { DebugSession, TreeItem, debug, Disposable } from 'vscode';
+import { DebugSession, Disposable, TreeItem, debug } from 'vscode';
 import { DebugSessionsView } from '../../src/debug';
+import { ContextType } from '../../src/odo';
 import { TestItem } from './openshift/testOSItem';
-import { ContextType, OdoImpl } from '../../src/odo';
 import sinon = require('sinon');
 
 const {expect} = chai;
@@ -51,7 +51,6 @@ suite('Debug Sessions View', () => {
             stopEmitter = cb;
             return new Disposable(()=> { return; });
         });
-        sandbox.stub(OdoImpl.prototype, 'getOpenShiftObjectByContext').returns(componentItem);
         view = new DebugSessionsView();
     });
 

--- a/test/unit/explorer.test.ts
+++ b/test/unit/explorer.test.ts
@@ -7,19 +7,17 @@ import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import { commands, Uri } from 'vscode';
 import { OpenShiftExplorer } from '../../src/explorer';
-import { OdoImpl, ContextType } from '../../src/odo';
-import { TestItem } from './openshift/testOSItem';
+import { OdoImpl } from '../../src/odo';
 import sinon = require('sinon');
 
 const {expect} = chai;
 chai.use(sinonChai);
 
 suite('OpenShift Application Explorer', () => {
-    const clusterItem = new TestItem(null, 'cluster', ContextType.CLUSTER);
     const sandbox = sinon.createSandbox();
 
     setup(() => {
-        sandbox.stub(OdoImpl.prototype, 'getClusters').resolves([clusterItem]);
+        sandbox.stub(OdoImpl.prototype, 'getActiveCluster').resolves('cluster');
     });
 
     teardown(() => {

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -14,7 +14,8 @@ import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as vscode from 'vscode';
 import { CommandText } from '../../src/base/command';
-import { OdoImpl, OpenShiftApplication, OpenShiftCluster, OpenShiftProject } from '../../src/odo';
+import { OdoImpl } from '../../src/odo';
+import { Project } from '../../src/odo/project';
 import { Progress } from '../../src/util/progress';
 import path = require('path');
 
@@ -50,10 +51,10 @@ function genComponentJson(p: string, a: string, n: string, c: string ): string {
 
 suite('openshift toolkit Extension', () => {
     let sandbox: sinon.SinonSandbox;
-
-    const clusterItem = new OpenShiftCluster('cluster');
-    const projectItem = new OpenShiftProject(clusterItem, 'myproject', true);
-    const appItem = new OpenShiftApplication(projectItem, 'app1');
+    const projectItem: Project = {
+        name: 'myproject',
+        active: true,
+    };
     const fixtureFolder = path.join(__dirname, '..', '..', '..', 'test', 'fixtures').normalize();
     const comp2Uri = vscode.Uri.file(path.join(fixtureFolder, 'components', 'comp2'));
 
@@ -87,15 +88,12 @@ suite('openshift toolkit Extension', () => {
             }
             return { error: undefined, stdout: '', stderr: ''};
         });
-        sandbox.stub(OdoImpl.prototype, '_getClusters').resolves([clusterItem]);
-        sandbox.stub(OdoImpl.prototype, '_getProjects').resolves([projectItem]);
-        sandbox.stub(OdoImpl.prototype, '_getApplications').resolves([appItem]);
-        sandbox.stub(OdoImpl.prototype, '_getServices').resolves([]);
+        sandbox.stub(OdoImpl.prototype, 'getActiveCluster').resolves('cluster');
+        sandbox.stub(OdoImpl.prototype, 'getProjects').resolves([projectItem]);
     });
 
     teardown(() => {
         sandbox.restore();
-        OdoImpl.Instance.clearCache();
     });
 
     test('Extension should be present', () => {

--- a/test/unit/oc.test.ts
+++ b/test/unit/oc.test.ts
@@ -9,9 +9,9 @@ import * as sinonChai from 'sinon-chai';
 import { window } from 'vscode';
 import { CliChannel } from '../../src/cli';
 import { Oc } from '../../src/oc';
-import { ContextType, getInstance } from '../../src/odo';
+import { getInstance } from '../../src/odo';
+import { Project } from '../../src/odo/project';
 import { ToolsConfig } from '../../src/tools';
-import { TestItem } from './openshift/testOSItem';
 
 const {expect} = chai;
 chai.use(sinonChai);
@@ -22,8 +22,7 @@ suite('Oc', function() {
     let warnStub: sinon.SinonStub<[string, import('vscode').MessageOptions, ...import('vscode').MessageItem[]], Thenable<import('vscode').MessageItem>>;
     let execStub: sinon.SinonStub;
     let getActiveProjectStub: sinon.SinonStub;
-    const clusterItem = new TestItem(null, 'cluster', ContextType.CLUSTER);
-    const projectItem = new TestItem(clusterItem, 'my-project', ContextType.PROJECT);
+    const projectItem: Project = { name: 'my-project', active: true };
 
     const sampleYaml = `
         # manifests.yaml
@@ -47,7 +46,7 @@ suite('Oc', function() {
         execStub = sandbox.stub(CliChannel.prototype, 'execute');
         getActiveProjectStub = sandbox.stub(getInstance(), 'getActiveProject').resolves('my-project');
         detectOrDownloadStub = sandbox.stub(ToolsConfig, 'detect').resolves('path');
-        sandbox.stub(getInstance(), 'getClusters').resolves([clusterItem]);
+        sandbox.stub(getInstance(), 'getActiveCluster').resolves('cluster');
         sandbox.stub(getInstance(), 'getProjects').resolves([projectItem]);
     });
 

--- a/test/unit/openshift/cluster.test.ts
+++ b/test/unit/openshift/cluster.test.ts
@@ -3,18 +3,17 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
-import { OdoImpl, ContextType } from '../../../src/odo';
+import * as sinonChai from 'sinon-chai';
+import * as vscode from 'vscode';
+import { CliExitData } from '../../../src/cli';
+import { OpenShiftExplorer } from '../../../src/explorer';
+import { ContextType, OdoImpl } from '../../../src/odo';
 import { Command } from '../../../src/odo/command';
 import { Cluster } from '../../../src/openshift/cluster';
-import { OpenShiftExplorer } from '../../../src/explorer';
-import { CliExitData } from '../../../src/cli';
+import { TokenStore, getVscodeModule } from '../../../src/util/credentialManager';
 import { TestItem } from './testOSItem';
-import OpenShiftItem from '../../../src/openshift/openshiftItem';
-import { getVscodeModule, TokenStore } from '../../../src/util/credentialManager';
 import pq = require('proxyquire');
 
 const {expect} = chai;
@@ -51,8 +50,6 @@ suite('Openshift/Cluster', () => {
     const testUser = 'user';
     const password = 'password';
     const token = 'token';
-    const projectItem = new TestItem(null, 'project', ContextType.PROJECT);
-    const appItem = new TestItem(projectItem, 'application', ContextType.APPLICATION);
 
     setup(() => {
         sandbox = sinon.createSandbox();
@@ -63,7 +60,6 @@ suite('Openshift/Cluster', () => {
         infoStub = sandbox.stub<any, any>(vscode.window, 'showInformationMessage').resolves('Yes');
         quickPickStub = sandbox.stub(vscode.window, 'showQuickPick').resolves({label: 'Credentials', description: 'Log in to the given server using credentials'});
         loginStub = sandbox.stub(OdoImpl.prototype, 'requireLogin').resolves(true);
-        sandbox.stub(OpenShiftItem, 'getApplicationNames').resolves([appItem]);
     });
 
     teardown(() => {
@@ -426,13 +422,13 @@ suite('Openshift/Cluster', () => {
         });
 
         test('opens URL from first cluster label', () => {
-            sandbox.stub(OdoImpl.prototype, 'getClusters').resolves([cluster]);
+            sandbox.stub(OdoImpl.prototype, 'getActiveCluster').resolves(cluster.getName());
             clusterMock.openshiftConsole();
             openStub.calledOnceWith('http://localhost');
         });
 
         test('shows error message if node label is not URL', () => {
-            sandbox.stub(OdoImpl.prototype, 'getClusters').resolves([cluster]);
+            sandbox.stub(OdoImpl.prototype, 'getActiveCluster').resolves(cluster.getName());
             const errMsgStub = sandbox.stub(vscode.window, 'showErrorMessage');
             clusterMock.openshiftConsole();
             errMsgStub.calledOnceWith('localhost', undefined);

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -12,12 +12,11 @@ import * as vscode from 'vscode';
 import { ContextType, OdoImpl } from '../../../src/odo';
 import { Command } from '../../../src/odo/command';
 import { ComponentTypeAdapter } from '../../../src/odo/componentType';
+import { Project } from '../../../src/odo/project';
 import { ComponentWorkspaceFolder } from '../../../src/odo/workspace';
-import OpenShiftItem from '../../../src/openshift/openshiftItem';
+import * as openShiftComponent from '../../../src/openshift/component';
 import * as Util from '../../../src/util/async';
-import { Platform } from '../../../src/util/platform';
-import { Progress } from '../../../src/util/progress';
-import { AddWorkspaceFolder } from '../../../src/util/workspace';
+import { comp1Folder } from '../../fixtures';
 import { TestItem } from './testOSItem';
 import pq = require('proxyquire');
 import fs = require('fs-extra');
@@ -34,13 +33,13 @@ suite('OpenShift/Component', function() {
     const comp2Uri = vscode.Uri.file(path.join(fixtureFolder, 'components', 'comp2'));
     const wsFolder1 = { uri: comp1Uri, index: 0, name: 'comp1' };
     const wsFolder2 = { uri: comp2Uri, index: 1, name: 'comp2' };
-    const clusterItem = new TestItem(null, 'cluster', ContextType.CLUSTER);
-    const projectItem = new TestItem(clusterItem, 'myproject', ContextType.PROJECT);
-    const appItem = new TestItem(projectItem, 'app1', ContextType.APPLICATION);
-    const componentItem = new TestItem(appItem, 'comp1', ContextType.COMPONENT_PUSHED, [], comp1Uri, 'https://host/proj/app/comp1', 'nodejs');
-    const errorMessage = 'FATAL ERROR';
-    let getApps: sinon.SinonStub;
-    let Component: any;
+    const projectItem = { name: 'myproject', active: false } as Project;
+    const componentItem = new TestItem(undefined, 'comp1', ContextType.COMPONENT_PUSHED, [], comp1Uri, 'https://host/proj/app/comp1', 'nodejs');
+    const componentItem1: ComponentWorkspaceFolder = {
+        contextPath: comp1Folder,
+        component: undefined,
+    };
+    let Component: typeof openShiftComponent.Component;
     let commandStub: sinon.SinonStub;
 
     setup(() => {
@@ -49,12 +48,9 @@ suite('OpenShift/Component', function() {
         Component = pq('../../../src/openshift/component', {}).Component;
         termStub = sandbox.stub(OdoImpl.prototype, 'executeInTerminal');
         execStub = sandbox.stub(OdoImpl.prototype, 'execute').resolves({ stdout: '', stderr: undefined, error: undefined });
-        sandbox.stub(OdoImpl.prototype, 'getClusters').resolves([clusterItem]);
+        sandbox.stub(OdoImpl.prototype, 'getActiveCluster').resolves('cluster');
         sandbox.stub(OdoImpl.prototype, 'getProjects').resolves([projectItem]);
-        sandbox.stub(OdoImpl.prototype, 'getApplications').resolves([]);
         sandbox.stub(Util, 'wait').resolves();
-        getApps = sandbox.stub(OpenShiftItem, 'getApplicationNames').resolves([appItem]);
-        sandbox.stub(OpenShiftItem, 'getComponentNames').resolves([componentItem]);
         commandStub = sandbox.stub(vscode.commands, 'executeCommand').resolves();
         sandbox.stub()
     });
@@ -63,173 +59,11 @@ suite('OpenShift/Component', function() {
         sandbox.restore();
     });
 
-    suite.skip('create component with no context', () => {
-
-        setup(() => {
-            quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-            quickPickStub.onFirstCall().resolves(undefined);
-        });
-
-        test('asks for context and exits if not provided', async () => {
-            const result = await Component.create(null);
-            expect(result).null;
-            expect(getApps).calledOnce;
-        });
-    });
-
     suite('reveal in explorer', () => {
 
         test('called revealInExplorer with component\'s context', async () => {
-            await Component.revealContextInExplorer(componentItem);
-            expect(commandStub).calledWith('revealInExplorer', componentItem.contextPath);
-        });
-    });
-
-    suite.skip('create', () => {
-        const componentType = new ComponentTypeAdapter('nodejs', 'latest', 'builder,nodejs');
-        const folder = { uri: { fsPath: 'folder' } };
-        let inputStub: sinon.SinonStub;
-        let progressFunctionStub: sinon.SinonStub;
-
-        setup(() => {
-            quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-            quickPickStub.onFirstCall().resolves({ label: 'file:///c:/Temp', folder: vscode.Uri.parse('file:///c:/Temp') });
-            quickPickStub.onSecondCall().resolves(componentType);
-            inputStub = sandbox.stub(vscode.window, 'showInputBox');
-            progressFunctionStub = sandbox.stub(Progress, 'execFunctionWithProgress').yields();
-            sandbox.stub(vscode.workspace, 'workspaceFolders').value([wsFolder1, wsFolder2]);
-        });
-
-        test('returns empty string and step name in cancelled_step property when cancelled', async () => {
-            quickPickStub.onFirstCall().resolves(undefined);
-            const result = await Component.create(appItem);
-
-            expect(result.toString()).equals('');
-            expect(result.properties.cancelled_step).equals('contextFolder');
-        });
-
-        test('errors when a subcommand fails', async () => {
-            quickPickStub.onFirstCall().rejects(new Error(errorMessage));
-            let expectedError: Error;
-            try {
-                await Component.create(appItem);
-            } catch (error) {
-                expectedError = error;
-            }
-            expect(expectedError.message).equals(errorMessage);
-        });
-
-        suite('from local workspace', () => {
-
-            setup(() => {
-                inputStub.resolves(componentItem.getName());
-                quickPickStub.onFirstCall().resolves({ label: folder.uri.fsPath, uri: folder.uri });
-            });
-
-            test('happy path works', async () => {
-                const result = await Component.create(appItem);
-
-                expect(result.toString()).equals(`Component '${componentItem.getName()}' successfully created. Perform actions on it from Components View.`);
-                expect(progressFunctionStub).calledOnceWith(
-                    `Creating new Component '${componentItem.getName()}'`);
-                expect(execStub).calledWith(Command.createLocalComponent(componentType.name, undefined, componentItem.getName(), folder.uri.fsPath));
-            });
-
-            test('returns empty string and step name in cancelled_step property when no option is selected from quick pick', async () => {
-                quickPickStub.onFirstCall().resolves(undefined);
-                const result = await Component.createFromLocal(null);
-
-                expect(result.toString()).equals('');
-                expect(result.properties.cancelled_step).equals('applicationName')
-            });
-
-            test('returns empty string and step name in cancelled_step property when no folder selected', async () => {
-                quickPickStub.onFirstCall().resolves(undefined);
-                const result = await Component.create(appItem);
-
-                expect(result.toString()).equals('');
-            });
-
-            test('returns empty string and step name in cancelled_step property when no new context folder selected', async () => {
-                quickPickStub.onFirstCall().resolves(AddWorkspaceFolder);
-                sandbox.stub(vscode.window, 'showOpenDialog').resolves(null);
-                const result = await Component.create(appItem);
-
-                expect(result.toString()).equals('');
-            });
-
-            test('returns empty string and step name in cancelled_step property when no new context folder selected', async () => {
-                quickPickStub.onFirstCall().resolves(AddWorkspaceFolder);
-                sandbox.stub(vscode.window, 'showOpenDialog').resolves(null);
-                const result = await Component.create(appItem);
-
-                expect(result.toString()).equals('');
-            });
-
-            test('ask again to select new context folder if selected one has odo component in it', async () => {
-                quickPickStub.restore();
-                quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-                quickPickStub.onFirstCall().resolves(AddWorkspaceFolder);
-                quickPickStub.onSecondCall().resolves(AddWorkspaceFolder)
-                const sod = sandbox.stub(vscode.window, 'showOpenDialog');
-                sod.onFirstCall().resolves([vscode.Uri.parse('file:///c%3A/Temp')]);
-                sandbox.stub(fs, 'existsSync').returns(true);
-                const sim = sandbox.stub(vscode.window, 'showInformationMessage').resolves();
-                sod.onSecondCall().resolves(null);
-                const result = await Component.create(appItem);
-
-                expect(result.toString()).equals('');
-                expect(sim).calledWith('The folder selected already contains a component. Please select a different folder.');
-            });
-
-            test('returns empty string and step name in cancelled_step property when no component name selected', async () => {
-                inputStub.resolves();
-                const result = await Component.create(appItem);
-
-                expect(result.toString()).equals('');
-            });
-
-            test('returns empty string and step name in cancelled_step property when no component type selected', async () => {
-                quickPickStub.onSecondCall().resolves(undefined);
-                const result = await Component.create(appItem);
-
-                expect(result.toString()).equals('');
-            });
-        });
-    });
-
-    suite.skip('deployRootWorkspaceFolder', () => {
-
-        test('starts new component workflow if provided folder is not odo component and pushes new component', async () => {
-            const o = new TestItem(undefined, 'object', ContextType.COMPONENT);
-            const getOso = sandbox.stub(OdoImpl.prototype, 'getOpenShiftObjectByContext')
-            getOso.onFirstCall().returns(undefined);
-            getOso.onSecondCall().returns(o)
-            sandbox.stub(Component, 'createFromRootWorkspaceFolder').resolves('Created successfully!');
-            const push = sandbox.stub(Component, 'push').resolves();
-            await Component.deployRootWorkspaceFolder(vscode.Uri.file(Platform.getUserHomePath()), 'component-type');
-            expect(push).calledWith(o);
-        });
-
-        test('skips new component workflow and pushes component to cluster if provided folder has component already', async () => {
-            const o = new TestItem(undefined, 'object', ContextType.COMPONENT);
-            const getOso = sandbox.stub(OdoImpl.prototype, 'getOpenShiftObjectByContext')
-            getOso.onFirstCall().returns(o);
-            const create = sandbox.stub(Component, 'createFromRootWorkspaceFolder').resolves('Created successfully!');
-            const push = sandbox.stub(Component, 'push').resolves();
-            await Component.deployRootWorkspaceFolder(vscode.Uri.file(Platform.getUserHomePath()), 'component-type');
-            expect(create).not.called;
-            expect(push).calledWith(o);
-        });
-
-        test('starts new component workflow if provided folder is not odo component and does not call push if workflow canceled', async () => {
-            const getOso = sandbox.stub(OdoImpl.prototype, 'getOpenShiftObjectByContext')
-            getOso.onFirstCall().returns(undefined);
-            getOso.onSecondCall().returns(null);
-            sandbox.stub(Component, 'createFromRootWorkspaceFolder').resolves(null);
-            const push = sandbox.stub(Component, 'push').resolves();
-            await Component.deployRootWorkspaceFolder(vscode.Uri.file(Platform.getUserHomePath()), 'component-type');
-            expect(push).not.called;
+            await Component.revealContextInExplorer(componentItem1);
+            expect(commandStub).calledWith('revealInExplorer', componentItem1.contextPath);
         });
     });
 
@@ -241,33 +75,32 @@ suite('OpenShift/Component', function() {
 
         setup(() => {
             quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-            quickPickStub.onFirstCall().resolves(appItem);
             inputStub = sandbox.stub(vscode.window, 'showInputBox');
         });
 
         test('returns empty string and step name in cancelled_step property when no option selected from quick pick', async () => {
             quickPickStub.onFirstCall().resolves(undefined);
-            const result = await Component.createFromRootWorkspaceFolder(null);
+            const result = await Component.createFromRootWorkspaceFolder(null, [], {});
             expect(result.toString()).equals('');
         });
 
         test('returns empty string and step name in cancelled_step property when no component type selected', async () => {
             inputStub.resolves(componentItem.getName());
             quickPickStub.onSecondCall().resolves(null);
-            const result = await Component.createFromRootWorkspaceFolder(folder);
+            const result = await Component.createFromRootWorkspaceFolder(folder, [], {});
             expect(result.toString()).equals('');
         });
 
         test('returns empty string and step name in cancelled_step property when no component name is provided', async () => {
             inputStub.resolves();
-            const result = await Component.createFromRootWorkspaceFolder(folder);
+            const result = await Component.createFromRootWorkspaceFolder(folder, [], {});
             expect(result.toString()).equals('');
         });
 
         test('happy path works', async () => {
             inputStub.resolves(componentItem.getName());
             quickPickStub.onSecondCall().resolves(componentType);
-            const result = await Component.createFromRootWorkspaceFolder(folder);
+            const result = await Component.createFromRootWorkspaceFolder(folder, [], {});
             expect(result.toString()).equals(`Component '${componentItem.getName()}' successfully created. Perform actions on it from Components View.`);
         });
 
@@ -281,7 +114,7 @@ suite('OpenShift/Component', function() {
                     ''
                 )
             ]);
-            const result = await Component.createFromRootWorkspaceFolder(folder, [], undefined, 'componentType1');
+            const result = await Component.createFromRootWorkspaceFolder(folder, [], { componentTypeName: 'componentType1'});
             expect(result.toString()).equals(`Component '${componentItem.getName()}' successfully created. Perform actions on it from Components View.`);
             expect(quickPickStub).calledOnce;
             expect(quickPickStub).have.not.calledWith({ placeHolder: 'Component type' })
@@ -307,7 +140,7 @@ suite('OpenShift/Component', function() {
             sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([
                 componentType1, componentType2
             ]);
-            const result = await Component.createFromRootWorkspaceFolder(folder, [], undefined, 'componentType1');
+            const result = await Component.createFromRootWorkspaceFolder(folder, [], {componentTypeName: 'componentType1'});
             expect(result.toString()).equals(`Component '${componentItem.getName()}' successfully created. Perform actions on it from Components View.`);
             expect(quickPickStub).calledTwice;
             expect(quickPickStub).calledWith([componentType1, componentType2]);
@@ -325,7 +158,7 @@ suite('OpenShift/Component', function() {
             sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([
                 componentType1
             ]);
-            const result = await Component.createFromRootWorkspaceFolder(folder, [], undefined, 'componentType1');
+            const result = await Component.createFromRootWorkspaceFolder(folder, [], {componentTypeName: 'componentType1'});
             expect(result.toString()).equals(`Component '${componentItem.getName()}' successfully created. Perform actions on it from Components View.`);
             expect(quickPickStub).calledTwice;
             expect(quickPickStub).calledWith([componentType1]);
@@ -333,248 +166,15 @@ suite('OpenShift/Component', function() {
 
         test('skips component type selection if devfile exists and use devfile name as initial value for component name', async () => {
             sandbox.stub(fs, 'existsSync').returns(true);
-            sandbox.stub(Component, 'getName').returns(componentItem.getName());
+            sandbox.stub(Component, 'getName').resolves(componentItem.getName());
             sandbox.stub(fs, 'readFileSync').returns(
                 'metadata:\n' +
                 '  name: componentName'
             );
-            const result = await Component.createFromRootWorkspaceFolder(folder, [], undefined, 'componentType1');
+            const result = await Component.createFromRootWorkspaceFolder(folder, [], {componentTypeName: 'componentType1'});
             expect(result.toString()).equals(`Component '${componentItem.getName()}' successfully created. Perform actions on it from Components View.`);
         });
 
-    });
-
-    suite.skip('unlinkComponent', () => {
-
-        let getLinkDataStub: sinon.SinonStub;
-        const mockData = `{
-            "kind": "Component",
-            "apiVersion": "odo.openshift.io/v1alpha1",
-            "metadata": {
-                "name": "comp2",
-                "creationTimestamp": null
-            },
-            "spec": {
-                "type": "nodejs",
-                "source": "file:///Users/nodejs-ex"
-            },
-            "status": {
-                "active": false,
-                "linkedServices": [{
-                    "ServiceName": "service1"
-                }],
-                "linkedComponents": {
-                    "comp1": ["8080"]
-                }
-            }
-        }`;
-
-        setup(() => {
-            quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-            quickPickStub.onFirstCall().resolves({
-                label: 'Component',
-                description: 'Unlink Component'
-            });
-            getLinkDataStub = sandbox.stub(Component, 'getLinkData').resolves({
-                kind: 'Component',
-                apiVersion: 'odo.openshift.io/v1alpha1',
-                metadata: {
-                    creationTimestamp: null,
-                    name: 'comp1',
-                    namespace: 'myproject'
-                },
-                spec: {
-                    type: 'nodejs',
-                    source: 'file:///Users/nodejs-ex'
-                },
-                status: {
-                    linkedComponents: {
-                        comp2: ['8080']
-                    },
-                    state: 'Pushed'
-                }
-            });
-            execStub.resolves({ error: undefined, stdout: mockData, stderr: '' });
-        });
-
-        test('returns null when no option is selected', async () => {
-            quickPickStub.onFirstCall().resolves(undefined);
-            const result = await Component.unlink(componentItem);
-            expect(result).null;
-        });
-
-        test('returns null when no option is selected from quick pick', async () => {
-            quickPickStub.onSecondCall().resolves(undefined);
-            const result = await Component.unlink(null);
-            expect(result).null;
-        });
-
-        test('works from context menu', async () => {
-            quickPickStub.resolves('comp2');
-            const result = await Component.unlink(componentItem);
-
-            expect(result).equals(`Component 'comp2' has been successfully unlinked from the Component '${componentItem.getName()}'`);
-        });
-
-        test('returns null when no component selected to unlink', async () => {
-            quickPickStub.resolves();
-            const result = await Component.unlink(componentItem);
-
-            expect(result).null;
-        });
-
-        test('errors when a command fails', async () => {
-            quickPickStub.onFirstCall().resolves('comp2');
-            quickPickStub.onSecondCall().resolves('8080');
-            execStub.onFirstCall().rejects(errorMessage);
-            let savedErr: any;
-
-            try {
-                await Component.unlinkComponent(componentItem);
-            } catch (err) {
-                savedErr = err;
-            }
-            expect(savedErr.message).equals(`Failed to unlink Component with error '${errorMessage}'`);
-        });
-
-        test('calls the appropriate error message when no link component found', async () => {
-            getLinkDataStub.onFirstCall().resolves({
-                kind: 'Component',
-                apiVersion: 'odo.openshift.io/v1alpha1',
-                metadata: {
-                    name: 'comp2',
-                    creationTimestamp: null
-                },
-                spec: {
-                    type: 'nodejs',
-                    source: 'file:///Users/nodejs-ex'
-                },
-                status: {
-                    active: false
-                }
-            });
-            try {
-                await Component.unlink(componentItem);
-            } catch (err) {
-                expect(err.message).equals('No linked Components found');
-                return;
-            }
-            expect.fail();
-        });
-
-        test('Should able to unlink the component', async () => {
-            await Component.unlinkAllComponents(componentItem);
-            execStub.calledOnce;
-        });
-    });
-
-    suite.skip('unlinkService', () => {
-
-        const mockData = `{
-            "kind": "Component",
-            "apiVersion": "odo.openshift.io/v1alpha1",
-            "metadata": {
-                "name": "comp2",
-                "creationTimestamp": null
-            },
-            "spec": {
-                "type": "nodejs",
-                "source": "file:///Users/nodejs-ex"
-            },
-            "status": {
-                "active": false,
-                "linkedServices": [{
-                    "ServiceName": "service1"
-                }],
-                "linkedComponents": {
-                    "comp1": ["8080"]
-                }
-            }
-        }`;
-
-        setup(() => {
-            quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-            quickPickStub.onFirstCall().resolves({
-                label: 'Service',
-                description: 'Unlink Component'
-            });
-            execStub.resolves({ error: undefined, stdout: mockData, stderr: '' });
-        });
-
-        test('works from context menu', async () => {
-            quickPickStub.resolves('service1');
-            const result = await Component.unlink(componentItem);
-
-            expect(result).equals(`Service 'service1' has been successfully unlinked from the Component '${componentItem.getName()}'`);
-        });
-
-        test('returns null when no option is selected from quick pick', async () => {
-            quickPickStub.onSecondCall().resolves(undefined);
-            const result = await Component.unlink(null);
-            expect(result).null;
-        });
-
-        test('returns null when no service selected to unlink', async () => {
-            quickPickStub.resolves();
-            const result = await Component.unlink(componentItem);
-
-            expect(result).null;
-        });
-
-        test('errors when a command fails', async () => {
-            sandbox.stub(Component, 'getLinkData').resolves({
-                kind: 'Component',
-                apiVersion: 'odo.openshift.io/v1alpha1',
-                metadata: {
-                    name: 'comp2',
-                    creationTimestamp: null
-                },
-                spec: {
-                    type: 'nodejs',
-                    source: 'file:///Users/nodejs-ex'
-                },
-                status: {
-                    linkedServices: [{
-                        'ServiceName': 'service'
-                    }]
-                }
-            });
-            quickPickStub.onFirstCall().resolves('service');
-            execStub.onFirstCall().rejects(errorMessage);
-            let savedErr: any;
-
-            try {
-                await Component.unlinkService(componentItem);
-            } catch (err) {
-                savedErr = err;
-            }
-            expect(savedErr.message).equals(`Failed to unlink Service with error '${errorMessage}'`);
-        });
-
-        test('calls the appropriate error message when no link component found', async () => {
-            sandbox.stub(Component, 'getLinkData').resolves({
-                kind: 'Component',
-                apiVersion: 'odo.openshift.io/v1alpha1',
-                metadata: {
-                    name: 'comp2',
-                    creationTimestamp: null
-                },
-                spec: {
-                    type: 'nodejs',
-                    source: 'file:///Users/nodejs-ex'
-                },
-                status: {
-                    active: false
-                }
-            });
-            try {
-                await Component.unlink(componentItem);
-            } catch (err) {
-                expect(err.message).equals('No linked Services found');
-                return;
-            }
-            expect.fail();
-        });
     });
 
     suite('deleteConfigurationFiles', function() {
@@ -682,7 +282,6 @@ suite('OpenShift/Component', function() {
     suite.skip('describe', () => {
         setup(() => {
             quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-            quickPickStub.onFirstCall().resolves(appItem);
             quickPickStub.onSecondCall().resolves(componentItem);
         });
 
@@ -693,7 +292,7 @@ suite('OpenShift/Component', function() {
         });
 
         test('calls the correct odo command', async () => {
-            await Component.describe(componentItem);
+            await Component.describe(componentItem1);
             expect(termStub).calledOnceWith(Command.describeComponent());
         });
 
@@ -706,12 +305,11 @@ suite('OpenShift/Component', function() {
     suite.skip('log', () => {
         setup(() => {
             quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-            quickPickStub.onFirstCall().resolves(appItem);
             quickPickStub.onSecondCall().resolves(componentItem);
         });
 
         test('log calls the correct odo command', async () => {
-            await Component.log(componentItem);
+            await Component.log(componentItem1);
             expect(termStub).calledOnceWith(Command.showLog());
         });
 
@@ -724,7 +322,6 @@ suite('OpenShift/Component', function() {
     suite.skip('followLog', () => {
         setup(() => {
             quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
-            quickPickStub.onFirstCall().resolves(appItem);
             quickPickStub.onSecondCall().resolves(componentItem);
         });
 
@@ -736,7 +333,7 @@ suite('OpenShift/Component', function() {
         });
 
         test('followLog calls the correct odo command', async () => {
-            await Component.followLog(componentItem);
+            await Component.followLog(componentItem1);
             expect(termStub).calledOnceWith(Command.showLogAndFollow());
         });
 
@@ -748,8 +345,7 @@ suite('OpenShift/Component', function() {
 
     suite.skip('debug', () => {
         test('without context exits if no component selected', async () => {
-            sandbox.stub(OpenShiftItem, 'getOpenShiftCmdData').resolves(null);
-            const result = await Component.debug();
+            const result = await Component.debug(undefined);
             expect(result).is.null;
             expect(execStub).not.called;
         });
@@ -786,7 +382,10 @@ suite('OpenShift/Component', function() {
         });
 
         test('shows warning if supported language is not detected for component', async () => {
-            const devfileComponentItem2 = new TestItem(appItem, 'comp1', ContextType.COMPONENT_PUSHED, [], comp1Uri, 'https://host/proj/app/comp1', 'node-js');
+            const devfileComponentItem2: ComponentWorkspaceFolder = {
+                contextPath: comp1Folder,
+                component: undefined,
+            };
             sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([
                 new ComponentTypeAdapter(
                     'componentType3',
@@ -802,7 +401,7 @@ suite('OpenShift/Component', function() {
         });
 
         function mockComponent(startDebugging: sinon.SinonStub<any[], any>, waitPort: sinon.SinonStub<any[], any>, exitCode = 0) {
-            return Component = pq('../../../src/openshift/component', {
+            return pq('../../../src/openshift/component', {
                 vscode: {
                     debug: {
                         startDebugging
@@ -830,19 +429,18 @@ suite('OpenShift/Component', function() {
                     }),
                 },
                 'wait-port': waitPort,
-            }).Component;
+            }).Component as typeof openShiftComponent.Component;
         }
         test('starts java debugger for devfile component with java in builder image', async () => {
             const startDebugging = sandbox.stub().resolves(true);
             const waitPort = sandbox.stub().resolves(true);
             Component = mockComponent(startDebugging, waitPort);
 
-            const devfileComponentItem2 = new TestItem(appItem, 'comp1', ContextType.COMPONENT_PUSHED, [], comp1Uri, 'https://host/proj/app/comp1', 'java');
-            sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([]);
-            devfileComponentItem2.builderImage = {
-                name: 'java',
-                tag: undefined
+            const devfileComponentItem2: ComponentWorkspaceFolder = {
+                contextPath: comp1Folder,
+                component: undefined,
             };
+            sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([]);
             sandbox.stub(vscode.extensions, 'getExtension').returns({} as vscode.Extension<any>);
             const resultPromise = Component.debug(devfileComponentItem2);
             const result = await resultPromise;
@@ -855,12 +453,11 @@ suite('OpenShift/Component', function() {
             const waitPort = sandbox.stub().resolves(true)
             Component = mockComponent(startDebugging, waitPort);
 
-            const devfileComponentItem2 = new TestItem(appItem, 'comp1', ContextType.COMPONENT_PUSHED, [], comp1Uri, 'https://host/proj/app/comp1', 'python');
-            sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([]);
-            devfileComponentItem2.builderImage = {
-                name: 'python',
-                tag: undefined
+            const devfileComponentItem2: ComponentWorkspaceFolder = {
+                contextPath: comp1Folder,
+                component: undefined,
             };
+            sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([]);
             sandbox.stub(vscode.extensions, 'getExtension').returns({} as vscode.Extension<any>);
             const resultPromise = Component.debug(devfileComponentItem2);
             const result = await resultPromise;
@@ -873,12 +470,11 @@ suite('OpenShift/Component', function() {
             const waitPort = sandbox.stub().resolves(true)
             Component = mockComponent(startDebugging, waitPort);
 
-            const devfileComponentItem2 = new TestItem(appItem, 'comp1', ContextType.COMPONENT_PUSHED, [], comp1Uri, 'https://host/proj/app/comp1', 'nodejs');
-            sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([]);
-            devfileComponentItem2.builderImage = {
-                name: 'python',
-                tag: undefined
+            const devfileComponentItem2: ComponentWorkspaceFolder = {
+                contextPath: comp1Folder,
+                component: undefined,
             };
+            sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([]);
             sandbox.stub(vscode.extensions, 'getExtension').returns({} as vscode.Extension<any>);
             const resultPromise = Component.debug(devfileComponentItem2);
             let caughtError;
@@ -896,12 +492,11 @@ suite('OpenShift/Component', function() {
             const waitPort = sandbox.stub().resolves(true)
             Component = mockComponent(startDebugging, waitPort, 1);
 
-            const devfileComponentItem2 = new TestItem(appItem, 'comp1', ContextType.COMPONENT_PUSHED, [], comp1Uri, 'https://host/proj/app/comp1');
-            sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([]);
-            devfileComponentItem2.builderImage = {
-                name: 'python',
-                tag: undefined
+            const devfileComponentItem2: ComponentWorkspaceFolder = {
+                contextPath: comp1Folder,
+                component: undefined,
             };
+            sandbox.stub(OdoImpl.prototype, 'getComponentTypes').resolves([]);
             sandbox.stub(vscode.extensions, 'getExtension').returns({} as vscode.Extension<any>);
             const resultPromise = Component.debug(devfileComponentItem2);
             let caughtError;

--- a/test/unit/openshift/openshiftitem.test.ts
+++ b/test/unit/openshift/openshiftitem.test.ts
@@ -3,13 +3,11 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { fail } from 'assert';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
-import { ContextType, OdoImpl } from '../../../src/odo';
+import { OdoImpl } from '../../../src/odo';
 import OpenShiftItem from '../../../src/openshift/openshiftItem';
 import { wait } from '../../../src/util/async';
-import { TestItem } from './testOSItem';
 import sinon = require('sinon');
 
 const {expect} = chai;
@@ -18,14 +16,10 @@ chai.use(sinonChai);
 suite('OpenShiftItem', () => {
 
     let sandbox: sinon.SinonSandbox;
-    const clusterItem = new TestItem(null, 'cluster', ContextType.CLUSTER);
-    const projectItem = new TestItem(clusterItem, 'project', ContextType.PROJECT);
-    const appItem = new TestItem(projectItem, 'application', ContextType.APPLICATION);
-    const componentItem = new TestItem(appItem, 'component', ContextType.COMPONENT);
 
     setup(() => {
         sandbox = sinon.createSandbox();
-        sandbox.stub(OdoImpl.prototype, 'getClusters').resolves([clusterItem]);
+        sandbox.stub(OdoImpl.prototype, 'getActiveCluster').resolves('cluster');
     });
 
     teardown(() => {
@@ -49,55 +43,6 @@ suite('OpenShiftItem', () => {
         test('returns undefined if provided value is in lower case alphanumeric characters', ()=> {
             const validateMatches = OpenShiftItem.validateMatches(undefined, 'nodejs-app');
             expect(validateMatches).equals(null);
-        });
-    });
-
-    suite('getApplicationNames', ()=> {
-
-        test('returns an array of application names for the project if there is at least one application', async ()=> {
-            sandbox.stub(OdoImpl.prototype, 'getApplications').resolves([appItem]);
-            const appNames = await OpenShiftItem.getApplicationNames(projectItem, false);
-            expect(appNames[0].getName()).equals('application');
-        });
-
-        test('shows item to create new application in QuickPick if no application available', async ()=> {
-            sandbox.stub(OdoImpl.prototype, 'getApplications').resolves([appItem]);
-            sandbox.stub(OpenShiftItem, 'getName').resolves();
-            const appNames = await OpenShiftItem.getApplicationNames(projectItem, true);
-            expect(appNames[0].label).equals('$(plus) Create new Application...');
-        });
-
-        test('throws error if there are no application available', async ()=> {
-            sandbox.stub(OdoImpl.prototype, 'getApplications').resolves([]);
-            try {
-                await OpenShiftItem.getApplicationNames(appItem, false);
-            } catch (err) {
-                expect(err.message).equals('You need at least one Component available. Please create new OpenShift Component and try again.');
-                return;
-            }
-            fail('should throw error in case components array is empty');
-        });
-
-    });
-
-    suite('getComponentNames', ()=> {
-
-        test('returns an array of component names for the application if there is at least one component', async ()=> {
-            sandbox.stub(OdoImpl.prototype, 'getComponents').resolves([componentItem]);
-            const componentNames = await OpenShiftItem.getComponentNames(appItem);
-            expect(componentNames[0].getName()).equals('component');
-
-        });
-
-        test('throws error if there are no components available', async ()=> {
-            sandbox.stub(OdoImpl.prototype, 'getComponents').resolves([]);
-            try {
-                await OpenShiftItem.getComponentNames(projectItem);
-            } catch (err) {
-                expect(err.message).equals('You need at least one Component available. Please create new OpenShift Component and try again.');
-                return;
-            }
-            fail('should throw error in case components array is empty');
         });
     });
 


### PR DESCRIPTION
- remove unused commands from `commands.ts` and unused methods from `odo.ts`
  - Notably, remove `ODO.getApplications()`, `ODO.getComponents()`, and the in-memory tree representing the cluster state, since they don't work properly and we have replacements for them
- rewrite integration tests for `commands.ts` and `odo.ts`
- report test coverage for integration tests
- add the integration tests to the UI test Jenkinsfile workflow

Depends on #2865, #2863, #2862

Fixes #2799

Signed-off-by: David Thompson <davthomp@redhat.com>
