### PR TITLE
Test case for component creation by importing from git.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -89,6 +89,28 @@
                 "--mocha_config",
                 "${workspaceFolder}/test/ui/.mocharc.js"
             ],
+            "preLaunchTask": "npm: watch",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "env": {
+                "NODE_OPTIONS": "--max_old_space_size=4096"
+            }
+        },
+        {
+            "name": "Debug UI Tests (Fast)",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/node_modules/.bin/extest",
+            "args": [
+                "run-tests",
+                "${workspaceFolder}/out/test/ui/public-ui-test.js",
+                "-o",
+                "${workspaceFolder}/test/ui/settings.json",
+                "-m",
+                "--mocha_config",
+                "${workspaceFolder}/test/ui/.mocharc.js"
+            ],
+            "preLaunchTask": "npm: watch",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         },

--- a/test/ui/public-ui-test.ts
+++ b/test/ui/public-ui-test.ts
@@ -7,6 +7,7 @@ import { checkAboutCommand } from './suite/command-about';
 import { testDevfileRegistries } from './suite/devfileRegistries';
 import { checkExtension } from './suite/extension';
 import { checkFocusOnCommands } from './suite/focusOn';
+import { testImportFromGit } from './suite/import-from-git';
 import { checkOpenshiftView } from './suite/openshift';
 
 describe('Extension public-facing UI tests', () => {
@@ -15,4 +16,5 @@ describe('Extension public-facing UI tests', () => {
     checkAboutCommand();
     testDevfileRegistries();
     checkFocusOnCommands();
+    testImportFromGit();
 });

--- a/test/ui/suite/import-from-git.ts
+++ b/test/ui/suite/import-from-git.ts
@@ -1,0 +1,101 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import { ActivityBar, By, EditorView, InputBox, SideBarView, ViewSection, WebElement, WebView, WelcomeContentButton, WelcomeContentSection, Workbench } from 'vscode-extension-tester';
+import { notificationExists } from '../common/conditions';
+import { VIEWS } from '../common/constants';
+import path = require('path');
+
+export function testImportFromGit() {
+    describe('Import From Git', function () {
+        let editorView: EditorView;
+        let welcome: WelcomeContentSection;
+        const tempDir: string = path.join(__dirname, 'temp');
+
+        before(async function () {
+            this.timeout(20000);
+            const view: SideBarView = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
+            editorView = (new Workbench().getEditorView());
+            await new Promise(res => setTimeout(res, 5000));
+            await (await new Workbench().openNotificationsCenter()).clearAllNotifications();
+
+            const explorer: ViewSection = await view.getContent().getSection(VIEWS.appExplorer);
+            await explorer.expand();
+            welcome = await explorer.findWelcomeContent();
+
+            for (const item of [VIEWS.components, VIEWS.compRegistries, VIEWS.debugSessions]) {
+                await (await view.getContent().getSection(item)).collapse();
+            }
+
+            if (fs.existsSync(tempDir)) {
+                fs.removeSync(tempDir);
+            }
+            fs.mkdirSync(tempDir);
+        });
+
+        after('remove temp dir', function () {
+            if (fs.existsSync(tempDir)) {
+                fs.removeSync(tempDir);
+            }
+        });
+
+        it('Import project from git', async function () {
+            await editorView.closeAllEditors();
+            const buttons: WelcomeContentButton[] = await welcome.getButtons();
+            let importButton: WelcomeContentButton;
+            for (const btn of buttons) {
+                const title = await btn.getTitle();
+                if (title === 'Import from Git') {
+                    importButton = btn;
+                    break;
+                }
+            }
+            await importButton.click();
+            await editorView.openEditor('Git Import');
+
+            let elements: WebElement[];
+            const webview = new WebView();
+
+            await webview.switchToFrame(); // START WEBVIEW CODE
+
+            elements = await webview.findWebElements(By.xpath('//input[@id="bootstrap-input"]'));
+            const importTextBox = elements[0];
+            await importTextBox.sendKeys('https://github.com/eclipse/lemminx');
+
+            elements  = await webview.findWebElements(By.xpath('//button[contains(text(),"Analyze")]'));
+            const analyzeButton = elements[0];
+            await analyzeButton.click();
+
+            await webview.switchBack(); // END WEBVIEW CODE
+
+            const fileDialog = await InputBox.create();
+            await fileDialog.setText(tempDir);
+            await fileDialog.confirm();
+            await new Promise(res => setTimeout(res, 5000)); // wait for clone operation to complete
+
+            await webview.switchToFrame(); // START WEBVIEW CODE
+
+            elements = await webview.findWebElements(By.xpath('//p[contains(text(),"Here is the recommended devfile")]'));
+            expect(elements).length.greaterThan(0);
+
+            elements = await webview.findWebElements(By.xpath('//div[@data-testid = "card-java-maven"]'));
+            expect(elements).length.greaterThan(0);
+
+            elements  = await webview.findWebElements(By.xpath('//button[contains(text(),"Create Component")]'));
+            expect(elements).length.greaterThan(0);
+            const createButton = elements[0];
+            expect(await createButton.isEnabled()).is.true;
+            await createButton.click();
+
+            await webview.switchBack(); // END WEBVIEW CODE
+
+            const devfile: string = path.join(tempDir, 'lemminx', 'devfile.yaml');
+            await notificationExists('Component \'lemminx-comp\' successfully created. Perform actions on it from Components View.', editorView.getDriver(), 3000);
+            expect(fs.existsSync(devfile)).is.true;
+        }).timeout(20000);
+
+    });
+}


### PR DESCRIPTION
- Fixes #2779
- Add npm-watch as preLaunchTask to ensure test changes get updated
- Create a separate launch config for running the tests quickly with run-tests instead of setup-and-run