### PR TITLE
updated latest helm 3.11.1

### DIFF
--- a/src/tools.json
+++ b/src/tools.json
@@ -63,27 +63,27 @@
         "description": "oc helm CLI",
         "vendor": "Red Hat, Inc.",
         "name": "helm",
-        "version": "3.10.1",
-        "versionRange": "^3.10.1",
-        "versionRangeLabel": "version >= 3.10.1",
+        "version": "3.11.1",
+        "versionRange": "^3.11.1",
+        "versionRangeLabel": "version >= 3.11.1",
         "dlFileName": "helm",
         "filePrefix": "",
         "platform": {
             "win32": {
-                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/helm/latest/helm-windows-amd64.exe.zip",
-                "sha256sum": "c1796e4ed2d7aa3de5d09c3f586bd45524ce28a6f69745297822e2da8611e9d1",
+                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/helm/3.11.1/helm-windows-amd64.exe.zip",
+                "sha256sum": "2ee9c0bec16252171aec7bb709219e069d4d747c5e40341d652708fa2a78640c",
                 "dlFileName": "helm-windows-amd64.exe.zip",
                 "cmdFileName": "helm-windows-amd64.exe"
             },
             "darwin": {
-                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/helm/latest/helm-darwin-amd64.tar.gz",
-                "sha256sum": "6f070900b97b12a06b838761a275b9cdf39bb1082612e8085491855cda2bbbbd",
+                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/helm/3.11.1/helm-darwin-amd64.tar.gz",
+                "sha256sum": "0930908a9a43a32c9a7dc859bc82b2d0d822d99b53d75979a6da64a824d80837",
                 "dlFileName": "helm-darwin-amd64.tar.gz",
                 "cmdFileName": "helm-darwin-amd64"
             },
             "linux": {
-                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/helm/latest/helm-linux-amd64.tar.gz",
-                "sha256sum": "3961f2f8c0ec61383c9efa295bb7c38769cda57847139b59d1ddf8958ee379e2",
+                "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/helm/3.11.1/helm-linux-amd64.tar.gz",
+                "sha256sum": "55a8ac91018650964ccaccc66a6d6b963428a2afa0a824e708e63509dbbd3316",
                 "dlFileName": "helm-linux-amd64.tar.gz",
                 "cmdFileName": "helm-linux-amd64"
             }


### PR DESCRIPTION
Signed-off-by: msivasubramaniaan [msivasub@redhat.com](mailto:msivasub@redhat.com)

Currently there were no release tags were maintained in https://github.com/redhat-developer/helm and we couldn't update the helm binary through GH workflow. 

We can directly use the https://github.com/helm/helm repo for the helm update GH workflow.

@rgrunber WDYT?