### PR TITLE
fix `npm run test` command that running unit tests without coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"lint-nic": "eslint . --ext .ts --no-inline-config",
 		"bundle-tools": "node ./out/build/bundle-tools.js --platform",
 		"todo": "leasot **/*.ts --ignore node_modules -x",
-		"test": "npm run vscode:prepublish && node ./out/build/run-tests.js unit",
+		"test": "npm run vscode:prepublish && node ./out/build/install-vscode.js redhat.vscode-redhat-account && node ./out/build/run-tests.js unit",
 		"test-integration": "npm run vscode:prepublish && node ./out/build/run-tests.js integration",
 		"test-integration:coverage": "npm run vscode:prepublish && npm run test:instrument && node ./out/build/run-tests.js integration",
 		"test:instrument": "shx rm -rf out/src-orig && shx mv out/src out/src-orig && istanbul instrument --complete-copy --embed-source --output out/src out/src-orig",


### PR DESCRIPTION
It fails right now because redhat-account-extension installation
script is not called before executing the tests

Signed-off-by: Denis Golovin <dgolovin@redhat.com>
