### PR TITLE
Use the extensions from `./test-resources/extensions` during UI tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -89,7 +89,10 @@
                 "${workspaceFolder}/test/ui/settings.json",
                 "-m",
                 "--mocha_config",
-                "${workspaceFolder}/test/ui/.mocharc.js"
+                "${workspaceFolder}/test/ui/.mocharc.js",
+                "-e",
+                "./test-resources/extensions",
+                "-i"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
@@ -114,7 +117,9 @@
                 "${workspaceFolder}/test/ui/settings.json",
                 "-m",
                 "--mocha_config",
-                "${workspaceFolder}/test/ui/.mocharc.js"
+                "${workspaceFolder}/test/ui/.mocharc.js",
+                "-e",
+                "./test-resources/extensions"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
 		"update-deps": "ncu --upgrade --loglevel verbose --packageFile package.json && npm update",
 		"coverage:upload": "codecov -f coverage/coverage-final.json",
 		"build": "npm run clean && npm run lint && npm run compile && npm run bundle-tools",
-		"smoke-test": "npm run compile && extest setup-and-run out/test/ui/smoke-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -c max",
-		"public-ui-test": "npm run compile && extest setup-and-run out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -c max"
+		"smoke-test": "extest setup-and-run out/test/ui/smoke-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max -i",
+		"public-ui-test": "extest setup-and-run out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max -i"
 	},
 	"dependencies": {
 		"@kubernetes/client-node": "^0.16.1",

--- a/test/ui/public-ui-test.ts
+++ b/test/ui/public-ui-test.ts
@@ -10,6 +10,8 @@ import { checkFocusOnCommands } from './suite/focusOn';
 import { testImportFromGit } from './suite/import-from-git';
 import { checkOpenshiftView } from './suite/openshift';
 
+require('source-map-support').install();
+
 describe('Extension public-facing UI tests', function() {
     checkExtension();
     checkOpenshiftView();

--- a/test/ui/suite/import-from-git.ts
+++ b/test/ui/suite/import-from-git.ts
@@ -17,8 +17,8 @@ export function testImportFromGit() {
 
         before(async function () {
             this.timeout(20000);
-            const view: SideBarView = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
-            editorView = (new Workbench().getEditorView());
+            const view: SideBarView = await (await (await new ActivityBar().wait(5_000)).getViewControl(VIEWS.openshift)).openView();
+            editorView = await ((await new Workbench().wait(5_000)).getEditorView().wait(5_000));
             await new Promise(res => setTimeout(res, 5000));
             await (await new Workbench().openNotificationsCenter()).clearAllNotifications();
 


### PR DESCRIPTION
Also:
- skip compiling the code when running from the command line, since `extest` does this for us
- use the `-i` flag in the call to `extest`, which installs the dependencies of the extension
- make more timeout changes to the git import test suite to try to stabilize the suite

Fixes #2919

Signed-off-by: David Thompson <davthomp@redhat.com>
