### PR TITLE
Fix unit tests

### DIFF
--- a/test/unit/oc.test.ts
+++ b/test/unit/oc.test.ts
@@ -48,6 +48,7 @@ suite('Oc', function() {
         detectOrDownloadStub = sandbox.stub(ToolsConfig, 'detect').resolves('path');
         sandbox.stub(getInstance(), 'getActiveCluster').resolves('cluster');
         sandbox.stub(getInstance(), 'getProjects').resolves([projectItem]);
+        sandbox.stub(getInstance(), 'canCreatePod').resolves(true);
     });
 
     teardown(function() {


### PR DESCRIPTION
The tests call clusterRequired(), which attempts to check if the cluster exists using ODO.canCreatePod(). This PR stubs that method in the relevant test to always return `true`. This was my fault, I forgot to ensure that the unit tests were passing before merging the PR.

Signed-off-by: David Thompson <davthomp@redhat.com>
