### PR TITLE
Fix cluster-dependent UI test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"update-deps": "ncu --upgrade --loglevel verbose --packageFile package.json && npm update",
 		"coverage:upload": "codecov -f coverage/coverage-final.json",
 		"build": "npm run clean && npm run lint && npm run compile && npm run bundle-tools",
-		"smoke-test": "extest setup-and-run out/test/ui/smoke-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max -i",
+		"cluster-ui-test": "extest setup-and-run out/test/ui/cluster-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max -i",
 		"public-ui-test": "extest setup-and-run out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max -i"
 	},
 	"dependencies": {

--- a/test/ui/Jenkinsfile
+++ b/test/ui/Jenkinsfile
@@ -19,9 +19,9 @@ node('rhel8') {
                 junit 'report.xml'
             }
         }
-        stage('UI smoke test') {
+        stage('cluster-dependent UI tests') {
             wrap([$class: 'Xvnc']) {
-                sh "npm run smoke-test"
+                sh "npm run cluster-ui-test"
                 junit 'report.xml'
             }
         }

--- a/test/ui/cluster-ui-test.ts
+++ b/test/ui/cluster-ui-test.ts
@@ -3,20 +3,19 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as fs from 'fs-extra';
+import * as path from 'path';
+import { createComponentTest } from './suite/component';
 import { checkExtension } from './suite/extension';
 import { checkOpenshiftView } from './suite/openshift';
-import { createComponentTest } from './suite/component';
-import { checkAboutCommand } from './suite/command-about';
 
-describe('Extension smoke test', () => {
+describe('Extension cluster-dependant UI tests', function () {
     const kubeConfig = path.join(process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'], '.kube', 'config');
     const kubeBackup = `${kubeConfig}.backup`;
     const contextFolder = path.join(__dirname, 'context');
 
     // test with an empty kube config, make a backup, wipe the context folder
-    before(async () => {
+    before(async function () {
         if (fs.existsSync(kubeConfig)) {
             await fs.move(kubeConfig, kubeBackup, { overwrite: true });
         }
@@ -24,7 +23,7 @@ describe('Extension smoke test', () => {
     });
 
     // restore the kube config backup after test
-    after(async () => {
+    after(async function () {
         if (fs.existsSync(kubeBackup)) {
             await fs.move(kubeBackup, kubeConfig, { overwrite: true });
         }
@@ -33,5 +32,4 @@ describe('Extension smoke test', () => {
     checkExtension();
     checkOpenshiftView();
     createComponentTest(contextFolder);
-    checkAboutCommand();
 });

--- a/test/ui/common/constants.ts
+++ b/test/ui/common/constants.ts
@@ -34,13 +34,14 @@ export const INPUTS = {
 export const MENUS = {
     newProject: 'New Project',
     delete: 'Delete',
-    push: 'Push',
+    bindService: 'Bind Service',
+    startDev: 'Start Dev',
 };
 
 export const COMPONENTS = {
-    nodejsDevfile: 'nodejs (devfile)',
+    nodejsDevfile: 'nodejs/DefaultDevfileRegistry',
     devfileComponent: (name: string) => `${name} (devfile)`,
-    pushSuccess: 'Changes successfully pushed',
+    devStarted: 'Ctrl+c',
 };
 
 export const NOTIFICATIONS = {

--- a/test/ui/suite/component.ts
+++ b/test/ui/suite/component.ts
@@ -4,33 +4,38 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { expect } from 'chai';
-import { ActivityBar, InputBox, SideBarView, TreeItem, ViewSection, VSBrowser, WelcomeContentButton, Workbench } from 'vscode-extension-tester';
-import { itemExists, notificationExists, terminalHasText, waitForInputProgress, waitForInputUpdate } from '../common/conditions';
-import { VIEWS, MENUS, BUTTONS, INPUTS, COMPONENTS, NOTIFICATIONS } from '../common/constants';
+import { ActivityBar, EditorView, InputBox, SideBarView, TerminalView, TreeItem, ViewSection, VSBrowser, WelcomeContentButton, Workbench } from 'vscode-extension-tester';
+import { itemExists, notificationExists, terminalHasText, waitForInputUpdate } from '../common/conditions';
+import { BUTTONS, COMPONENTS, INPUTS, MENUS, NOTIFICATIONS, VIEWS } from '../common/constants';
 
 export function createComponentTest(contextFolder: string) {
-    describe('Component creation', () => {
-        const cluster = process.env.CLUSTER_URL || 'https://api.ocp2.adapters-crs.ccitredhat.com:6443';
-        const clusterName = (/https?:\/\/(.*)/.exec(cluster))[1];
+    describe('Component creation', function() {
+        const cluster = process.env.CLUSTER_URL || 'https://api.crc.testing:6443';
+        const clusterName = cluster;
         const user = process.env.CLUSTER_USER || 'developer';
         const password = process.env.CLUSTER_PASSWORD || 'developer';
         let view: SideBarView;
         let explorer: ViewSection;
         let components: ViewSection;
+        let editorView: EditorView;
 
         const projectName = `project${Math.floor(Math.random() * 100)}`
-        const appName = `app${Math.floor(Math.random() * 100)}`;
         const compName = `comp${Math.floor(Math.random() * 100)}`;
 
-        before(async () => {
+        before(async function () {
             view = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
             explorer = await view.getContent().getSection(VIEWS.appExplorer);
             components = await view.getContent().getSection(VIEWS.components);
         });
 
-        beforeEach(async () => {
+        beforeEach(async function() {
             const center = await new Workbench().openNotificationsCenter();
             await center.clearAllNotifications();
+        });
+
+        afterEach(async function() {
+            editorView = new EditorView();
+            await editorView.closeAllEditors();
         });
 
         after(async function() {
@@ -46,7 +51,7 @@ export function createComponentTest(contextFolder: string) {
         });
 
         it('Login with credentials', async function() {
-            this.timeout(30000);
+            this.timeout(30_000);
             await explorer.expand();
             const content = await explorer.findWelcomeContent();
             // eslint-disable-next-line no-console, @typescript-eslint/restrict-template-expressions
@@ -118,32 +123,21 @@ export function createComponentTest(contextFolder: string) {
         });
 
         it('Create a new component from scratch', async function() {
-            this.timeout(60000);
-            const newComponent = (await (await components.findWelcomeContent()).getButtons())[0];
+            this.timeout(120_000);
+            const newComponent = (await (await components.findWelcomeContent()).getButtons())[1];
             await newComponent.click();
 
-            // provide application name
+            // wait for input quick pick to appear
             const input = await InputBox.create();
-            const appMessage = await input.getMessage();
-            await input.setText(appName);
-            await input.confirm();
 
             // select to add new context folder
-            await waitForInputUpdate(input, appMessage);
             await input.selectQuickPick(INPUTS.newFolderQuickPick);
 
             // select the context folder
             await input.setText(contextFolder);
             await input.confirm();
 
-            // provide component name
-            await waitForInputUpdate(input, '');
-            await input.setText(compName);
-            await input.confirm();
-
             // select nodejs devfile template
-            await waitForInputProgress(input, true);
-            await waitForInputProgress(input, false, 20000);
             await new Promise(res => setTimeout(res, 500));
             await input.setText(COMPONENTS.nodejsDevfile);
             await input.confirm();
@@ -151,21 +145,39 @@ export function createComponentTest(contextFolder: string) {
             // select yes for starter project
             await new Promise(res => setTimeout(res, 500));
             await input.selectQuickPick(INPUTS.yes);
+
+            // provide component name
+            await new Promise(res => setTimeout(res, 500));
+            await input.setText(compName);
+            await input.confirm();
+
             await new Promise(res => setTimeout(res, 5000));
             const project = await itemExists(projectName, explorer) as TreeItem;
             await project.expand();
 
-            const app = await itemExists(appName, explorer) as TreeItem;
-            await app.expand();
-            await itemExists(COMPONENTS.devfileComponent(compName), explorer);
+            await itemExists(compName, components, 30_000);
         });
 
-        it('Push the component', async function() {
-            this.timeout(150000);
-            const component = await itemExists(COMPONENTS.devfileComponent(compName), explorer);
+        it('Start the component in dev mode', async function() {
+            this.timeout(180000);
+            const component = await itemExists(compName, components, 30_000);
+
             const menu = await component.openContextMenu();
-            await menu.select(MENUS.push);
-            await terminalHasText(COMPONENTS.pushSuccess, 120000);
+            await menu.select(MENUS.startDev);
+            await terminalHasText(COMPONENTS.devStarted, 60_000);
+
+            const term = new TerminalView();
+            await term.killTerminal();
+
+            // wait for component to stop running.
+            // the component name changes to
+            // `component-name (stopping)`
+            // while `odo dev` is stopping
+            // then it returns to
+            // `component-name`
+            // when `odo dev` has stopped
+            await itemExists(compName, components, 60_000);
         });
+
     });
 }


### PR DESCRIPTION
With a running `crc` cluster, run `npm run cluster-ui-test` in order to run the cluster-dependent UI test suite.

- renamed `smoke-test` to `cluster-ui-test` and removed some of the tests that overlap between the suites
- Most of this work is also done in #2803, so I just copied it from over there
- Temporarily addresses #2780, we will need to rewrite it once the new create component workflow is in place

Fixes #2777

Signed-off-by: David Thompson <davthomp@redhat.com>
