### PR TITLE
Address feedback from create component demo

### DIFF
--- a/src/odo.ts
+++ b/src/odo.ts
@@ -106,6 +106,14 @@ export interface Odo {
      * @param templateProjectName the template project from the devfile to use
      */
     createComponentFromTemplateProject(componentPath: string, componentName: string, devfileName: string, registryName: string, templateProjectName: string): Promise<void>;
+    /**
+     * Create a component from the given local codebase.
+     *
+     * @param devfileName the name of the devfile to use
+     * @param componentName the name of the component
+     * @param location the location of the local codebase
+     */
+    createComponentFromLocation(devfileName: string, componentName: string, location: Uri): Promise<void>;
 }
 
 export class OdoImpl implements Odo {
@@ -253,6 +261,10 @@ export class OdoImpl implements Odo {
         if (!workspace.workspaceFolders || !wsFolder) {
             workspace.updateWorkspaceFolders(workspace.workspaceFolders? workspace.workspaceFolders.length : 0 , null, { uri: location });
         }
+    }
+
+    public async createComponentFromLocation(devfileName: string, componentName: string, location: Uri): Promise<void> {
+        await this.execute(Command.createLocalComponent(devfileName, undefined, componentName, undefined, false, ''), location.fsPath);
     }
 
     public async createComponentFromTemplateProject(componentPath: string, componentName: string, devfileName: string, registryName: string, templateProjectName: string): Promise<void> {

--- a/src/webview/common/createComponentButton.tsx
+++ b/src/webview/common/createComponentButton.tsx
@@ -1,0 +1,50 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import ConstructionIcon from '@mui/icons-material/Construction';
+import LoadingButton from '@mui/lab/LoadingButton';
+import { Alert, AlertTitle } from '@mui/material';
+import * as React from 'react';
+
+export type CreateComponentButtonProps = {
+    componentName: string;
+    componentParentFolder: string;
+    isComponentNameFieldValid: boolean;
+    isFolderFieldValid: boolean;
+    isLoading: boolean;
+    createComponent: (projectFolder: string, componentName: string) => void;
+    setLoading: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export function CreateComponentButton(props: CreateComponentButtonProps) {
+    return (
+        <LoadingButton
+            variant="contained"
+            onClick={() => {
+                props.createComponent(props.componentParentFolder, props.componentName);
+                props.setLoading(true);
+            }}
+            disabled={!props.isComponentNameFieldValid || !props.isFolderFieldValid || props.isLoading}
+            loading={props.isLoading}
+            loadingPosition="start"
+            startIcon={<ConstructionIcon />}
+        >
+            <span>Create Component</span>
+        </LoadingButton>
+    );
+}
+
+export function CreateComponentErrorAlert({ createComponentErrorMessage }) {
+    return (
+        <>
+            {createComponentErrorMessage.length !== 0 &&
+                <Alert severity="error">
+                    <AlertTitle>Create Component Failed:</AlertTitle>
+                    {createComponentErrorMessage}
+                </Alert>
+            }
+        </>
+    );
+}
+

--- a/src/webview/common/devfileListItem.tsx
+++ b/src/webview/common/devfileListItem.tsx
@@ -84,7 +84,7 @@ export function DevfileListItem(props: DevfileListItemProps) {
             </Stack>
             <Box sx={{ flexGrow: '1' }} />
             {props.buttonCallback ? (
-                <Button variant="outlined" onClick={props.buttonCallback}>
+                <Button variant="contained" onClick={props.buttonCallback}>
                     Use Devfile
                 </Button>
             ) : (

--- a/src/webview/common/devfileRecommendationInfo.tsx
+++ b/src/webview/common/devfileRecommendationInfo.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 export function DevfileRecommendationInfo() {
     return (
         <Alert severity='info'>
-            Recommended based on a scan of languages and structure the project.
+            Recommended based on a scan of languages and structure of the project.
         </Alert>
     );
 }

--- a/src/webview/common/devfileSearch.tsx
+++ b/src/webview/common/devfileSearch.tsx
@@ -405,7 +405,7 @@ export function DevfileSearch(props: DevfileSearchProps) {
                     <DevfileExplanation />
                     {props.goBack && (
                         <Button
-                            variant="text"
+                            variant="outlined"
                             onClick={(_) => {
                                 props.goBack();
                             }}

--- a/src/webview/common/fromTemplateProject.tsx
+++ b/src/webview/common/fromTemplateProject.tsx
@@ -26,13 +26,14 @@ export function FromTemplateProject(props: FromTemplateProjectProps) {
         setCurrentPage((_) => 'setNameAndFolder');
     }
 
-    function createComponentFromTemplateProject(projectFolder: string, componentName: string) {
+    function createComponent(projectFolder: string, componentName: string) {
         window.vscodeApi.postMessage({
-            action: 'createComponentFromTemplateProject',
+            action: 'createComponent',
             data: {
                 templateProject: selectedTemplateProject,
                 projectFolder,
                 componentName,
+                isFromTemplateProject: true,
             },
         });
     }
@@ -53,7 +54,7 @@ export function FromTemplateProject(props: FromTemplateProjectProps) {
                     goBack={() => {
                         setCurrentPage('selectTemplateProject');
                     }}
-                    createComponent={createComponentFromTemplateProject}
+                    createComponent={createComponent}
                     devfile={selectedDevfile}
                     templateProject={selectedTemplateProject.templateProjectName}
                 />

--- a/src/webview/common/optionCard.tsx
+++ b/src/webview/common/optionCard.tsx
@@ -2,12 +2,13 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-import { Button, Card, CardActions, Typography } from '@mui/material';
+import { Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 import * as React from 'react';
 
 
 interface OptionCardProps {
     pageId: string;
+    description: string;
     setCurrentView: any;
     title: string;
     icon: any;
@@ -17,14 +18,19 @@ export default function OptionCard(props: OptionCardProps) {
 
     return (
         <Card variant='outlined'>
-            <div style={{ display: 'flex', height: '10em', alignItems: 'center', gap: '2em', marginTop: '1em'}}>
-                <props.icon sx={{ width: '30px', height: '30px', marginLeft: '1.5em', color: 'var(--vscode-editor-foreground)'}}/>
-                <Typography variant='h6' sx={{ marginRight: '1.5em'}}>
+            <div style={{ display: 'flex', height: '10em', alignItems: 'center', gap: '2em', marginTop: '1em' }}>
+                <props.icon sx={{ width: '30px', height: '30px', marginLeft: '1.5em', color: 'var(--vscode-editor-foreground)' }} />
+                <Typography variant='h6' sx={{ marginRight: '1.5em' }}>
                     {props.title}
                 </Typography>
             </div>
+            <CardContent style={{ marginLeft: '1em', marginRight: '1em' }}>
+                <Typography variant='body2'>
+                    {props.description}
+                </Typography>
+            </CardContent>
             <CardActions sx={{ justifyContent: 'center', height: '5em' }}>
-                <Button variant='text' onClick={() => {props.setCurrentView(props.pageId)}} size='large' sx={{ marginBottom: '1em' }}>
+                <Button variant='text' onClick={() => { props.setCurrentView(props.pageId) }} size='large' sx={{ marginBottom: '1em' }}>
                     CREATE
                 </Button>
             </CardActions>

--- a/src/webview/common/setNameAndFolder.tsx
+++ b/src/webview/common/setNameAndFolder.tsx
@@ -2,7 +2,6 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-import LoadingButton from '@mui/lab/LoadingButton';
 import {
     Button,
     FormControl,
@@ -10,11 +9,12 @@ import {
     Paper,
     Stack,
     TextField,
-    Typography,
+    Typography
 } from '@mui/material';
 import * as React from 'react';
 import 'react-dom';
 import { ComponentNameInput } from './componentNameInput';
+import { CreateComponentButton, CreateComponentErrorAlert } from './createComponentButton';
 import { Devfile } from './devfile';
 import { DevfileListItem } from './devfileListItem';
 
@@ -36,11 +36,13 @@ export function SetNameAndFolder(props: SetNameAndFolderProps) {
     const [componentNameErrorMessage, setComponentNameErrorMessage] = React.useState('Please enter a component name.');
 
     const [componentParentFolder, setComponentParentFolder] = React.useState('');
-    const [isFolderFieldValid, setFolderFieldValid] = React.useState('');
+    const [isFolderFieldValid, setFolderFieldValid] = React.useState(false);
     const [folderFieldErrorMessage, setFolderFieldErrorMessage] = React.useState('');
     const [isFolderFieldInteracted, setFolderFieldInteracted] = React.useState(false);
 
     const [isLoading, setLoading] = React.useState(false);
+
+    const [createComponentErrorMessage, setCreateComponentErrorMessage] = React.useState('');
 
     function respondToMessage(messageEvent: MessageEvent) {
         const message = messageEvent.data as Message;
@@ -62,6 +64,11 @@ export function SetNameAndFolder(props: SetNameAndFolderProps) {
                     setComponentNameFieldValid(true);
                     setComponentNameErrorMessage('');
                 }
+                break;
+            }
+            case 'createComponentFailed': {
+                setLoading(false);
+                setCreateComponentErrorMessage(message.data);
                 break;
             }
         }
@@ -152,18 +159,16 @@ export function SetNameAndFolder(props: SetNameAndFolderProps) {
                     <Button variant="text" onClick={props.goBack}>
                         {props.templateProject ? ('Use Different Template Project') : ('Back')}
                     </Button>
-                    <LoadingButton
-                        variant="contained"
-                        onClick={() => {
-                            props.createComponent(componentParentFolder, componentName);
-                            setLoading(true);
-                        }}
-                        disabled={!isComponentNameFieldValid || !isFolderFieldValid || isLoading}
-                        loading={isLoading}
-                    >
-                        Create Component
-                    </LoadingButton>
+                    <CreateComponentButton
+                        componentName={componentName}
+                        componentParentFolder={componentParentFolder}
+                        isComponentNameFieldValid={isComponentNameFieldValid}
+                        isFolderFieldValid={isFolderFieldValid}
+                        isLoading={isLoading}
+                        createComponent={props.createComponent}
+                        setLoading={setLoading} />
                 </Stack>
+                <CreateComponentErrorAlert createComponentErrorMessage={createComponentErrorMessage} />
             </Stack>
         </Stack>
     );

--- a/src/webview/create-component/pages/createComponent.tsx
+++ b/src/webview/create-component/pages/createComponent.tsx
@@ -37,18 +37,21 @@ function SelectStrategy({ setCurrentView }) {
             >
                 <OptionCard
                     pageId="fromLocalCodeBase"
+                    description="Create component from an existing codebase on your local machine."
                     setCurrentView={setCurrentView}
                     title="From Existing Local Codebase"
                     icon={FolderOpenIcon}
                 />
                 <OptionCard
                     pageId="fromExistingGitRepo"
+                    description="Create component by importing code from an existing Git repository."
                     setCurrentView={setCurrentView}
                     title="From Existing Remote Git Repository"
                     icon={GitHubIcon}
                 />
                 <OptionCard
                     pageId="devfileSearch"
+                    description="Create component by selecting a devfile and template project."
                     setCurrentView={setCurrentView}
                     title="From Template Project"
                     icon={ConstructionIcon}

--- a/src/webview/create-component/pages/fromExisitingGitRepo.tsx
+++ b/src/webview/create-component/pages/fromExisitingGitRepo.tsx
@@ -105,7 +105,8 @@ export function FromExistingGitRepo({ setCurrentView }) {
                 devfileDisplayName: selectedDevfile ? (selectedDevfile.name) : (recommendedDevfile.devfile.name),
                 componentName: componentName,
                 tmpDirUri: tmpDir,
-                gitDestinationPath: projectFolder
+                gitDestinationPath: projectFolder,
+                isFromTemplateProject: false,
             }
         });
     }
@@ -202,6 +203,7 @@ export function FromExistingGitRepo({ setCurrentView }) {
                                             </Button>
                                             <Button
                                                 variant='text'
+                                                disabled={cloneFailed}
                                                 onClick={() => {
                                                     setCloneFailed(false);
                                                     setRecommendedDevfile((prevState) => ({ ...prevState, showRecommendation: true }));

--- a/src/webview/create-component/pages/fromLocalCodebase.tsx
+++ b/src/webview/create-component/pages/fromLocalCodebase.tsx
@@ -1,8 +1,8 @@
-import LoadingButton from '@mui/lab/LoadingButton';
 import { Button, CircularProgress, Divider, FormControl, FormHelperText, InputLabel, MenuItem, Select, Stack, Typography } from '@mui/material';
 import * as React from 'react';
 import { Uri } from 'vscode';
 import { ComponentNameInput } from '../../common/componentNameInput';
+import { CreateComponentButton, CreateComponentErrorAlert } from '../../common/createComponentButton';
 import { Devfile } from '../../common/devfile';
 import { DevfileListItem } from '../../common/devfileListItem';
 import { DevfileRecommendationInfo } from '../../common/devfileRecommendationInfo';
@@ -46,6 +46,8 @@ export function FromLocalCodebase({ setCurrentView }) {
 
     const [selectedDevfile, setSelectedDevfile] = React.useState<Devfile>(undefined);
 
+    const [createComponentErrorMessage, setCreateComponentErrorMessage] = React.useState('');
+
     function respondToMessage(messageEvent: MessageEvent) {
         const message = messageEvent.data as Message;
         switch (message.action) {
@@ -77,6 +79,11 @@ export function FromLocalCodebase({ setCurrentView }) {
                 setRecommendedDevfile((prevState) => ({ ...prevState, isDevfileExistsInFolder: message.data }));
                 break;
             }
+            case 'createComponentFailed': {
+                setLoading(false);
+                setCreateComponentErrorMessage(message.data);
+                break;
+            }
         }
     }
 
@@ -99,13 +106,14 @@ export function FromLocalCodebase({ setCurrentView }) {
         setRecommendedDevfile((prevState) => ({ ...prevState, isLoading: true }));
     };
 
-    function handleCreateComponent() {
+    function createComponentFromLocalCodebase(projectFolder: string, componentName: string) {
         window.vscodeApi.postMessage({
             action: 'createComponent',
             data: {
                 devfileDisplayName: selectedDevfile ? (selectedDevfile.name) : (recommendedDevfile.devfile.name),
                 componentName: componentName,
-                path: projectFolder
+                path: projectFolder,
+                isFromTemplateProject: false,
             }
         });
         setLoading(true);
@@ -214,10 +222,16 @@ export function FromLocalCodebase({ setCurrentView }) {
                                             }}>
                                             SELECT A DIFFERENT DEVFILE
                                         </Button>
-                                        <LoadingButton variant='contained' disabled={isLoading} loading={isLoading} onClick={handleCreateComponent}>
-                                            CREATE COMPONENT
-                                        </LoadingButton>
+                                        <CreateComponentButton
+                                            componentName={componentName}
+                                            componentParentFolder={projectFolder}
+                                            isComponentNameFieldValid={isComponentNameFieldValid}
+                                            isFolderFieldValid={true}
+                                            isLoading={isLoading}
+                                            createComponent={createComponentFromLocalCodebase}
+                                            setLoading={setLoading} />
                                     </Stack >
+                                    <CreateComponentErrorAlert createComponentErrorMessage={createComponentErrorMessage} />
                                 </Stack >
                             </>
                         )}


### PR DESCRIPTION
The following feedback is addressed in this PR:
* info box for “existing project” typo → …structure *of* the…
* add description for each option
* error page or notification if `odo init` fails, allow the user to go back and try again
* add “creating” next to the progress indicator when creating the component during the final step
   * added loading indicator beside the `Create Component` button text
   
Also:
* combines `createComponent` and `createComponentFromTemplateProject` cases in `createComponentLoader.ts`
