### PR TITLE
Address some of the feedback on 'Create Component' (see notes)

### DIFF
--- a/src/webview/common/devfileListItem.tsx
+++ b/src/webview/common/devfileListItem.tsx
@@ -21,68 +21,76 @@ export function DevfileListItem(props: DevfileListItemProps) {
             sx={{ width: 'calc(100% - 16px)' }}
             alignItems="center"
             paddingX={1}
-            spacing={3}
+            justifyContent="space-between"
         >
-            <Box
-                sx={{
-                    display: 'flex',
-                    width: '7em',
-                    height: '7em',
-                    bgcolor: 'white',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    borderRadius: '4px',
-                }}
-            >
-                <img src={props.devfile.logoUrl} style={{ maxWidth: '6em', maxHeight: '6em' }} />
-            </Box>
-            <Stack
-                direction="column"
-                spacing={1}
-                sx={{ flexShrink: '5', minWidth: '0', maxWidth: '35rem' }}
-            >
-                <Stack direction="row" spacing={2} alignItems="center">
+            <Stack direction="row" spacing={3}>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        width: '7em',
+                        height: '7em',
+                        bgcolor: 'white',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        borderRadius: '4px',
+                    }}
+                >
+                    <img
+                        src={props.devfile.logoUrl}
+                        style={{ maxWidth: '6em', maxHeight: '6em' }}
+                    />
+                </Box>
+                <Stack
+                    direction="column"
+                    spacing={1}
+                    sx={{ flexShrink: '5', minWidth: '0', maxWidth: '35rem' }}
+                >
+                    <Stack direction="row" spacing={2} alignItems="center">
+                        <Typography
+                            variant="body1"
+                            sx={{
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                            }}
+                        >
+                            {props.devfile.name}
+                        </Typography>
+                        <Typography variant="body2" fontStyle="italic">
+                            from {props.devfile.registryName}
+                        </Typography>
+                    </Stack>
                     <Typography
-                        variant="body1"
+                        variant="body2"
                         sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
                     >
-                        {props.devfile.name}
+                        {props.devfile.description}
                     </Typography>
-                    <Typography variant="body2" fontStyle="italic">
-                        from {props.devfile.registryName}
-                    </Typography>
-                </Stack>
-                <Typography
-                    variant="body2"
-                    sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
-                >
-                    {props.devfile.description}
-                </Typography>
-                <Stack direction="row" spacing={1}>
-                    <Chip
-                        size="small"
-                        label="Debug Support"
-                        icon={props.devfile.supportsDebug ? <Check /> : <Close />}
-                        color={props.devfile.supportsDebug ? 'success' : 'error'}
-                    />
-                    <Chip
-                        size="small"
-                        label="Deploy Support"
-                        icon={props.devfile.supportsDeploy ? <Check /> : <Close />}
-                        color={props.devfile.supportsDeploy ? 'success' : 'error'}
-                    />
-                    {props.devfile.tags.map((tag, i) => {
-                        if (i >= 4) {
-                            return;
-                        }
-                        return <Chip size="small" label={tag} key={tag} />;
-                    })}
-                    {props.devfile.tags.length > 4 && (
-                        <Chip size="small" label="..." key="ellipsis" />
-                    )}
+                    <Stack direction="row" spacing={1}>
+                        <Chip
+                            size="small"
+                            label="Debug Support"
+                            icon={props.devfile.supportsDebug ? <Check /> : <Close />}
+                            color={props.devfile.supportsDebug ? 'success' : 'error'}
+                        />
+                        <Chip
+                            size="small"
+                            label="Deploy Support"
+                            icon={props.devfile.supportsDeploy ? <Check /> : <Close />}
+                            color={props.devfile.supportsDeploy ? 'success' : 'error'}
+                        />
+                        {props.devfile.tags.map((tag, i) => {
+                            if (i >= 4) {
+                                return;
+                            }
+                            return <Chip size="small" label={tag} key={tag} />;
+                        })}
+                        {props.devfile.tags.length > 4 && (
+                            <Chip size="small" label="..." key="ellipsis" />
+                        )}
+                    </Stack>
                 </Stack>
             </Stack>
-            <Box sx={{ flexGrow: '1' }} />
             {props.buttonCallback ? (
                 <Button variant="contained" onClick={props.buttonCallback}>
                     Use Devfile

--- a/src/webview/common/fromTemplateProject.tsx
+++ b/src/webview/common/fromTemplateProject.tsx
@@ -57,6 +57,7 @@ export function FromTemplateProject(props: FromTemplateProjectProps) {
                     createComponent={createComponent}
                     devfile={selectedDevfile}
                     templateProject={selectedTemplateProject.templateProjectName}
+                    initialComponentName={selectedTemplateProject.templateProjectName}
                 />
             );
     }

--- a/src/webview/common/setNameAndFolder.tsx
+++ b/src/webview/common/setNameAndFolder.tsx
@@ -9,7 +9,7 @@ import {
     Paper,
     Stack,
     TextField,
-    Typography
+    Typography,
 } from '@mui/material';
 import * as React from 'react';
 import 'react-dom';
@@ -28,12 +28,15 @@ type SetNameAndFolderProps = {
     createComponent: (projectFolder: string, componentName: string) => void;
     devfile: Devfile;
     templateProject?: string;
+    initialComponentName?: string;
 };
 
 export function SetNameAndFolder(props: SetNameAndFolderProps) {
-    const [componentName, setComponentName] = React.useState('');
+    const [componentName, setComponentName] = React.useState(props.initialComponentName);
     const [isComponentNameFieldValid, setComponentNameFieldValid] = React.useState(true);
-    const [componentNameErrorMessage, setComponentNameErrorMessage] = React.useState('Please enter a component name.');
+    const [componentNameErrorMessage, setComponentNameErrorMessage] = React.useState(
+        'Please enter a component name.',
+    );
 
     const [componentParentFolder, setComponentParentFolder] = React.useState('');
     const [isFolderFieldValid, setFolderFieldValid] = React.useState(false);
@@ -91,12 +94,19 @@ export function SetNameAndFolder(props: SetNameAndFolderProps) {
         };
     }, []);
 
+    React.useEffect(() => {
+        if (props.initialComponentName) {
+            window.vscodeApi.postMessage({
+                action: 'validateComponentName',
+                data: props.initialComponentName,
+            });
+        }
+    }, []);
+
     return (
         <Stack direction="column" spacing={3}>
             <div style={{ position: 'relative' }}>
-                <Typography variant='h5'>
-                    Set Component Name and Folder
-                </Typography>
+                <Typography variant="h5">Set Component Name and Folder</Typography>
             </div>
 
             <Stack direction="column" spacing={2} marginTop={2}>
@@ -104,12 +114,12 @@ export function SetNameAndFolder(props: SetNameAndFolderProps) {
                     <Stack margin={2} spacing={2}>
                         <DevfileListItem devfile={props.devfile} />
                         {/* padding here is to match the padding build into the devfile list component */}
-                        {props.templateProject &&
+                        {props.templateProject && (
                             <Stack direction="row" alignItems="center" spacing={1} paddingX={1}>
                                 <Typography variant="body1">Project:</Typography>
                                 <code>{props.templateProject}</code>
                             </Stack>
-                        }
+                        )}
                     </Stack>
                 </Paper>
                 <ComponentNameInput
@@ -157,7 +167,7 @@ export function SetNameAndFolder(props: SetNameAndFolderProps) {
 
                 <Stack direction="row" justifyContent="space-between">
                     <Button variant="text" onClick={props.goBack}>
-                        {props.templateProject ? ('Use Different Template Project') : ('Back')}
+                        {props.templateProject ? 'Use Different Template Project' : 'Back'}
                     </Button>
                     <CreateComponentButton
                         componentName={componentName}
@@ -166,9 +176,12 @@ export function SetNameAndFolder(props: SetNameAndFolderProps) {
                         isFolderFieldValid={isFolderFieldValid}
                         isLoading={isLoading}
                         createComponent={props.createComponent}
-                        setLoading={setLoading} />
+                        setLoading={setLoading}
+                    />
                 </Stack>
-                <CreateComponentErrorAlert createComponentErrorMessage={createComponentErrorMessage} />
+                <CreateComponentErrorAlert
+                    createComponentErrorMessage={createComponentErrorMessage}
+                />
             </Stack>
         </Stack>
     );

--- a/src/webview/common/vscode-theme.ts
+++ b/src/webview/common/vscode-theme.ts
@@ -3,11 +3,19 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import {
-    PaletteMode,
-    Theme,
-    createTheme
-} from '@mui/material';
+import { createTheme, PaletteMode, Theme } from '@mui/material';
+
+// in order to add custom named colours for use in Material UI's `color` prop,
+// you need to use module augmentation.
+// see https://mui.com/material-ui/customization/palette/#typescript
+declare module '@mui/material/styles' {
+    interface Palette {
+        textSecondary: Palette['primary'];
+    }
+    interface PaletteOptions {
+        textSecondary?: PaletteOptions['primary'];
+    }
+}
 
 export function createVSCodeTheme(paletteMode: PaletteMode): Theme {
     const computedStyle = window.getComputedStyle(document.body);
@@ -33,6 +41,9 @@ export function createVSCodeTheme(paletteMode: PaletteMode): Theme {
             success: {
                 main: computedStyle.getPropertyValue('--vscode-debugIcon-startForeground'),
             },
+            textSecondary: {
+                main: computedStyle.getPropertyValue('--vscode-descriptionForeground'),
+            },
         },
         typography: {
             allVariants: {
@@ -44,90 +55,96 @@ export function createVSCodeTheme(paletteMode: PaletteMode): Theme {
                 variants: [
                     {
                         props: {
-                            variant: 'outlined'
+                            variant: 'outlined',
                         },
                         style: {
                             width: '35em',
-                            backgroundColor: computedStyle.getPropertyValue('--vscode-editor-inactiveSelectionBackground')
-                        }
-                    }
-                ]
+                            backgroundColor: computedStyle.getPropertyValue(
+                                '--vscode-editor-inactiveSelectionBackground',
+                            ),
+                        },
+                    },
+                ],
             },
             MuiTypography: {
                 variants: [
                     {
                         props: {
-                            variant: 'h5'
+                            variant: 'h5',
                         },
                         style: {
                             fontSize: '2.3em',
                             fontWeight: '650',
-                            color: computedStyle.getPropertyValue('--vscode-foreground')
-                        }
+                            color: computedStyle.getPropertyValue('--vscode-foreground'),
+                        },
                     },
                     {
                         props: {
-                            variant: 'h6'
+                            variant: 'h6',
                         },
                         style: {
                             fontSize: '1.5em',
                             fontWeight: '600',
-                            color: computedStyle.getPropertyValue('--vscode-foreground')
-                        }
+                            color: computedStyle.getPropertyValue('--vscode-foreground'),
+                        },
                     },
                     {
                         props: {
-                            variant: 'body1'
+                            variant: 'body1',
                         },
                         style: {
-                            color: computedStyle.getPropertyValue('--vscode-foreground')
-                        }
+                            color: computedStyle.getPropertyValue('--vscode-foreground'),
+                        },
                     },
                     {
                         props: {
-                            variant: 'body2'
+                            variant: 'body2',
                         },
                         style: {
-                            color: computedStyle.getPropertyValue('--vscode-descriptionForeground')
-                        }
+                            color: computedStyle.getPropertyValue('--vscode-descriptionForeground'),
+                        },
                     },
-                ]
+                ],
             },
             MuiAccordion: {
                 variants: [
                     {
                         props: {
-                            className: 'accordion'
+                            className: 'accordion',
                         },
                         style: {
                             width: '100%',
                             color: computedStyle.getPropertyValue('--vscode-editor-foreground'),
-                            backgroundColor: computedStyle.getPropertyValue('--vscode-editor-background')
-                        }
-                    }
-                ]
+                            backgroundColor: computedStyle.getPropertyValue(
+                                '--vscode-editor-background',
+                            ),
+                        },
+                    },
+                ],
             },
             MuiSelect: {
                 variants: [
                     {
                         props: {
-                            className: 'selectFolder'
+                            className: 'selectFolder',
                         },
                         style: {
                             width: '100%',
                             color: computedStyle.getPropertyValue('--vscode-editor-foreground'),
-                            backgroundColor: computedStyle.getPropertyValue('--vscode-editor-background')
-                        }
-                    }
-                ]
+                            backgroundColor: computedStyle.getPropertyValue(
+                                '--vscode-editor-background',
+                            ),
+                        },
+                    },
+                ],
             },
             MuiButton: {
                 defaultProps: {
                     style: {
-                        whiteSpace: 'nowrap'
-                    }
-                }
-            }
+                        whiteSpace: 'nowrap',
+                    },
+                },
+            },
         },
     });
 }

--- a/src/webview/create-component/createComponentLoader.ts
+++ b/src/webview/create-component/createComponentLoader.ts
@@ -41,6 +41,10 @@ export default class CreateComponentLoader {
     }
 
     static async loadView(title: string): Promise<WebviewPanel> {
+        if (CreateComponentLoader.panel) {
+            CreateComponentLoader.panel.reveal();
+            return;
+        }
         const localResourceRoot = Uri.file(
             path.join(CreateComponentLoader.extensionPath, 'out', 'createComponentViewer'),
         );
@@ -64,7 +68,7 @@ export default class CreateComponentLoader {
         panel.onDidDispose(() => {
             colorThemeDisposable.dispose();
             messageHandlerDisposable.dispose();
-            panel = undefined;
+            CreateComponentLoader.panel = undefined;
         });
 
         panel.iconPath = Uri.file(

--- a/src/webview/create-component/pages/createComponent.tsx
+++ b/src/webview/create-component/pages/createComponent.tsx
@@ -7,11 +7,11 @@ import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import { Container, Theme, ThemeProvider, Typography } from '@mui/material';
 import * as React from 'react';
+import { FromTemplateProject } from '../../common/fromTemplateProject';
 import OptionCard from '../../common/optionCard';
 import { createVSCodeTheme } from '../../common/vscode-theme';
-import { FromExistingGitRepo } from './fromExisitingGitRepo';
+import { FromExistingGitRepo } from './fromExistingGitRepo';
 import { FromLocalCodebase } from './fromLocalCodebase';
-import { FromTemplateProject } from '../../common/fromTemplateProject';
 
 interface VSCodeMessage {
     action: string;
@@ -112,8 +112,12 @@ export default function CreateComponent() {
     return (
         <ThemeProvider theme={theme}>
             <Container
-                maxWidth="lg"
-                sx={{ height: '100%', paddingTop: '5em', paddingBottom: '16px' }}
+                maxWidth='lg'
+                sx={{
+                    height: '100%',
+                    paddingTop: '5em',
+                    paddingBottom: '16px',
+                }}
             >
                 {renderComponent()}
             </Container>

--- a/src/webview/create-component/pages/fromExistingGitRepo.tsx
+++ b/src/webview/create-component/pages/fromExistingGitRepo.tsx
@@ -264,6 +264,7 @@ export function FromExistingGitRepo({ setCurrentView }) {
                     }}
                     createComponent={createComponentFromGitRepo}
                     devfile={selectedDevfile ? (selectedDevfile) : (recommendedDevfile.devfile)}
+                    initialComponentName={gitURL.url.substring(gitURL.url.lastIndexOf('/') + 1)}
                 />
             );
         case 'selectDifferentDevfile':

--- a/src/webview/tsconfig.json
+++ b/src/webview/tsconfig.json
@@ -17,6 +17,8 @@
     "include": [
         "*/app/**/*.ts",
         "*/app/**/*.tsx",
+        "common/*.tsx",
+        "common/*.ts"
     ],
     "exclude": [
         "*/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
         "src/webview/cluster/app",
         "src/webview/create-service/app",
         "src/webview/create-component/app",
+        "src/webview/create-component/pages",
         "src/webview/devfile-registry/app",
         "src/webview/welcome/app",
         "src/webview/git-import/app",


### PR DESCRIPTION
- Clear field button for search field in devfile search
- Select the template project by default if there is only one
  - Handle the case that there are no template projects (you can test with the Universal Developer Image devfile)
- Change icon buttons to use secondary text colour
- Prepopulate the component name field based on the git url or template project name
- Rename `fromExistingGitRepo.tsx` to address typo
- Add a copy button for devfile YAML
- Focus existing Create Component webview instead of opening a second instance (There are issues with how message passing is handled if there are multiple instances of Create Component running)
- Make devfile search scale better when zooming (there is no horizontal scrolling up to zoom level 4 on my 1440p monitor)