### PR TITLE
Add context menu to create Routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -827,6 +827,28 @@
 				"command": "openshift.Serverless.stopRun",
 				"title": "Stop",
 				"category": "OpenShift"
+			},
+			{
+				"command": "openshift.resource.exposeAsRoute",
+				"title": "Expose service as Route",
+				"category": "OpenShift"
+			},
+			{
+				"command": "openshift.resource.unexpose",
+				"title": "Remove Route for service",
+				"category": "OpenShift"
+			},
+			{
+				"command": "openshift.resource.openUrl",
+				"title": "Open Service Url",
+				"category": "OpenShift",
+				"icon": "$(link-external)"
+			},
+			{
+				"command": "openshift.resource.copyUrl",
+				"title": "Copy Service Url",
+				"category": "OpenShift",
+				"icon": "$(link)"
 			}
 		],
 		"keybindings": [
@@ -1153,8 +1175,23 @@
 				{
 					"command": "openshift.Serverless.stopRun",
 					"when": "false"
+				},
+				{
+					"command": "openshift.resource.exposeAsRoute",
+					"when": "false"
+				},
+				{
+					"command": "openshift.resource.unexpose",
+					"when": "false"
+				},
+				{
+					"command": "openshift.resource.openUrl",
+					"when": "false"
+				},
+				{
+					"command": "openshift.resource.copyUrl",
+					"when": "false"
 				}
-
 			],
 			"view/title": [
 				{
@@ -1477,11 +1514,29 @@
 				},
 				{
 					"command": "openshift.resource.load",
-					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject"
+					"when": "view == openshiftProjectExplorer && (viewItem == openshift.k8sObject || viewItem == openshift.k8sObject.route)"
 				},
 				{
 					"command": "openshift.resource.unInstall",
 					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject.helm"
+				},
+				{
+					"command": "openshift.resource.exposeAsRoute",
+					"when": "view == openshiftProjectExplorer && isOpenshiftCluster && viewItem == openshift.k8sObject"
+				},
+				{
+					"command": "openshift.resource.unexpose",
+					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject.route"
+				},
+				{
+					"command": "openshift.resource.openUrl",
+					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject.route",
+					"group": "inline"
+				},
+				{
+					"command": "openshift.resource.copyUrl",
+					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject.route",
+					"group": "inline"
 				},
 				{
 					"command": "openshift.resource.openInDeveloperConsole",

--- a/src/oc/ocWrapper.ts
+++ b/src/oc/ocWrapper.ts
@@ -1,0 +1,110 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { KubernetesObject } from '@kubernetes/client-node/dist/types';
+import { CommandOption, CommandText } from '../base/command';
+import { CliChannel } from '../cli';
+
+/**
+ * Returns the oc command to list all resources of the given type in the given (or current) namespace
+ *
+ * @param resourceType the resource type to get
+ * @param namespace the namespace from which to get all the stateful sets
+ * @returns the oc command to list all resources of the given type in the given (or current) namespace
+ */
+function getKubernetesObjectCommand(resourceType: string, namespace?: string): CommandText {
+    if (!resourceType) {
+        throw new Error('Must pass the resource type to get');
+    }
+    const args = [new CommandOption('-o', 'json')];
+    if (namespace) {
+        args.push(new CommandOption('--namespace', namespace));
+    }
+    return new CommandText('oc get', resourceType, args);
+}
+
+function deleteKubernetesObjectCommand(
+    resourceType: string,
+    resourceName: string,
+    namespace?: string,
+): CommandText {
+    if (!resourceType || !resourceName) {
+        throw new Error('Must pass the resource type and resource name');
+    }
+    const args = [];
+    if (namespace) {
+        args.push(new CommandOption('--namespace', namespace));
+    }
+    return new CommandText('oc delete', `${resourceType} ${resourceName}`, args);
+}
+
+function ocExposeCommand(resourceName: string): CommandText {
+    return new CommandText('oc expose svc', resourceName);
+}
+
+/**
+ * Wraps `oc`. It's a class so that it can be stubbed in unit tests.
+ */
+export class Oc {
+    private static INSTANCE = new Oc();
+
+    static get Instance() {
+        return Oc.INSTANCE;
+    }
+
+    /**
+     * Returns a list of all resources of the given type in the given namespace.
+     *
+     * If no namespace is supplied, the current namespace is used.
+     *
+     * @param resourceType the type of resource to get a list of
+     * @param namespace the namespace to list the resources of (defaults to the current namespace if none is provided)
+     * @returns a list of all resources of the given type in the given namespace
+     */
+    public async getKubernetesObject(
+        resourceType: string,
+        namespace?: string,
+    ): Promise<KubernetesObject[]> {
+        const result = await CliChannel.getInstance().executeTool(
+            getKubernetesObjectCommand(resourceType, namespace),
+        );
+        return JSON.parse(result.stdout).items;
+    }
+
+    /**
+     * Delete the given Kubernetes resource
+     *
+     * @param resourceType the type of the Kubernetes resource to delete
+     * @param resourceName the name of the Kubernetes resource to delete
+     * @param namespace the namespace that the Kubernetes resource to delete is in. If not provided, the current namespace will be used
+     */
+    public async deleteKubernetesObject(
+        resourceType: string,
+        resourceName: string,
+        namespace?: string,
+    ) {
+        await CliChannel.getInstance().executeTool(
+            deleteKubernetesObjectCommand(resourceType, resourceName, namespace),
+        );
+    }
+
+    /**
+     * Expose the given service as a Route.
+     *
+     * @throws Error if the service doesn't exist
+     * @param serviceName the name of the service to expose as a route
+     */
+    public async exposeServiceAsRoute(serviceName: string): Promise<void> {
+        await this.checkForService(serviceName);
+        await CliChannel.getInstance().executeTool(ocExposeCommand(serviceName));
+    }
+
+    private async checkForService(resourceName: string): Promise<void> {
+        const services = await this.getKubernetesObject('service');
+        if (!services.some((service) => service.metadata.name === resourceName)) {
+            throw new Error(`The resource ${resourceName} has no corresponding service to expose`);
+        }
+    }
+}


### PR DESCRIPTION
- Add a context menu item in order to add a route for a given service
- Add a context menu item in order to delete the route for a given service
- Add a button when there is a route to open the route in the browser
- Add a button when there is a route to copy the route URL

I think that we should wait on working similar funcitonality for Ingresses in a future PR (see [my comment on the issue](https://github.com/redhat-developer/vscode-openshift-tools/issues/3072#issuecomment-1664563162)).

Closes #3072

Signed-off-by: David Thompson <davthomp@redhat.com>
