### PR TITLE
Migrate Jenkins release build to GitHub Actions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      publishPreRelease:
+        description: 'Publish a pre-release ?'
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'true'
+      publishToMarketPlace:
+        description: 'Publish to VS Code Marketplace ?'
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'false'
+      publishToOVSX:
+        description: 'Publish to OpenVSX Registry ?'
+        required: true
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+        default: 'false'
+
+jobs:
+  packaging-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout vscode-openshift-tools
+        uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: |
+          npm install -g typescript "vsce" "ovsx"
+          npm install
+          echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
+      - name: Build And Run Unit Tests
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 #v1.0.1
+        with:
+          run: npm run test
+      - name: Package
+        run: |
+          jq --tab '.extensionDependencies += [ "ms-kubernetes-tools.vscode-kubernetes-tools" ]' package.json  > package.json.new
+          mv package.json.new package.json
+          node ./out/build/update-readme.js
+          declare -A targets
+          targets["win32-x64"]=win32
+          targets["win32-arm64"]=win32
+          targets["linux-x64"]=linux
+          targets["darwin-x64"]=darwin
+          targets["darwin-arm64"]=darwin
+          for target in ${!targets[@]}; do
+            export TARGET=${targets[${target}]}
+            vsce package --target ${target} -o openshift-toolkit-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}-${target}.vsix
+            sha256sum *-${target}.vsix > openshift-toolkit-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}-${target}.vsix.sha256
+          done
+          ls -lash *.vsix *.sha256
+      - name: Upload VSIX Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: openshift-toolkit
+          path: openshift-toolkit*-${{ env.EXT_VERSION }}-${{github.run_number}}*.vsix
+          if-no-files-found: error
+      - name: Publish to GH Release Tab
+        if: ${{ inputs.publishToMarketPlace == 'true' && inputs.publishToOVSX == 'true' }}
+        uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ env.EXT_VERSION }}"
+          draft: true
+          files: |
+            openshift-toolkit-${{ env.EXT_VERSION }}-${{github.run_number}}*.vsix
+            openshift-toolkit-${{ env.EXT_VERSION }}-${{github.run_number}}*.sha256
+
+  release-job:
+    if: ${{ inputs.publishToMarketPlace == 'true' || inputs.publishToOVSX == 'true' }}
+    environment: ${{ (inputs.publishToMarketPlace == 'true' || inputs.publishToOVSX == 'true') && 'release' || 'pre-release' }}
+    runs-on: ubuntu-latest
+    needs: packaging-job
+    steps:
+    - name: Checkout vscode-openshift-tools
+      uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: |
+        npm install -g typescript "vsce" "ovsx"
+        echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
+    - name: Download VSIX Artifacts
+      uses: actions/download-artifact@v3
+    - name: Publish to VS Code Marketplace
+      if: ${{ github.event_name == 'schedule' || inputs.publishToMarketPlace == 'true' || inputs.publishPreRelease == 'true' }}
+      run: |
+        for platform in darwin-x64 darwin-arm64 linux-x64 win32-x64 win32-arm64; do
+          vsce publish -p ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --packagePath openshift-toolkit/openshift-toolkit-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}-${platform}.vsix
+        done
+    - name: Publish to OpenVSX Registry
+      if: ${{ github.event_name == 'schedule' || inputs.publishToOVSX == 'true' || inputs.publishPreRelease == 'true' }}
+      run: |
+        for platform in darwin-x64 darwin-arm64 linux-x64 win32-x64 win32-arm64; do
+          ovsx publish -p ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --packagePath openshift-toolkit/openshift-toolkit-${{ env.EXT_VERSION }}-${GITHUB_RUN_NUMBER}-${platform}.vsix
+        done


### PR DESCRIPTION
- Fixes https://github.com/redhat-developer/vscode-openshift-tools/issues/3059
See https://github.com/rgrunber/vscode-openshift-tools/actions/runs/5804080228 for a sample of the build. It publishes a draft release at https://github.com/rgrunber/vscode-openshift-tools/releases/tag/1.6.0 (with the vsix artifacts included so they can be tested prior to approval) in addition to tagging the release.

- Is it worth adding the smoke tests ? They seem to be failing now.
- I have simplified some of the packaging logic, but it should behave the same, just less duplication of lines
- The `TARGET=all` was used to create a universal vsix that contained all of the tooling (and was also used in the smoke tests although maybe we could just use linux-x64 vsix for the smoke tests on ubuntu-latest). It was very large, and only used on OpenVSX. We removed it in #2908. So we have no real reason to package it since we don't publish it anywhere.
- We aren't using pre-releases but I kept that input option in for potential future use.