### PR TITLE
Run integration tests on KinD

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -44,13 +44,6 @@ jobs:
         with:
           run: npm run test:coverage --silent
 
-      # Upload coverage to codecov.io
-      - name: Codecov
-        uses: codecov/codecov-action@40a12dcee2df644d47232dde008099a3e9e4f865 #v3.1.2
-        if: runner.os == 'Linux'
-        with:
-          file: ./out/coverage/coverage-final.json
-
       # UI tests fail under linux
       # Run UI tests
       - name: Run UI Tests
@@ -62,6 +55,36 @@ jobs:
           run: npm run public-ui-test
           options: -screen 0 1920x1080x24
 
+      - uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 #v0.5.0
+        if: (success() || failure()) && runner.os == 'Linux'
+        name: Start cluster
+        with:
+          version: v0.11.1
+
+      - name: Configure cluster
+        if: (success() || failure()) && runner.os == 'Linux'
+        run: |
+          curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.19.1/install.sh | bash -s v0.19.1
+          kubectl create -f https://operatorhub.io/install/service-binding-operator.yaml
+          kubectl create -f https://operatorhub.io/install/stable/cloud-native-postgresql.yaml
+          nb=0
+          echo -n "Waiting for operator to show up "
+          while [ "$nb" != "2" ]
+          do
+            echo -n "."
+            sleep 1
+            nb=`kubectl get pods -n operators --no-headers --ignore-not-found | grep Running | wc -l`
+          done
+          echo CLUSTER_URL=`kubectl cluster-info | sed -n -e "s/\x1B\[[0-9;]*[a-zA-Z]//g" -e '1s/.*running at \(.*\)$/\1/p'` >> $GITHUB_ENV
+
+      - name: Build and run integration tests
+        if: (success() || failure()) && runner.os == 'Linux'
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 #v1.0.1
+        env:
+          NODE_OPTIONS: --max_old_space_size=16384
+        with:
+          run: npm run test-integration:coverage --silent
+
       # Archiving integration tests artifacts
       - name: Upload test artifacts
         uses: actions/upload-artifact@v3
@@ -72,3 +95,9 @@ jobs:
             test-resources/screenshots/*.png
           retention-days: 2
 
+      # Upload coverage to codecov.io
+      - name: Codecov
+        uses: codecov/codecov-action@40a12dcee2df644d47232dde008099a3e9e4f865 #v3.1.2
+        if: (success() || failure()) && runner.os == 'Linux'
+        with:
+          files: ./coverage/unit/coverage-final.json,./coverage/integration/coverage-final.json

--- a/coverconfig.json
+++ b/coverconfig.json
@@ -1,7 +1,7 @@
 {
     "enabled": true,
     "relativeSourcePath": "../../src",
-    "relativeCoverageDir": "../../coverage",
+    "relativeCoverageDir": "../../../coverage",
     "ignorePatterns": [
         "**/node_modules/**"
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -18689,9 +18689,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -34576,9 +34576,9 @@
 			}
 		},
 		"semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"compile:checkWebviews": "tsc -p ./src/webview -noEmit",
 		"compile:webviews": "node ./build/esbuild.mjs",
 		"watch": "node ./build/esbuild-watch.mjs",
-		"clean": "shx rm -rf out/build out/coverage out/src out/test out/tools out/test-resources out/*Viewer out/**.tsbuildinfo",
+		"clean": "shx rm -rf out/build out/src out/test out/tools out/test-resources out/*Viewer out/**.tsbuildinfo",
 		"lint": "eslint . --ext .ts --quiet",
 		"lint-fix": "eslint . --ext .ts --fix",
 		"lint-nic": "eslint . --ext .ts --no-inline-config",
@@ -69,7 +69,6 @@
 		"test:instrument": "shx rm -rf out/src-orig && shx mv out/src out/src-orig && istanbul instrument --complete-copy --embed-source --output out/src out/src-orig",
 		"test:coverage": "npm run build && npm run test:instrument && node ./out/build/install-vscode.js && node ./out/build/run-tests.js unit",
 		"update-deps": "ncu --upgrade --loglevel verbose --packageFile package.json && npm update",
-		"coverage:upload": "codecov -f coverage/coverage-final.json",
 		"build": "npm run clean && npm run lint && npm run compile && npm run bundle-tools",
 		"cluster-ui-test": "extest setup-and-run out/test/ui/cluster-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max -i",
 		"public-ui-test": "extest setup-and-run out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max -i"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,7 +89,7 @@ export class CliChannel implements Cli {
         this.odoChannel.show();
     }
 
-    async execute(cmd: string, opts: cp.ExecOptions = {}): Promise<CliExitData> {
+    execute(cmd: string, opts: cp.ExecOptions = {}): Promise<CliExitData> {
         return new Promise<CliExitData>((resolve) => {
             if (opts.maxBuffer === undefined) {
                 opts.maxBuffer = 2 * 1024 * 1024;
@@ -139,7 +139,7 @@ export class CliChannel implements Cli {
         return optsCopy;
     }
 
-    async executeTool(command: CommandText, opts?: cp.ExecOptions, fail = false): Promise<CliExitData> {
+    async executeTool(command: CommandText, opts?: cp.ExecOptions, fail = true): Promise<CliExitData> {
         const commandActual = command.toString();
         const commandPrivacy = command.privacyMode(true).toString();
         const [cmd] = commandActual.split(' ');

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -238,7 +238,7 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
             result = [...await this.odo3.getDeploymentConfigs(), ...await this.odo3.getDeployments(), ...await Helm.getHelmReleases()];
         }
         // don't show Open In Developer Dashboard if not openshift cluster
-        const openshiftResources = await CliChannel.getInstance().executeTool(Command.isOpenshiftCluster());
+        const openshiftResources = await CliChannel.getInstance().executeTool(Command.isOpenshiftCluster(), undefined, false);
         let isOpenshiftCluster = true;
         if (openshiftResources.stdout.length === 0){
             isOpenshiftCluster = false;

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -260,6 +260,9 @@ export class Command {
         return new CommandText('oc whoami -t');
     }
 
+    /**
+     * Only works for OpenShift clusters
+     */
     static showConsoleUrl(): CommandText {
         return new CommandText('oc get configmaps console-public -n openshift-config-managed -o json');
     }

--- a/src/openshift/project.ts
+++ b/src/openshift/project.ts
@@ -10,16 +10,16 @@ import { CliChannel } from '../cli';
 import { OpenShiftExplorer } from '../explorer';
 import { getInstance as getOdoInstance } from '../odo';
 import { Progress } from '../util/progress';
-import { VsCommandError, vsCommand } from '../vscommand';
+import { vsCommand, VsCommandError } from '../vscommand';
 import OpenShiftItem from './openshiftItem';
 
 export class Command {
     static setActiveProject(name: string) {
-        return new CommandText('oc', `project ${name}`);
+        return new CommandText('odo', `set namespace ${name}`);
     }
 
     static deleteProject(name: string) {
-        return new CommandText('oc delete project', name, [new CommandOption('--wait=true')])
+        return new CommandText('odo delete namespace', name, [new CommandOption('--wait=true'), new CommandOption('-f')])
     }
 
     static getAll(namespace: string) {

--- a/test/coverage.ts
+++ b/test/coverage.ts
@@ -9,15 +9,9 @@
 
 import paths = require('path');
 import fs = require('fs');
-
+import * as mkdirp from 'mkdirp';
 const istanbul = require('istanbul');
 const remapIstanbul = require('remap-istanbul');
-
-function _mkDirIfExists(dir: string): void {
-    if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir);
-    }
-}
 
 export interface TestRunnerOptions {
     relativeCoverageDir?: string;
@@ -43,7 +37,7 @@ export class CoverageRunner {
      *
      * @memberOf CoverageRunner
      */
-    public reportCoverage(): void {
+    public async reportCoverage(): Promise<void> {
         // istanbul.hook.unhookRequire();
 
         if (typeof global[this.coverageVar] === 'undefined' || Object.keys(global[this.coverageVar]).length === 0) {
@@ -58,8 +52,7 @@ export class CoverageRunner {
         const coverageFile = paths.resolve(reportingDir, `coverage${pidExt}.json`);
 
         // yes, do this again since some test runners could clean the dir initially created
-        _mkDirIfExists(reportingDir);
-
+        await mkdirp(reportingDir);
         fs.writeFileSync(coverageFile, JSON.stringify(cov), 'utf8');
 
         const remappedCollector = remapIstanbul.remap(cov, {
@@ -74,5 +67,6 @@ export class CoverageRunner {
         reporter.write(remappedCollector, true, () => {
             console.log(`Reports written to ${reportingDir}`);
         });
+
     }
 }

--- a/test/integration/helm.test.ts
+++ b/test/integration/helm.test.ts
@@ -11,6 +11,7 @@ import { getInstance } from '../../src/odo';
 import { Command } from '../../src/odo/command';
 
 suite('helm integration', function () {
+    const isOpenShift = process.env.IS_OPENSHIFT || false;
     const clusterUrl = process.env.CLUSTER_URL || 'https://api.crc.testing:6443';
     const username = process.env.CLUSTER_USER || 'developer';
     const password = process.env.CLUSTER_PASSWORD || 'developer';
@@ -18,25 +19,40 @@ suite('helm integration', function () {
     const odo = getInstance();
 
     const RELEASE_NAME = 'my-helm-release';
-    const CHART_NAME = 'janus-idp-backstage';
-    const CHART_VERSION = '2.2.0';
+    const CHART_NAME = 'fredco-samplechart';
+    const CHART_VERSION = '0.1.3';
+    const HELM_NAMESPACE = 'my-helm-charts';
 
-    setup(async function () {
-        await odo.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+    suiteSetup(async function () {
+        if (isOpenShift) {
+            await odo.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+        }
+        try {
+            await odo.deleteProject(HELM_NAMESPACE);
+        } catch (e) {
+            // do nothing
+        }
+        await odo.createProject(HELM_NAMESPACE);
     });
 
-    teardown(async function () {
+    suiteTeardown(async function () {
         try {
             await Helm.unInstallHelmChart(CHART_NAME);
         } catch (_) {
             // do nothing
         }
-        await odo.execute(Command.odoLogout());
+        // this call fails to exit on minikube/kind
+        void odo.deleteProject(HELM_NAMESPACE);
+        if (isOpenShift) {
+            await odo.execute(Command.odoLogout());
+        }
     });
 
     test('installs OpenShift repo', async function () {
         await Helm.addHelmRepo();
-        const repoListOutput = (await CliChannel.getInstance().executeTool(new CommandText('helm', 'repo list'))).stdout;
+        const repoListOutput = (
+            await CliChannel.getInstance().executeTool(new CommandText('helm', 'repo list'))
+        ).stdout;
         expect(repoListOutput).to.contain('openshift');
         expect(repoListOutput).to.contain('https://charts.openshift.io/');
     });
@@ -44,15 +60,14 @@ suite('helm integration', function () {
     test('installs a chart as a release', async function () {
         await Helm.installHelmChart(RELEASE_NAME, CHART_NAME, CHART_VERSION);
         const releases = await Helm.getHelmReleases();
-        const janusRelease = releases.find(release => release.name === RELEASE_NAME);
-        expect(janusRelease).to.exist;
+        const sampleChartRelease = releases.find((release) => release.name === RELEASE_NAME);
+        expect(sampleChartRelease).to.exist;
     });
 
     test('uninstalls a release', async function () {
         await Helm.unInstallHelmChart(RELEASE_NAME);
         const releases = await Helm.getHelmReleases();
-        const janusRelease = releases.find(release => release.name === RELEASE_NAME);
-        expect(janusRelease).to.not.exist;
+        const sampleChartRelease = releases.find((release) => release.name === RELEASE_NAME);
+        expect(sampleChartRelease).to.not.exist;
     });
-
 });

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -25,8 +25,10 @@ function loadCoverageRunner(testsRoot: string): CoverageRunner | undefined {
     let coverageRunner: CoverageRunner;
     const coverConfigPath = paths.join(testsRoot, '..', '..', '..', 'coverconfig.json');
     if (!process.env.OST_DISABLE_COVERAGE && fs.existsSync(coverConfigPath)) {
+        const coverageConfig = JSON.parse(fs.readFileSync(coverConfigPath, 'utf-8')) as TestRunnerOptions;
+        coverageConfig.relativeCoverageDir = paths.join(coverageConfig.relativeCoverageDir, 'integration');
         coverageRunner = new CoverageRunner(
-            JSON.parse(fs.readFileSync(coverConfigPath, 'utf-8')) as TestRunnerOptions,
+            coverageConfig,
             testsRoot,
         );
     }
@@ -60,7 +62,7 @@ export async function run(): Promise<void> {
             reject(e);
         }
     });
-    coverageRunner && coverageRunner.reportCoverage();
+    coverageRunner && await coverageRunner.reportCoverage();
     if (numFailures) {
         throw new Error(`${numFailures} tests failed`);
     }

--- a/test/integration/odo.test.ts
+++ b/test/integration/odo.test.ts
@@ -6,7 +6,6 @@
 import { V1Deployment } from '@kubernetes/client-node';
 import { expect } from 'chai';
 import * as fs from 'fs/promises';
-import * as _ from 'lodash';
 import { suite, suiteSetup } from 'mocha';
 import * as tmp from 'tmp';
 import { promisify } from 'util';
@@ -18,6 +17,7 @@ import { Command } from '../../src/odo/command';
 import { Project } from '../../src/odo/project';
 
 suite('odo integration', function () {
+    const isOpenShift = process.env.IS_OPENSHIFT || false;
     const clusterUrl = process.env.CLUSTER_URL || 'https://api.crc.testing:6443';
     const username = process.env.CLUSTER_USER || 'developer';
     const password = process.env.CLUSTER_PASSWORD || 'developer';
@@ -25,12 +25,14 @@ suite('odo integration', function () {
     const odo: Odo.Odo = Odo.getInstance();
 
     suiteSetup(async function () {
-        try {
-            await odo.execute(Command.odoLogout());
-        } catch (e) {
-            // do nothing
+        if (isOpenShift) {
+            try {
+                await odo.execute(Command.odoLogout());
+            } catch (e) {
+                // do nothing
+            }
+            await odo.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
         }
-        await odo.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
     });
 
     suiteTeardown(async function () {
@@ -46,7 +48,9 @@ suite('odo integration', function () {
             // do nothing
         }
 
-        await odo.execute(Command.odoLogout());
+        if (isOpenShift) {
+            await odo.execute(Command.odoLogout());
+        }
     });
 
     suite('clusters', function () {
@@ -131,7 +135,9 @@ suite('odo integration', function () {
         });
 
         suiteTeardown(async function () {
-            await odo.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+            if (isOpenShift) {
+                await odo.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+            }
             const newWorkspaceFolders = workspace.workspaceFolders.filter((workspaceFolder) => {
                 const fsPath = workspaceFolder.uri.fsPath;
                 return (fsPath !== tmpFolder1.fsPath && fsPath !== tmpFolder2.fsPath);
@@ -164,16 +170,18 @@ suite('odo integration', function () {
             const canCreatePod1 = await odo.canCreatePod();
             expect(canCreatePod1).to.exist;
             expect(canCreatePod1).to.equal(true);
-            await odo.execute(Command.odoLogout());
-            const canCreatePod2 = await odo.canCreatePod();
-            expect(canCreatePod2).to.exist;
-            expect(canCreatePod2).to.equal(false);
+            if (isOpenShift) {
+                await odo.execute(Command.odoLogout());
+                const canCreatePod2 = await odo.canCreatePod();
+                expect(canCreatePod2).to.exist;
+                expect(canCreatePod2).to.equal(false);
+            }
         });
     });
 
     suite('services', function () {
         const serviceName = 'my-test-service';
-        const projectName = `my-test-project${_.random(100)}`;
+        const projectName = 'my-test-service-project2';
 
         // taken from https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/kubernetes_deployments.html
         const serviceFileYaml = //
@@ -204,10 +212,12 @@ suite('odo integration', function () {
                 // do nothing
             }
             await odo.createProject(projectName);
+            await odo.execute(Command.setNamespace(projectName));
         });
 
-        suiteTeardown(async function () {
-            await odo.execute(Command.deleteProject(projectName));
+        suiteTeardown(function () {
+            // this call fails to exit on minikube/kind
+            void odo.deleteProject(projectName);
         });
 
         test('createService()', async function () {
@@ -272,8 +282,16 @@ suite('odo integration', function () {
     });
 
     suite('require login', function () {
+        suiteSetup(function () {
+            if (!isOpenShift) {
+                this.skip();
+            }
+        });
+
         suiteTeardown(async function () {
-            await odo.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+            if (isOpenShift) {
+                await odo.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
+            }
         });
 
         test('requireLogin()', async function () {

--- a/test/integration/project.test.ts
+++ b/test/integration/project.test.ts
@@ -10,6 +10,7 @@ import { Command as ProjectCommand } from '../../src/openshift/project';
 
 suite('openshift/project.ts', function () {
 
+    const isOpenShift = process.env.IS_OPENSHIFT || false;
     const clusterUrl = process.env.CLUSTER_URL || 'https://api.crc.testing:6443';
     const username = process.env.CLUSTER_USER || 'developer';
     const password = process.env.CLUSTER_PASSWORD || 'developer';
@@ -20,7 +21,7 @@ suite('openshift/project.ts', function () {
     const ODO = getInstance();
 
     suiteSetup(async function () {
-        if (await ODO.requireLogin()) {
+        if (isOpenShift && await ODO.requireLogin()) {
             await ODO.execute(Command.odoLoginWithUsernamePassword(clusterUrl, username, password));
         }
         try {

--- a/test/ui/Jenkinsfile
+++ b/test/ui/Jenkinsfile
@@ -16,7 +16,7 @@ node('rhel8') {
         stage('integration tests') {
             catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                 wrap([$class: 'Xvnc']) {
-                sh "npm run test-integration"
+                sh "IS_OPENSHIFT=1 npm run test-integration"
                 junit 'report.xml'
                 }
             }


### PR DESCRIPTION
- Introduce another environment variable in the tests, `IS_OPENSHIFT`, which indicates if the cluster is OpenShift or another k8s
- Set `IS_OPENSHIFT` to true when running on Jenkins
- Rewrite the tests to skip tests of OpenShift-specific features when the cluster isn't OpenShift
- Modify the CI GitHub Action to run the integration tests on KinD on Linux

*minor annoyance:*

When deleting a namespace in the teardown step of tests, the command wouldn't return when running on a non-OpenShift Kubernetes cluster. (Note that it works fine when running the command on CLI). In order to prevent this from causing timeout errors, I don't `await` these calls.

Closes #2871

Signed-off-by: David Thompson <davthomp@redhat.com>
