### PR TITLE
Background colour for "Create Function" wizard should respect theme.

### DIFF
--- a/src/webview/serverless-function/app/createFunction.tsx
+++ b/src/webview/serverless-function/app/createFunction.tsx
@@ -198,8 +198,9 @@ export class CreateFunction extends React.Component<CreateFunctionPageProps, {
                 </div>
                 <Container maxWidth='md' sx={{
                     border: '1px groove var(--vscode-activityBar-activeBorder)',
-                    borderRadius: '1rem', margin: 'auto', backgroundColor: '#101418',
-                    color: '#99CCF3'
+                    borderRadius: '1rem', margin: 'auto',
+                    backgroundColor: 'var(--vscode-settings-textInputBackground)',
+                    color: 'var(--vscode-settings-textInputForeground)'
                 }}>
                     <Box
                         display='flex'


### PR DESCRIPTION
Prior to this change on a light theme:

![image](https://github.com/redhat-developer/vscode-openshift-tools/assets/1417342/988df602-b6a5-4f78-80a2-fa6ee11cf95a)

I'm actually not sure what `color` does in this instance as I wasn't able to see it shown at all, but I've also changed that to what seems like a better value.