### PR TITLE
Why is the dependency on vscode-kubernetes added during release? #3091

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -74,7 +74,8 @@
             "sourceMaps": true,
             "preLaunchTask": "instrument",
             "env": {
-                "VSCODE_REDHAT_TELEMETRY_DEBUG":"true"
+                "VSCODE_REDHAT_TELEMETRY_DEBUG":"true",
+                "IS_OPENSHIFT": "true",
             }
         },
         {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,6 @@ node('rhel8'){
 
   withEnv(['TARGET=all']) {
     stage('Package sources and ovsx package') {
-        packageJson.extensionDependencies << "ms-kubernetes-tools.vscode-kubernetes-tools"
-        writeJSON file: 'package.json', json: packageJson, pretty: 4
         sh 'node ./out/build/update-readme.js'
         sh "vsce package -o openshift-toolkit-${packageJson.version}-${env.BUILD_NUMBER}-ovsx.vsix"
         sh "sha256sum *-ovsx.vsix > openshift-toolkit-${packageJson.version}-${env.BUILD_NUMBER}-ovsx.vsix.sha256"

--- a/build/install-vscode.ts
+++ b/build/install-vscode.ts
@@ -28,7 +28,8 @@ void testElectron.downloadAndUnzipVSCode().then((executable: string) => {
 
     // Install extensions that openshift-toolkit depends on
     const extensionsToInstall = [
-        'redhat.vscode-redhat-account'
+        'redhat.vscode-redhat-account',
+        'ms-kubernetes-tools.vscode-kubernetes-tools'
     ];
 
     const extensionRootPath = path.resolve(__dirname, '..', '..');

--- a/package.json
+++ b/package.json
@@ -1895,7 +1895,8 @@
 		]
 	},
 	"extensionDependencies": [
-		"redhat.vscode-redhat-account"
+		"redhat.vscode-redhat-account",
+		"ms-kubernetes-tools.vscode-kubernetes-tools"
 	],
 	"__metadata": {
 		"id": "8fea1f1f-b45c-4eea-b479-3a92c6e697d3",

--- a/test/unit/extension.test.ts
+++ b/test/unit/extension.test.ts
@@ -105,6 +105,7 @@ suite('openshift toolkit Extension', () => {
 
     test('Extension should be present', () => {
 		assert.ok(vscode.extensions.getExtension('redhat.vscode-openshift-connector'));
+		assert.ok(vscode.extensions.getExtension('ms-kubernetes-tools.vscode-kubernetes-tools'));
 	});
 
     test('should register all extension commands declared commands in package descriptor', async function() {


### PR DESCRIPTION
Fixes: #3091