### PR TITLE
[build] Try limiting the supported Node.js version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,8 @@
 				"vscode-extension-tester": "^5.2.0"
 			},
 			"engines": {
+				"node": ">=16.0.0  <18.0.0",
+				"npm": ">=8.0.0 <9.0.0",
 				"vscode": "^1.64.2"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
 	},
 	"bugs": "https://github.com/redhat-developer/vscode-openshift-tools/issues",
 	"engines": {
-		"vscode": "^1.64.2"
+		"vscode": "^1.64.2",
+		"npm" : ">=8.0.0 <9.0.0",
+		"node" : ">=16.0.0  <18.0.0"
 	},
 	"badges": [
 		{


### PR DESCRIPTION
Try limiting Node.js to [v16, v18] (inclusively) to use only the versions supported by VSCode