### PR TITLE
Removed current namespace from serverless function tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1627,11 +1627,11 @@
 				},
 				{
 					"command": "openshift.Serverless.deploy",
-					"when": "view == openshiftServerlessFunctionsView && viewItem =~ /^(localFunctions|localFunctionsWithBuild|localDeployFunctions)$/"
+					"when": "view == openshiftServerlessFunctionsView && viewItem =~ /^(localFunctions|localFunctionsWithBuild|localDeployFunctions)$/ && isLoggedIn"
 				},
 				{
 					"command": "openshift.Serverless.undeploy",
-					"when": "view == openshiftServerlessFunctionsView && viewItem =~ /^(localDeployFunctions|deployFunctions)$/"
+					"when": "view == openshiftServerlessFunctionsView && viewItem =~ /^(localDeployFunctions|deployFunctions)$/ && isLoggedIn"
 				},
 				{
 					"command": "openshift.Serverless.stopRun",

--- a/src/serverlessFunction/functions.ts
+++ b/src/serverlessFunction/functions.ts
@@ -234,7 +234,7 @@ export class Functions {
         const yamlContent = await Utils.getFuncYamlContent(context.folderURI.fsPath);
         if (yamlContent) {
             const deployedNamespace = yamlContent.deploy?.namespace || undefined;
-            if (!deployedNamespace) {
+            if (!deployedNamespace || (deployedNamespace === currentNamespace)) {
                 await this.deployProcess(context, deployedNamespace, yamlContent);
             } else if (deployedNamespace !== currentNamespace) {
                 const response = await window.showInformationMessage(`Function namespace (declared in func.yaml) is different from the current active namespace. Deploy function ${context.name} to current namespace ${currentNamespace}?`,
@@ -243,8 +243,6 @@ export class Functions {
                 if (response === 'Ok') {
                     await this.deployProcess(context, currentNamespace, yamlContent);
                 }
-            } else {
-                await this.deployProcess(context, deployedNamespace, yamlContent);
             }
         }
     }

--- a/src/serverlessFunction/functions.ts
+++ b/src/serverlessFunction/functions.ts
@@ -237,11 +237,11 @@ export class Functions {
             if (!deployedNamespace) {
                 await this.deployProcess(context, deployedNamespace, yamlContent);
             } else if (deployedNamespace !== currentNamespace) {
-                const response = await window.showInformationMessage(`Function namespace (declared in func.yaml) is different from the current active namespace. Deploy function ${context.name} to namespace ${deployedNamespace}?`,
+                const response = await window.showInformationMessage(`Function namespace (declared in func.yaml) is different from the current active namespace. Deploy function ${context.name} to current namespace ${currentNamespace}?`,
                     'Ok',
                     'Cancel');
                 if (response === 'Ok') {
-                    await this.deployProcess(context, deployedNamespace, yamlContent);
+                    await this.deployProcess(context, currentNamespace, yamlContent);
                 }
             } else {
                 await this.deployProcess(context, deployedNamespace, yamlContent);

--- a/src/serverlessFunction/view.ts
+++ b/src/serverlessFunction/view.ts
@@ -169,16 +169,7 @@ export class ServerlessFunctionView implements TreeDataProvider<ExplorerItem>, D
     async getChildren(element?: ExplorerItem): Promise<ExplorerItem[]> {
         let result: ExplorerItem[] = [];
         if (!element) {
-            result = [{
-                kind: 'project',
-                metadata: {
-                    name: this.kubeContext?.namespace,
-                },
-            } as KubernetesObject];
-            this.setCurrentNameSpace(this.kubeContext?.namespace);
-        } else if ('kind' in element) {
-            if (element.kind === 'project') {
-                result = [...await this.serverlessFunction.getLocalFunctions()]
+            result = [...await this.serverlessFunction.getLocalFunctions()]
                 if (result.length === 0) {
                     const functionNode: FunctionObject = {
                         name: 'No Available Functions',
@@ -186,7 +177,7 @@ export class ServerlessFunctionView implements TreeDataProvider<ExplorerItem>, D
                     }
                     result = [functionNode]
                 }
-            }
+            this.setCurrentNameSpace(this.kubeContext?.namespace);
         }
         return result;
     }

--- a/src/serverlessFunction/view.ts
+++ b/src/serverlessFunction/view.ts
@@ -43,7 +43,6 @@ export class ServerlessFunctionView implements TreeDataProvider<ExplorerItem>, D
     private fsw: FileContentChangeNotifier;
     private kubeContext: Context;
     private kubeConfig: KubeConfigUtils;
-    private currentNameSpace: string;
 
     private eventEmitter: EventEmitter<ExplorerItem | undefined> =
         new EventEmitter<ExplorerItem | undefined>();
@@ -158,14 +157,6 @@ export class ServerlessFunctionView implements TreeDataProvider<ExplorerItem>, D
             'Local Only' : context === FunctionStatus.CLUSTERONLY ? 'Cluster Only' : '';
     }
 
-    setCurrentNameSpace(value: string) {
-        this.currentNameSpace = value;
-    }
-
-    public getCurrentNameSpace(): string {
-        return this.currentNameSpace;
-    }
-
     async getChildren(element?: ExplorerItem): Promise<ExplorerItem[]> {
         let result: ExplorerItem[] = [];
         if (!element) {
@@ -177,7 +168,6 @@ export class ServerlessFunctionView implements TreeDataProvider<ExplorerItem>, D
                     }
                     result = [functionNode]
                 }
-            this.setCurrentNameSpace(this.kubeContext?.namespace);
         }
         return result;
     }


### PR DESCRIPTION
Fixes: https://github.com/redhat-developer/vscode-openshift-tools/issues/3145