### PR TITLE
Add `./src/tools.json` to distribution

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,7 @@ out/tools-cache/**
 out/**/*.map
 out/src-orig/**
 src/**
+!src/tools.json
 doc/**
 .gitignore
 .github


### PR DESCRIPTION
To verify this change,
- build and run from the .vsix
- remove `crc` from PATH if you have it (or rename it)
- log out of crc
- select "+" in the application explorer in the OpenShift sidebar
- select OpenShift Local in the wizard that appears
  - There should be no error popup
- Click reset then download crc
  - it should take you inside the folder for the latest version instead of the parent folder with all the versions listed

Fixes #3154

Signed-off-by: David Thompson <davthomp@redhat.com>
