### PR TITLE
[build] Install extension dependencies defined in package.json

### DIFF
--- a/build/install-vscode.ts
+++ b/build/install-vscode.ts
@@ -11,33 +11,35 @@ import cp = require('child_process');
 import path = require('path');
 
 void testElectron.downloadAndUnzipVSCode().then((executable: string) => {
-    let vsCodeExecutable: string;
-    if (platform() === 'darwin') {
-        console.log(executable);
-        vsCodeExecutable = `'${path.join(
-            executable.substring(0, executable.indexOf('.app') + 4),
-            'Contents',
-            'Resources',
-            'app',
-            'bin',
-            'code',
-        )}'`;
-    } else {
-        vsCodeExecutable = path.join(path.dirname(executable), 'bin', 'code');
-    }
-
     // Install extensions that openshift-toolkit depends on
-    const extensionsToInstall = [
-        'redhat.vscode-redhat-account',
-        'ms-kubernetes-tools.vscode-kubernetes-tools'
-    ];
+    const packageJson = require('../package.json');
+    const extensionsToInstall = packageJson.extensionDependencies;
 
-    const extensionRootPath = path.resolve(__dirname, '..', '..');
-    const vsCodeTest = path.resolve(path.join(extensionRootPath, '.vscode-test'));
-    const userDataDir = path.join(vsCodeTest, 'user-data');
-    const extDir = path.join(vsCodeTest, 'extensions');
-    for (const extension of extensionsToInstall) {
-        console.log('Installing extension: ', extension );
-        cp.execSync(`${vsCodeExecutable} --install-extension ${extension} --user-data-dir ${userDataDir} --extensions-dir ${extDir}`);
+    if (extensionsToInstall) {
+        let vsCodeExecutable: string;
+        if (platform() === 'darwin') {
+            console.log(executable);
+            vsCodeExecutable = `'${path.join(
+                executable.substring(0, executable.indexOf('.app') + 4),
+                'Contents',
+                'Resources',
+                'app',
+                'bin',
+                'code',
+            )}'`;
+        } else {
+            vsCodeExecutable = path.join(path.dirname(executable), 'bin', 'code');
+        }
+
+        const extensionRootPath = path.resolve(__dirname, '..', '..');
+        const vsCodeTest = path.resolve(path.join(extensionRootPath, '.vscode-test'));
+        const userDataDir = path.join(vsCodeTest, 'user-data');
+        const extDir = path.join(vsCodeTest, 'extensions');
+        for (const extension of extensionsToInstall) {
+            console.log('Installing extension: ', extension );
+            cp.execSync(`${vsCodeExecutable} --install-extension ${extension} --user-data-dir ${userDataDir} --extensions-dir ${extDir}`);
+        }
+    } else {
+        console.log('No extension dependencies found in "package.json"');
     }
 });


### PR DESCRIPTION
Make the list of extensions to be installed to be read from `extensionDependencies` key of `package.json`  instead of duplicating the same list in a constant.