### PR TITLE
Support `KUBECONFIG` environment variable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { ServerlessFunctionView } from './serverlessFunction/view';
 import { startTelemetry } from './telemetry';
 import { ToolsConfig } from './tools';
 import { TokenStore } from './util/credentialManager';
+import { setKubeConfig } from './util/kubeUtils';
 import { Platform } from './util/platform';
 import { setupWorkspaceDevfileContext } from './util/workspace';
 import { registerCommands } from './vscommand';
@@ -71,6 +72,10 @@ export async function activate(extensionContext: ExtensionContext): Promise<unkn
     migrateFromOdo018();
     Cluster.extensionContext = extensionContext;
     TokenStore.extensionContext = extensionContext;
+
+    // pick kube config in case multiple are configured
+    await setKubeConfig();
+
     const crcStatusItem = window.createStatusBarItem(StatusBarAlignment.Left);
     crcStatusItem.command = 'openshift.explorer.stopCluster';
     const disposable = [

--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -7,6 +7,7 @@ import { KubernetesObject } from '@kubernetes/client-node';
 import { ExtensionContext, InputBox, QuickInputButton, QuickInputButtons, QuickPickItem, QuickPickItemButtonEvent, ThemeIcon, Uri, commands, env, window, workspace } from 'vscode';
 import { CommandText } from '../base/command';
 import { CliChannel } from '../cli';
+import { OpenShiftExplorer } from '../explorer';
 import { Oc } from '../oc/ocWrapper';
 import { Command } from '../odo/command';
 import { Odo } from '../odo/odoWrapper';
@@ -48,7 +49,7 @@ export class Cluster extends OpenShiftItem {
                     ),
                 )
                 .then(async () => {
-                    Cluster.explorer.refresh();
+                    OpenShiftExplorer.getInstance().refresh();
                     Cluster.serverlessView.refresh();
                     void commands.executeCommand('setContext', 'isLoggedIn', false);
                     const logoutInfo = await window.showInformationMessage(
@@ -67,7 +68,7 @@ export class Cluster extends OpenShiftItem {
 
     @vsCommand('openshift.explorer.refresh')
     static refresh(): void {
-        Cluster.explorer.refresh();
+        OpenShiftExplorer.getInstance().refresh();
         Cluster.serverlessView.refresh();
     }
 
@@ -806,7 +807,7 @@ export class Cluster extends OpenShiftItem {
     }
 
     static async loginMessage(clusterURL: string): Promise<string> {
-        Cluster.explorer.refresh();
+        OpenShiftExplorer.getInstance().refresh();
         Cluster.serverlessView.refresh();
         await commands.executeCommand('setContext', 'isLoggedIn', true);
         return `Successfully logged in to '${clusterURL}'`;

--- a/src/openshift/openshiftItem.ts
+++ b/src/openshift/openshiftItem.ts
@@ -4,7 +4,6 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { commands, QuickPickItem, window } from 'vscode';
-import { OpenShiftExplorer } from '../explorer';
 import { Oc } from '../oc/ocWrapper';
 import { Odo } from '../odo/odoWrapper';
 import { Project } from '../odo/project';
@@ -25,8 +24,6 @@ export class QuickPickCommand implements QuickPickItem {
 
 export default class OpenShiftItem {
     protected static readonly odo = Odo.Instance;
-
-    protected static readonly explorer: OpenShiftExplorer = OpenShiftExplorer.getInstance();
 
     protected static readonly serverlessView: ServerlessFunctionView = ServerlessFunctionView.getInstance();
 

--- a/src/openshift/project.ts
+++ b/src/openshift/project.ts
@@ -37,7 +37,7 @@ export class Project extends OpenShiftItem {
         } else {
             const projectName = selectedItem.label;
             await Odo.Instance.setProject(projectName);
-            Project.explorer.refresh();
+            OpenShiftExplorer.getInstance().refresh();
             Project.serverlessView.refresh();
             message = `Project '${projectName}' set as active.`;
         }


### PR DESCRIPTION
- Watch for changes in file(s) indicated by `KUBECONFIG` when it's set
- Warn when multiple config files are specified in `KUBECONFIG`, since the Kubernetes client library we are using doesn't support this use case

Closes #3382

Signed-off-by: David Thompson <davthomp@redhat.com>
