### PR TITLE
CodeLens to apply a k8s YAML file

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
 		"onCommand:openshift.oc.about",
 		"onCommand:openshift.output",
 		"onCommand:openshift.create",
+		"onCommand:openshift.delete",
 		"onCommand:openshift.open.developerConsole",
 		"onCommand:openshift.open.developerConsole.palette",
 		"onCommand:openshift.explorer.addCluster",
@@ -262,6 +263,11 @@
 			{
 				"command": "openshift.create",
 				"title": "Create",
+				"category": "OpenShift"
+			},
+			{
+				"command": "openshift.delete",
+				"title": "Delete",
 				"category": "OpenShift"
 			},
 			{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import { setupWorkspaceDevfileContext } from './util/workspace';
 import { registerCommands } from './vscommand';
 import { OpenShiftTerminalManager } from './webview/openshift-terminal/openShiftTerminal';
 import { WelcomePage } from './welcomePage';
+import { registerYamlHandlers } from './yaml/yamlDocumentFeatures';
 
 import fsx = require('fs-extra');
 
@@ -103,6 +104,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<unkn
         ComponentsTreeDataProvider.instance.createTreeView('openshiftComponentsView'),
         setupWorkspaceDevfileContext(),
         window.registerWebviewViewProvider('openShiftTerminalView', OpenShiftTerminalManager.getInstance(), { webviewOptions: { retainContextWhenHidden: true, } }),
+        ...registerYamlHandlers(),
     ];
     disposable.forEach((value) => extensionContext.subscriptions.push(value));
 

--- a/src/oc/ocWrapper.ts
+++ b/src/oc/ocWrapper.ts
@@ -125,6 +125,17 @@ export class Oc {
     }
 
     /**
+     * Delete the Kubernetes object described by the given file.
+     *
+     * @param file the file containing the spec of the kubernetes object to delete
+     */
+    public async deleteKubernetesObjectFromFile(file: string): Promise<void> {
+        await CliChannel.getInstance().executeTool(
+            new CommandText('oc', 'delete', [new CommandOption('-f', file)])
+        );
+    }
+
+    /**
      * Returns the username of the current user.
      *
      * @returns the username of the current user

--- a/src/yaml/yamlDocumentFeatures.ts
+++ b/src/yaml/yamlDocumentFeatures.ts
@@ -1,0 +1,65 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { KubernetesObject } from '@kubernetes/client-node';
+import { load as loadYaml } from 'js-yaml';
+import * as vscode from 'vscode';
+
+const YAML_SELECTOR: vscode.DocumentSelector = {
+    language: 'yaml',
+    scheme: 'file'
+};
+
+const RANGE: vscode.Range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1));
+
+export function registerYamlHandlers(): vscode.Disposable[] {
+    const disposables: vscode.Disposable[] = [];
+    disposables.push(
+        vscode.languages.registerCodeLensProvider(YAML_SELECTOR, new YamlCodeLensProvider()));
+    return disposables;
+}
+
+class YamlCodeLensProvider implements vscode.CodeLensProvider {
+    provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
+
+        try {
+
+            const objectTexts: string[] = document.getText().split(/(?:^---\r?\n)|(?:\n---\r?\n)/).filter(text => text && text.length > 0);
+
+            for (const objectText of objectTexts) {
+                const yaml = loadYaml(objectText) as KubernetesObject;
+
+                // heuristic to check if it's a k8s yaml
+                if (!yaml.apiVersion || !yaml.kind || !yaml.metadata) {
+                    return [];
+                }
+            }
+
+        } catch (e) {
+            return [];
+        }
+
+        return [
+            {
+                isResolved: true,
+                range: RANGE,
+                command: {
+                    command: 'openshift.create',
+                    title: 'Apply YAML to cluster',
+                    tooltip: 'Performs `kubectl apply -f` on this file'
+                }
+            },
+            {
+                isResolved: true,
+                range: RANGE,
+                command: {
+                    command: 'openshift.delete',
+                    title: 'Delete YAML from cluster',
+                    tooltip: 'Performs `kubectl delete -f` on this file'
+                }
+            }
+        ];
+    }
+}

--- a/test/integration/ocWrapper.test.ts
+++ b/test/integration/ocWrapper.test.ts
@@ -152,6 +152,13 @@ suite('./oc/ocWrapper.ts', function () {
             const deployments = await Oc.Instance.getKubernetesObjects('Deployment');
             expect(deployments).to.have.length(0);
         });
+
+        test('deleteKubernetesObjectFromFile()', async function() {
+            await Oc.Instance.createKubernetesObjectFromFile(yamlFile);
+            await Oc.Instance.deleteKubernetesObjectFromFile(yamlFile);
+            const deployments = await Oc.Instance.getKubernetesObjects('Deployment');
+            expect(deployments).to.have.length(0);
+        });
     });
 
     test('getConsoleInfo()', async function() {


### PR DESCRIPTION
To try out this PR, try cloning https://github.com/quarkusio/quarkus-super-heroes and open one of the YAML files under `./deploy/k8s`. Once the extension is activated, there should be a new CodeLens at the top of the file.

This CodeLens will not appear in `devfile.yaml`.

Closes #2873

Signed-off-by: David Thompson <davthomp@redhat.com>
