### PR TITLE
Only check basename for file extension when downloading binaries

### DIFF
--- a/src/downloadUtil/downloadBinaries.ts
+++ b/src/downloadUtil/downloadBinaries.ts
@@ -35,7 +35,8 @@ async function extractTool(toolsFolder: string, platform: PlatformData, currentF
         toolLocation = path.join(toolsFolder, platform.cmdFileName);
     }
     console.log(`Extracting ${currentFile} to ${toolLocation}`);
-    if (!currentFile.endsWith('.exe') && currentFile.includes('.')) {
+    const fileBasename = path.basename(currentFile);
+    if (!fileBasename.endsWith('.exe') && fileBasename.includes('.')) {
         await Archive.extract(currentFile, toolsFolder, platform.cmdFileName, platform.filePrefix);
     } else {
         fs.copyFileSync(currentFile, toolLocation);


### PR DESCRIPTION
Fixes #3527
