### PR TITLE
Fix `--build` option when using `func run`

### DIFF
--- a/src/serverlessFunction/commands.ts
+++ b/src/serverlessFunction/commands.ts
@@ -100,7 +100,7 @@ export class ServerlessCommand {
     static runFunction(location: string, runBuild: boolean): CommandText {
         const commandText = new CommandText('func', 'run', [
             new CommandOption('-p', location),
-            new CommandOption('-b', runBuild.toString())
+            new CommandOption('--build', runBuild.toString())
         ]);
         return commandText;
     }


### PR DESCRIPTION
It seems like they changed `-b` abbreviation to mean "builder" instead of "build", somewhere between 1.10.0 and 1.12.0.

Fixes #3522

Signed-off-by: David Thompson <davidethompson@me.com>
