### PR TITLE
[test] Fix Dervile Registry UI suite test

### DIFF
--- a/test/ui/suite/devfileRegistries.ts
+++ b/test/ui/suite/devfileRegistries.ts
@@ -126,7 +126,7 @@ export function testDevfileRegistries() {
             // initialize web view editor
             const webView = new RegistryWebViewEditor('Devfile Registry - DefaultDevfileRegistry');
             await webView.initializeEditor();
-            expect(await webView.getRegistryStackNames()).to.include.members(['Quarkus Java', 'Django', 'Maven Java', 'Node.js Runtime', 'Open Liberty Gradle', 'Open Liberty Maven']);
+            expect(await webView.getRegistryStackNames()).to.include.members(['Quarkus Java', 'Django', 'Go Runtime', 'Maven Java', 'Node.js Runtime', 'Open Liberty Gradle']);
         });
 
         after(async function context() {


### PR DESCRIPTION
```
  1) Extension public-facing UI tests
       Devfile Registries
         open Devfile registry view from item's context menu and verify the content of the registry:

      AssertionError: expected [ 'Quarkus Java', 'Django', …(4) ] to be a superset of [ 'Quarkus Java', 'Django', …(4) ]
      + expected - actual

       [
         "Quarkus Java"
         "Django"
      -  "Go Runtime"
         "Maven Java"
         "Node.js Runtime"
         "Open Liberty Gradle"
      +  "Open Liberty Maven"
       ]

      at Context.<anonymous> (test/ui/suite/devfileRegistries.ts:129:70)
      at Generator.next (<anonymous>)
      at fulfilled (out/test/ui/suite/devfileRegistries.js:5:58)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```