### PR TITLE
Fix integration test debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -72,7 +72,7 @@
                 "${workspaceFolder}/out/**/*.js"
             ],
             "sourceMaps": true,
-            "preLaunchTask": "instrument",
+            "preLaunchTask": "compile",
             "env": {
                 "VSCODE_REDHAT_TELEMETRY_DEBUG":"true",
                 "IS_OPENSHIFT": "true",


### PR DESCRIPTION
It used to run the instrument command, however the coverage instrumentation doesn't play well with VS Code debugging. Instead, I set it to run the compile command like the other debugging configurations.

Signed-off-by: David Thompson <davthomp@redhat.com>
