### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
 				"@types/lodash": "^4.14.202",
 				"@types/make-fetch-happen": "^10.0.4",
 				"@types/mocha": "^10.0.6",
-				"@types/node": "^16.18.66",
+				"@types/node": "^16.18.68",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^17.0.71",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -5610,9 +5610,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.66",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.66.tgz",
-			"integrity": "sha512-sePmD/imfKvC4re/Wwos1NEcXYm6O96CAG5gQVY53nmDb8ePQ4qPku6uruN7n6TJ0t5FhcoUc2+yvE2/UZVDZw=="
+			"version": "16.18.68",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
+			"integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
 		},
 		"node_modules/@types/node-fetch": {
 			"version": "2.6.6",
@@ -20917,9 +20917,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.18.66",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.66.tgz",
-			"integrity": "sha512-sePmD/imfKvC4re/Wwos1NEcXYm6O96CAG5gQVY53nmDb8ePQ4qPku6uruN7n6TJ0t5FhcoUc2+yvE2/UZVDZw=="
+			"version": "16.18.68",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
+			"integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
 		},
 		"@types/node-fetch": {
 			"version": "2.6.6",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
 		"@types/lodash": "^4.14.202",
 		"@types/make-fetch-happen": "^10.0.4",
 		"@types/mocha": "^10.0.6",
-		"@types/node": "^16.18.66",
+		"@types/node": "^16.18.68",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^17.0.71",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
@types/node           16.18.66  16.18.68  20.10.4  node_modules/@types/node        vscode-openshift-tools
...
```