### PR TITLE
Remove 'react-loader-spinner' dependency as unused

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,6 @@
 				"react-copy-to-clipboard": "^5.1.0",
 				"react-dom": "^17.0.2",
 				"react-error-boundary": "^4.0.11",
-				"react-loader-spinner": "^5.4.5",
 				"react-phone-input-2": "^2.14.0",
 				"react-scroll-to-top": "^3.0.0",
 				"react-syntax-highlighter": "^15.5.0",
@@ -221,18 +220,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-			"integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.22.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-compilation-targets": {
 			"version": "7.22.9",
 			"dev": true,
@@ -325,15 +312,6 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-simple-access": {
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
@@ -424,21 +402,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-			"integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -580,6 +543,7 @@
 			"version": "1.2.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@emotion/memoize": "^0.8.0"
 			}
@@ -657,12 +621,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@emotion/stylis": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-			"dev": true
 		},
 		"node_modules/@emotion/unitless": {
 			"version": "0.8.0",
@@ -6823,22 +6781,6 @@
 				"npm": ">=6"
 			}
 		},
-		"node_modules/babel-plugin-styled-components": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
-			"integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-module-imports": "^7.22.5",
-				"@babel/plugin-syntax-jsx": "^7.22.5",
-				"lodash": "^4.17.21",
-				"picomatch": "^2.3.1"
-			},
-			"peerDependencies": {
-				"styled-components": ">= 2"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -7314,15 +7256,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/camelize": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-			"integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/caniuse-lite": {
@@ -8113,15 +8046,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/css-color-keywords": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/css-select": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -8136,17 +8060,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/css-to-react-native": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-			"integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-			"dev": true,
-			"dependencies": {
-				"camelize": "^1.0.0",
-				"css-color-keywords": "^1.0.0",
-				"postcss-value-parser": "^4.0.2"
 			}
 		},
 		"node_modules/css-vendor": {
@@ -14520,13 +14433,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/postcss-value-parser": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -14983,21 +14889,6 @@
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/react-loader-spinner": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-5.4.5.tgz",
-			"integrity": "sha512-32f+sb/v2tnNfyvnCCOS4fpyVHsGXjSyNo6QLniHcaj1XjKLxx14L2z0h6szRugOL8IEJ+53GPwNAdbkDqmy4g==",
-			"dev": true,
-			"dependencies": {
-				"react-is": "^18.2.0",
-				"styled-components": "^5.3.5",
-				"styled-tools": "^1.7.2"
-			},
-			"peerDependencies": {
-				"react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-			}
 		},
 		"node_modules/react-phone-input-2": {
 			"version": "2.15.1",
@@ -15806,12 +15697,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/shallowequal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-			"dev": true
-		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -16448,48 +16333,6 @@
 			"integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/styled-components": {
-			"version": "5.3.11",
-			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-			"integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/traverse": "^7.4.5",
-				"@emotion/is-prop-valid": "^1.1.0",
-				"@emotion/stylis": "^0.8.4",
-				"@emotion/unitless": "^0.7.4",
-				"babel-plugin-styled-components": ">= 1.12.0",
-				"css-to-react-native": "^3.0.0",
-				"hoist-non-react-statics": "^3.0.0",
-				"shallowequal": "^1.1.0",
-				"supports-color": "^5.5.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/styled-components"
-			},
-			"peerDependencies": {
-				"react": ">= 16.8.0",
-				"react-dom": ">= 16.8.0",
-				"react-is": ">= 16.8.0"
-			}
-		},
-		"node_modules/styled-components/node_modules/@emotion/unitless": {
-			"version": "0.7.5",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-			"dev": true
-		},
-		"node_modules/styled-tools": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/styled-tools/-/styled-tools-1.7.2.tgz",
-			"integrity": "sha512-IjLxzM20RMwAsx8M1QoRlCG/Kmq8lKzCGyospjtSXt/BTIIcvgTonaxQAsKnBrsZNwhpHzO9ADx5te0h76ILVg==",
-			"dev": true
 		},
 		"node_modules/stylis": {
 			"version": "4.1.3",
@@ -18305,15 +18148,6 @@
 				"jsesc": "^2.5.1"
 			}
 		},
-		"@babel/helper-annotate-as-pure": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-			"integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.22.5"
-			}
-		},
 		"@babel/helper-compilation-targets": {
 			"version": "7.22.9",
 			"dev": true,
@@ -18376,12 +18210,6 @@
 				"@babel/helper-validator-identifier": "^7.22.5"
 			}
 		},
-		"@babel/helper-plugin-utils": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-			"dev": true
-		},
 		"@babel/helper-simple-access": {
 			"version": "7.22.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
@@ -18441,15 +18269,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
 			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
 			"dev": true
-		},
-		"@babel/plugin-syntax-jsx": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-			"integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.22.5"
-			}
 		},
 		"@babel/runtime": {
 			"version": "7.23.5",
@@ -18575,6 +18394,7 @@
 		"@emotion/is-prop-valid": {
 			"version": "1.2.0",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@emotion/memoize": "^0.8.0"
 			}
@@ -18630,12 +18450,6 @@
 				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
 				"@emotion/utils": "^1.2.0"
 			}
-		},
-		"@emotion/stylis": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-			"dev": true
 		},
 		"@emotion/unitless": {
 			"version": "0.8.0",
@@ -21834,19 +21648,6 @@
 				"resolve": "^1.19.0"
 			}
 		},
-		"babel-plugin-styled-components": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
-			"integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-module-imports": "^7.22.5",
-				"@babel/plugin-syntax-jsx": "^7.22.5",
-				"lodash": "^4.17.21",
-				"picomatch": "^2.3.1"
-			}
-		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -22166,12 +21967,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true
-		},
-		"camelize": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-			"integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
 			"dev": true
 		},
 		"caniuse-lite": {
@@ -22710,12 +22505,6 @@
 				}
 			}
 		},
-		"css-color-keywords": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-			"dev": true
-		},
 		"css-select": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -22727,17 +22516,6 @@
 				"domhandler": "^5.0.2",
 				"domutils": "^3.0.1",
 				"nth-check": "^2.0.1"
-			}
-		},
-		"css-to-react-native": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-			"integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-			"dev": true,
-			"requires": {
-				"camelize": "^1.0.0",
-				"css-color-keywords": "^1.0.0",
-				"postcss-value-parser": "^4.0.2"
 			}
 		},
 		"css-vendor": {
@@ -27227,12 +27005,6 @@
 				}
 			}
 		},
-		"postcss-value-parser": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-			"dev": true
-		},
 		"prebuild-install": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -27570,17 +27342,6 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
-		},
-		"react-loader-spinner": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-5.4.5.tgz",
-			"integrity": "sha512-32f+sb/v2tnNfyvnCCOS4fpyVHsGXjSyNo6QLniHcaj1XjKLxx14L2z0h6szRugOL8IEJ+53GPwNAdbkDqmy4g==",
-			"dev": true,
-			"requires": {
-				"react-is": "^18.2.0",
-				"styled-components": "^5.3.5",
-				"styled-tools": "^1.7.2"
-			}
 		},
 		"react-phone-input-2": {
 			"version": "2.15.1",
@@ -28171,12 +27932,6 @@
 				"kind-of": "^6.0.2"
 			}
 		},
-		"shallowequal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-			"dev": true
-		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -28608,38 +28363,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
 			"integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-			"dev": true
-		},
-		"styled-components": {
-			"version": "5.3.11",
-			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-			"integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/traverse": "^7.4.5",
-				"@emotion/is-prop-valid": "^1.1.0",
-				"@emotion/stylis": "^0.8.4",
-				"@emotion/unitless": "^0.7.4",
-				"babel-plugin-styled-components": ">= 1.12.0",
-				"css-to-react-native": "^3.0.0",
-				"hoist-non-react-statics": "^3.0.0",
-				"shallowequal": "^1.1.0",
-				"supports-color": "^5.5.0"
-			},
-			"dependencies": {
-				"@emotion/unitless": {
-					"version": "0.7.5",
-					"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-					"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-					"dev": true
-				}
-			}
-		},
-		"styled-tools": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/styled-tools/-/styled-tools-1.7.2.tgz",
-			"integrity": "sha512-IjLxzM20RMwAsx8M1QoRlCG/Kmq8lKzCGyospjtSXt/BTIIcvgTonaxQAsKnBrsZNwhpHzO9ADx5te0h76ILVg==",
 			"dev": true
 		},
 		"stylis": {

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
 		"react-copy-to-clipboard": "^5.1.0",
 		"react-dom": "^17.0.2",
 		"react-error-boundary": "^4.0.11",
-		"react-loader-spinner": "^5.4.5",
 		"react-phone-input-2": "^2.14.0",
 		"react-scroll-to-top": "^3.0.0",
 		"react-syntax-highlighter": "^15.5.0",


### PR DESCRIPTION
We don't need this dependency anymore, as it was used in src/webview/log/app/spinner.tsx which was completely removed in #3500.

Supercedes #3705