### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
 				"@types/mocha": "^10.0.6",
 				"@types/node": "^16.18.68",
 				"@types/proxyquire": "^1.3.31",
-				"@types/react": "^17.0.71",
+				"@types/react": "^17.0.72",
 				"@types/react-copy-to-clipboard": "^5.0.7",
 				"@types/react-dom": "^17.0.25",
 				"@types/react-syntax-highlighter": "^15.5.11",
@@ -5613,9 +5613,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "17.0.71",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.71.tgz",
-			"integrity": "sha512-lfqOu9mp16nmaGRrS8deS2Taqhd5Ih0o92Te5Ws6I1py4ytHBcXLqh0YIqVsViqwVI5f+haiFM6hju814BzcmA==",
+			"version": "17.0.72",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.72.tgz",
+			"integrity": "sha512-iFqLaDdU/V/xU+rnii7KdMi4xU+Rz0ArNW6q1r0xauGv++hD1eUMCvYn3zqm5jSXTtyb6O5Tr0qmHJ2bnzAsVA==",
 			"dev": true,
 			"dependencies": {
 				"@types/prop-types": "*",
@@ -20773,9 +20773,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "17.0.71",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.71.tgz",
-			"integrity": "sha512-lfqOu9mp16nmaGRrS8deS2Taqhd5Ih0o92Te5Ws6I1py4ytHBcXLqh0YIqVsViqwVI5f+haiFM6hju814BzcmA==",
+			"version": "17.0.72",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.72.tgz",
+			"integrity": "sha512-iFqLaDdU/V/xU+rnii7KdMi4xU+Rz0ArNW6q1r0xauGv++hD1eUMCvYn3zqm5jSXTtyb6O5Tr0qmHJ2bnzAsVA==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 		"@types/mocha": "^10.0.6",
 		"@types/node": "^16.18.68",
 		"@types/proxyquire": "^1.3.31",
-		"@types/react": "^17.0.71",
+		"@types/react": "^17.0.72",
 		"@types/react-copy-to-clipboard": "^5.0.7",
 		"@types/react-dom": "^17.0.25",
 		"@types/react-syntax-highlighter": "^15.5.11",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/react        17.0.71   17.0.72  18.2.44  node_modules/@types/react       vscode-openshift-tools
...
```