### PR TITLE
Deploy container image to cluster

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,7 +364,7 @@
 			},
 			{
 				"command": "openshift.helm.openView",
-				"title": "Open Helm View",
+				"title": "Browse and Install Helm Charts",
 				"category": "OpenShift"
 			},
 			{
@@ -756,8 +756,23 @@
 				"category": "OpenShift"
 			},
 			{
+				"command": "openshift.deployment.create.fromImageUrl",
+				"title": "Create Deployment from Container Image URL",
+				"category": "OpenShift"
+			},
+			{
 				"command": "openshift.resource.load",
 				"title": "Load",
+				"category": "OpenShift"
+			},
+			{
+				"command": "openshift.resource.delete",
+				"title": "Delete",
+				"category": "OpenShift"
+			},
+			{
+				"command": "openshift.resource.watchLogs",
+				"title": "Watch Logs",
 				"category": "OpenShift"
 			},
 			{
@@ -944,7 +959,7 @@
 			},
 			{
 				"id": "view/item/context/createService",
-				"label": "Create Service"
+				"label": "Create..."
 			}
 		],
 		"viewsContainers": {
@@ -1243,6 +1258,14 @@
 					"when": "false"
 				},
 				{
+					"command": "openshift.resource.delete",
+					"when": "false"
+				},
+				{
+					"command": "openshift.resource.watchLogs",
+					"when": "false"
+				},
+				{
 					"command": "openshift.resource.unInstall",
 					"when": "false"
 				},
@@ -1493,6 +1516,11 @@
 				{
 					"command": "openshift.service.create",
 					"when": "view == openshiftProjectExplorer && isLoggedIn && viewItem =~ /openshift.project.*/i && showCreateService",
+					"group": "c2"
+				},
+				{
+					"command": "openshift.deployment.create.fromImageUrl",
+					"when": "view == openshiftProjectExplorer && isLoggedIn && viewItem =~ /openshift.project.*/i",
 					"group": "c2"
 				}
 			],
@@ -1753,6 +1781,14 @@
 					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject || viewItem == openshift.k8sObject.route"
 				},
 				{
+					"command": "openshift.resource.delete",
+					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject || viewItem == openshift.k8sObject.route"
+				},
+				{
+					"command": "openshift.resource.watchLogs",
+					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject || viewItem == openshift.k8sObject.route"
+				},
+				{
 					"command": "openshift.resource.unInstall",
 					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject.helm"
 				},
@@ -1901,6 +1937,18 @@
 						},
 						"completionEvents": [
 							"onCommand:openshift.helm.openView"
+						]
+					},
+					{
+						"id": "deployContainerImage",
+						"title": "Deploy Container Image from URL",
+						"description": "In the Application Explorer sidebar panel, expand the tree item corresponding to the OpenShift/Kubernetes cluster, then right click on the project, and select \"Create...\" > \"Create Deployment from Container Image URL\". You will be asked to enter the URL to the container image and enter a name for the deployment. Once you've submitted this information, the Deployment will be created, and the logs for the first container created as a part of the Deployment will be opened in the OpenShift Terminal.",
+						"media": {
+							"image": "images/walkthrough/deploy-a-container-image.gif",
+							"altText": "Creating a Deployment of the Docker Hub MongoDB container image called my-mongo-db using the steps from the description"
+						},
+						"completionEvents": [
+							"onCommand:openshift.deployment.create.fromImageUrl"
 						]
 					},
 					{

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -1,0 +1,206 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import validator from 'validator';
+import { Disposable, QuickInputButtons, ThemeIcon, TreeItem, window } from 'vscode';
+import { OpenShiftExplorer } from './explorer';
+import { Oc } from './oc/ocWrapper';
+import { validateRFC1123DNSLabel } from './openshift/nameValidator';
+import { quickBtn } from './util/inputValue';
+import { vsCommand } from './vscommand';
+
+export class Deployment {
+
+    @vsCommand('openshift.deployment.create.fromImageUrl')
+    static async createFromImageUrl(context: TreeItem): Promise<void> {
+
+        enum State {
+            SelectImage, SelectName
+        }
+
+        let state: State = State.SelectImage;
+        let imageUrl: string;
+
+        while (state !== undefined) {
+
+            switch (state) {
+
+            case State.SelectImage: {
+
+                imageUrl = await Deployment.getImageUrl(false, imageUrl);
+
+                if (imageUrl === null || imageUrl === undefined) {
+                    return;
+                }
+                state = State.SelectName;
+                break;
+            }
+
+            case State.SelectName: {
+                let cleanedUrl = imageUrl.startsWith('https://') ? imageUrl : `https://${imageUrl}`;
+                if (cleanedUrl.lastIndexOf('/') > 0
+                        && cleanedUrl.substring(cleanedUrl.lastIndexOf('/')).indexOf(':') >=0) {
+                    // it has a version tag, which we need to clean for the
+                    cleanedUrl = cleanedUrl.substring(0, cleanedUrl.lastIndexOf(':'));
+                }
+                const imageUrlAsUrl = new URL(cleanedUrl);
+                const suggestedName = `my-${path.basename(imageUrlAsUrl.pathname)}`;
+
+                const deploymentName = await Deployment.getDeploymentName(suggestedName, true);
+
+                if (deploymentName === null) {
+                    return;
+                } else if (deploymentName === undefined) {
+                    state = State.SelectImage;
+                    break;
+                }
+
+                await Oc.Instance.createDeploymentFromImage(deploymentName, imageUrl);
+                void window.showInformationMessage(`Created deployment '${deploymentName}' from image '${imageUrl}'`);
+                OpenShiftExplorer.getInstance().refresh(context);
+
+                void OpenShiftExplorer.watchLogs({
+                    kind: 'Deployment',
+                    metadata: {
+                        name: deploymentName
+                    }
+                });
+
+                return;
+            }
+            default:
+            }
+
+        }
+
+    }
+
+    /**
+     * Prompt the user for the URL of a container image.
+     *
+     * @returns the selected container image URL, or undefined if "back" was requested, and null if "cancel" was requested
+     */
+    private static async getImageUrl(allowBack: boolean, initialValue?: string): Promise<string> {
+        return new Promise<string | null | undefined>(resolve => {
+            const disposables: Disposable[] = [];
+
+            const cancelBtn = new quickBtn(new ThemeIcon('close'), 'Cancel');
+            const okBtn = new quickBtn(new ThemeIcon('check'), 'Ok');
+
+            const inputBox = window.createInputBox();
+            inputBox.placeholder = 'docker.io/library/mongo';
+            inputBox.title = 'Image URL';
+            inputBox.value = initialValue;
+            if (allowBack) {
+                inputBox.buttons = [QuickInputButtons.Back, okBtn, cancelBtn];
+            } else {
+                inputBox.buttons = [okBtn, cancelBtn];
+            }
+            inputBox.ignoreFocusOut = true;
+
+            disposables.push(inputBox.onDidHide(() => resolve(null)));
+
+            disposables.push(inputBox.onDidChangeValue((e) => {
+                if (validator.isURL(inputBox.value)) {
+                    inputBox.validationMessage = undefined;
+                } else {
+                    inputBox.validationMessage = 'Please enter a valid URL';
+                }
+            }));
+
+            disposables.push(inputBox.onDidAccept((e) => {
+                if (inputBox.validationMessage === undefined && inputBox.value !== undefined) {
+                    resolve(inputBox.value);
+                    inputBox.hide();
+                    disposables.forEach(disposable => {disposable.dispose()});
+                }
+            }));
+
+            disposables.push(inputBox.onDidTriggerButton((button) => {
+                if (button === QuickInputButtons.Back) {
+                    inputBox.hide();
+                    resolve(undefined);
+                } else if (button === cancelBtn) {
+                    inputBox.hide();
+                    resolve(null);
+                } else if (button === okBtn) {
+                    if (inputBox.validationMessage === undefined && inputBox.value !== undefined) {
+                        inputBox.hide();
+                        resolve(inputBox.value);
+                        disposables.forEach(disposable => {disposable.dispose()});
+                    }
+                }
+            }));
+
+            inputBox.show();
+        });
+    }
+
+    /**
+     * Prompt the user for the name of the deployment.
+     *
+     * @returns the selected deployment name, or undefined if "back" was requested, and null if "cancel" was requested
+     */
+    private static async getDeploymentName(suggestedName: string, allowBack: boolean): Promise<string> {
+        return new Promise<string | null | undefined>(resolve => {
+            const disposables: Disposable[] = [];
+
+            const cancelBtn = new quickBtn(new ThemeIcon('close'), 'Cancel');
+            const okBtn = new quickBtn(new ThemeIcon('check'), 'Ok');
+
+            const inputBox = window.createInputBox();
+            inputBox.placeholder = suggestedName;
+            inputBox.value = suggestedName;
+            inputBox.title = 'Deployment Name';
+            if (allowBack) {
+                inputBox.buttons = [QuickInputButtons.Back, okBtn, cancelBtn];
+            } else {
+                inputBox.buttons = [okBtn, cancelBtn];
+            }
+            inputBox.ignoreFocusOut = true;
+
+            disposables.push(inputBox.onDidHide(() => resolve(null)));
+
+            disposables.push(inputBox.onDidChangeValue((e) => {
+                if (inputBox.value === undefined) {
+                    inputBox.validationMessage = undefined;
+                } else {
+                    inputBox.validationMessage = validateRFC1123DNSLabel('Must be a valid Kubernetes name', inputBox.value);
+                    if (inputBox.validationMessage.length === 0) {
+                        inputBox.validationMessage = undefined;
+                    }
+                }
+            }));
+
+            disposables.push(inputBox.onDidAccept((e) => {
+                if (inputBox.validationMessage === undefined && inputBox.value !== undefined) {
+                    resolve(inputBox.value);
+                    inputBox.hide();
+                    disposables.forEach(disposable => {disposable.dispose()});
+                }
+            }));
+
+            disposables.push(inputBox.onDidTriggerButton((button) => {
+                if (button === QuickInputButtons.Back) {
+                    inputBox.hide();
+                    resolve(undefined);
+                } else if (button === cancelBtn) {
+                    inputBox.hide();
+                    resolve(null);
+                } else if (button === okBtn) {
+                    if (inputBox.validationMessage === undefined && inputBox.value !== undefined) {
+                        resolve(inputBox.value);
+                        inputBox.hide();
+                        disposables.forEach(disposable => {disposable.dispose()});
+                    }
+                }
+            }));
+
+            inputBox.show();
+        });
+    }
+
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,7 +92,8 @@ export async function activate(extensionContext: ExtensionContext): Promise<unkn
             './webview/devfile-registry/registryViewLoader',
             './webview/helm-chart/helmChartLoader',
             './webview/helm-manage-repository/manageRepositoryLoader',
-            './feedback'
+            './feedback',
+            './deployment'
         )),
         commands.registerCommand('clusters.openshift.useProject', (context) =>
             commands.executeCommand('extension.vsKubernetesUseNamespace', context),

--- a/src/oc/ocWrapper.ts
+++ b/src/oc/ocWrapper.ts
@@ -411,6 +411,33 @@ export class Oc {
     }
 
     /**
+     * Creates a deployment with the given name from the given image URL.
+     *
+     * @param name the name of the deployment to create
+     * @param imageUrl the url of the image to deploy
+     */
+    public async createDeploymentFromImage(name: string, imageUrl: string): Promise<void> {
+        await CliChannel.getInstance().executeTool(
+            new CommandText('oc', `create deployment ${name}`, [new CommandOption('--image', imageUrl)])
+        );
+    }
+
+    /**
+     * Returns the logs for the given resource.
+     *
+     * @param resourceType the type of resource to get the logs for
+     * @param name the name of the resource to get the logs for
+     * @throws if the logs are not available
+     * @returns the logs for the given resource
+     */
+    public async getLogs(resourceType: string, name: string): Promise<string> {
+        const result = await CliChannel.getInstance().executeTool(
+            new CommandText('oc', `logs ${resourceType}/${name}`)
+        );
+        return result.stdout;
+    }
+
+    /**
      * Returns the oc command to list all resources of the given type in the given (or current) namespace
      *
      * @param resourceType the resource type to get


### PR DESCRIPTION
- Add "Create Deployment from Container Image URL" wizard to project context menu
  - It uses the VS Code text input
  - It has a back button and remembers what you've entered when you go back, similar to what Victor did for the login workflow
  - Once the deployment's been created, the logs for the container are opened in the OpenShift Terminal
- Add demo gif and walkthrough entry for "Create Deployment from Container Image URL"
- Add "Delete" context menu item for Kubernetes objects (eg. Deployments)
- Add "Watch logs" context menu item for Kubernetes objects (eg. Deployments)

![deploy-a-container-image](https://github.com/redhat-developer/vscode-openshift-tools/assets/22376627/c44babc2-997e-4e1f-87a7-8352807ea612)

Closes #2418

Signed-off-by: David Thompson <davthomp@redhat.com>
