### PR TITLE
Correctly package binaries for linux-arm64 .

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           targets["win32-x64"]=win32
           targets["win32-arm64"]=win32
           targets["linux-x64"]=linux
+          targets["linux-arm64"]=linux-arm64
           targets["darwin-x64"]=darwin
           targets["darwin-arm64"]=darwin
           for target in ${!targets[@]}; do

--- a/src/tools.json
+++ b/src/tools.json
@@ -164,7 +164,7 @@
                 "url": "https://developers.redhat.com/content-gateway/rest/mirror2/pub/openshift-v4/clients/helm/3.12.1/helm-linux-arm64.tar.gz",
                 "sha256sum": "2eb64b3d1772ae4ca0f2b34c50826860222c01f8f7306965c9aa84c11b5a83b4",
                 "dlFileName": "helm-linux-arm64.tar.gz",
-                "cmdFileName": "helm-linux-amd64"
+                "cmdFileName": "helm-linux-arm64"
             }
         }
     },


### PR DESCRIPTION
- The release workflow should ensure we package the linux-arm64 binaries for a tool into the corresponding vsix, as opposed to the amd64 versions
- Update filename metadata for helm on linux-arm64