### PR TITLE
Don't show "Open in Developer Console" on non-OpenShift clusters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1794,7 +1794,7 @@
 				},
 				{
 					"command": "openshift.resource.openInDeveloperConsole",
-					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject || openshift.k8sObject.helm || viewItem == openshift.k8sObject.route && isOpenshiftCluster"
+					"when": "view == openshiftProjectExplorer && (viewItem == openshift.k8sObject || openshift.k8sObject.helm || viewItem == openshift.k8sObject.route) && isOpenshiftCluster"
 				},
 				{
 					"command": "openshift.resource.openInBrowser",


### PR DESCRIPTION
- Fix condition for when the context menu item is shown

Fixes #3814

Signed-off-by: David Thompson <davthomp@redhat.com>
