### PR TITLE
Open a Deployment in shell from Application Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -761,6 +761,11 @@
 				"category": "OpenShift"
 			},
 			{
+				"command": "openshift.deployment.shell",
+				"title": "Open Shell to Container",
+				"category": "OpenShift"
+			},
+			{
 				"command": "openshift.resource.load",
 				"title": "Load",
 				"category": "OpenShift"
@@ -1263,6 +1268,10 @@
 				},
 				{
 					"command": "openshift.resource.watchLogs",
+					"when": "false"
+				},
+				{
+					"command": "openshift.deployment.shell",
 					"when": "false"
 				},
 				{
@@ -1778,15 +1787,19 @@
 				},
 				{
 					"command": "openshift.resource.load",
-					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject || viewItem == openshift.k8sObject.route"
+					"when": "view == openshiftProjectExplorer && viewItem =~ /^openshift\\.k8sObject\\.(?!helm)/"
 				},
 				{
 					"command": "openshift.resource.delete",
-					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject || viewItem == openshift.k8sObject.route"
+					"when": "view == openshiftProjectExplorer && viewItem =~ /^openshift\\.k8sObject\\.(?!helm)/"
 				},
 				{
 					"command": "openshift.resource.watchLogs",
-					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject || viewItem == openshift.k8sObject.route"
+					"when": "view == openshiftProjectExplorer && viewItem =~ /^openshift\\.k8sObject\\.(?!helm)/"
+				},
+				{
+					"command": "openshift.deployment.shell",
+					"when": "view == openshiftProjectExplorer && viewItem =~ /^openshift\\.k8sObject\\.Deployment/"
 				},
 				{
 					"command": "openshift.resource.unInstall",
@@ -1794,11 +1807,11 @@
 				},
 				{
 					"command": "openshift.resource.openInDeveloperConsole",
-					"when": "view == openshiftProjectExplorer && (viewItem == openshift.k8sObject || openshift.k8sObject.helm || viewItem == openshift.k8sObject.route) && isOpenshiftCluster"
+					"when": "view == openshiftProjectExplorer && viewItem =~ /^openshift\\.k8sObject/ && isOpenshiftCluster"
 				},
 				{
 					"command": "openshift.resource.openInBrowser",
-					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sObject.route && isOpenshiftCluster"
+					"when": "view == openshiftProjectExplorer && viewItem =~ /^openshift\\.k8sObject\\..*route$/ && isOpenshiftCluster"
 				},
 				{
 					"command": "openshift.Serverless.buildAndRun",

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -3,14 +3,17 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
+import { KubernetesObject } from '@kubernetes/client-node';
 import * as path from 'path';
 import validator from 'validator';
 import { Disposable, QuickInputButtons, ThemeIcon, TreeItem, window } from 'vscode';
+import { CommandText } from './base/command';
 import { OpenShiftExplorer } from './explorer';
 import { Oc } from './oc/ocWrapper';
 import { validateRFC1123DNSLabel } from './openshift/nameValidator';
 import { quickBtn } from './util/inputValue';
 import { vsCommand } from './vscommand';
+import { OpenShiftTerminalManager } from './webview/openshift-terminal/openShiftTerminal';
 
 export class Deployment {
 
@@ -76,6 +79,12 @@ export class Deployment {
 
         }
 
+    }
+
+    @vsCommand('openshift.deployment.shell')
+    static shellIntoDeployment(component: KubernetesObject): Promise<void> {
+        void OpenShiftTerminalManager.getInstance().createTerminal(new CommandText('oc', `exec -it ${component.kind}/${component.metadata.name} -- /bin/sh`), `Shell to '${component.metadata.name}'`);
+        return Promise.resolve();
     }
 
     /**

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -200,7 +200,7 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
 
             const routeURL = await Oc.Instance.getRouteURL(element.metadata.name);
             return {
-                contextValue: !routeURL ? 'openshift.k8sObject' : 'openshift.k8sObject.route',
+                contextValue: `openshift.k8sObject.${element.kind}${routeURL ? '.route' : ''}`,
                 label: element.metadata.name,
                 description: `${element.kind.substring(0, 1).toLocaleUpperCase()}${element.kind.substring(1)}`,
                 collapsibleState: TreeItemCollapsibleState.None,


### PR DESCRIPTION
Right click on a Deployment in the Application Explorer and select "Open Shell to Container" to open a terminal connection to the running container in the 'OpenShift Terminal'.

Closes #3825

Signed-off-by: David Thompson <davthomp@redhat.com>
