### PR TITLE
As a user I initially couldn't find "Change Active Project" #3812

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
 		"onCommand:openshift.explorer.refresh",
 		"onCommand:openshift.componentTypesView.refresh",
 		"onCommand:openshift.project.create",
+		"onCommand:openshift.project.set",
 		"onCommand:openshift.project.delete",
 		"onCommand:openshift.project.delete.palette",
 		"onCommand:openshift.component.openCreateComponent",
@@ -250,6 +251,22 @@
 		"onWalkthrough:serverlessFunctionWalkthrough"
 	],
 	"contributes": {
+		"configurationDefaults": {
+			"vs-kubernetes": {
+				"vs-kubernetes.disable-context-info-status-bar": true,
+				"vs-kubernetes.disable-namespace-info-status-bar": true
+			}
+		},
+		"icons": {
+			"current-context": {
+				"description": "context",
+				"default":"selection"
+			},
+			"project-node": {
+				"description": "project node",
+				"default":"project"
+			}
+		},
 		"commands": [
 			{
 				"command": "openshift.about",
@@ -1632,7 +1649,12 @@
 				{
 					"command": "openshift.project.create",
 					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sContext && canCreateNamespace",
-					"group": "c1"
+					"group": "c1@1"
+				},
+				{
+					"command": "openshift.project.set",
+					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sContext && canCreateNamespace",
+					"group": "c1@2"
 				},
 				{
 					"command": "openshift.explorer.logout",
@@ -1655,9 +1677,19 @@
 					"group": "p2"
 				},
 				{
+					"command": "openshift.project.set",
+					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && canCreateNamespace",
+					"group": "p3@1"
+				},
+				{
 					"command": "openshift.project.delete",
 					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*.can-delete/i",
-					"group": "p3"
+					"group": "p3@2"
+				},
+				{
+					"command": "openshift.project.set",
+					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && canCreateNamespace",
+					"group": "inline"
 				},
 				{
 					"command": "openshift.component.describe",
@@ -1773,11 +1805,6 @@
 				{
 					"command": "openshift.open.configFile",
 					"when": "view == openshiftProjectExplorer && viewItem == openshift.openConfigFile",
-					"group": "inline"
-				},
-				{
-					"command": "openshift.project.set",
-					"when": "view == openshiftProjectExplorer && (viewItem == openshift.k8sContext || viewItem =~ /openshift.project.*/i) && canCreateNamespace",
 					"group": "inline"
 				},
 				{
@@ -2087,6 +2114,21 @@
 				"order": 1,
 				"title": "OpenShift Toolkit",
 				"properties": {
+					"openshiftToolkit": {
+						"type": "object",
+						"title": "Additional settings",
+						"description": "OpenShift Toolkit configuration",
+						"properties": {
+							"openshiftToolkit.disable-context-info-status-bar": {
+								"type": "boolean",
+								"description": "Disable displaying the current Kubernetes context in VS Code's status bar."
+							},
+							"openshiftToolkit.disable-namespace-info-status-bar": {
+								"type": "boolean",
+								"description": "Disable displaying the active namespace in VS Code's status bar."
+							}
+						}
+					},
 					"openshiftToolkit.showWelcomePage": {
 						"type": "boolean",
 						"default": true,

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -78,6 +78,8 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
     readonly onDidChangeTreeData: Event<ExplorerItem | undefined> = this
         .eventEmitter.event;
 
+    public onDidChangeContextEmitter = new EventEmitter<string>();
+
     private constructor() {
         try {
             this.kubeConfig = new KubeConfigUtils();
@@ -100,6 +102,7 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
                         || this.kubeContext.user !== newCtx.user
                         || this.kubeContext.namespace !== newCtx.namespace)) {
                     this.refresh();
+                    this.onDidChangeContextEmitter.fire(newCtx.name);
                 }
                 this.kubeContext = newCtx;
                 this.kubeConfig = ku2;
@@ -234,6 +237,7 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
             } catch (err) {
                 // ignore because ether server is not accessible or user is logged out
             }
+            OpenShiftExplorer.getInstance().onDidChangeContextEmitter.fire(new KubeConfigUtils().currentContext);
         } else if ('name' in element) { // we are dealing with context here
             // user is logged into cluster from current context
             // and project should be show as child node of current context


### PR DESCRIPTION
In Application Explorer this:
- removes 'Change Active Project' inline action from the Cluster tree item (but it's still shown for the Project tree item);
- Adds 'Change Active Project' context menu item to the Cluster and Project tree items context menu.
- Disables the k8s Context and Namespace status bar items and adds the similar OpenShift Tools own items that use OpenShift Tools own actions to switch context/change current project
