### PR TITLE
Get rid of using k8s extension provided 'kubectl' binary

### DIFF
--- a/src/k8s/build.ts
+++ b/src/k8s/build.ts
@@ -118,8 +118,8 @@ export class Build {
         }
         if (buildName) {
             result = Progress.execFunctionWithProgress('Starting build', () =>
-                Build.cli.executeTool(Build.command.startBuild(buildName)),
-            )
+                    Build.cli.executeTool(Build.command.startBuild(buildName)),
+                )
                 .then(() => `Build '${buildName}' successfully started`)
                 .catch((err) =>
                     Promise.reject(
@@ -186,8 +186,8 @@ export class Build {
         const build = await Build.selectBuild(context, 'Select a build to delete');
         if (build) {
             result = Progress.execFunctionWithProgress('Deleting build', () =>
-                Build.cli.executeTool(Build.command.delete(build)),
-            )
+                    Build.cli.executeTool(Build.command.delete(build))
+                )
                 .then(() => `Build '${build}' successfully deleted`)
                 .catch((err) =>
                     Promise.reject(

--- a/src/k8s/clusterExplorer.ts
+++ b/src/k8s/clusterExplorer.ts
@@ -10,22 +10,21 @@ import { DeploymentConfig } from './deploymentConfig';
 import path = require('path');
 import { ClusterServiceVersion } from './csv';
 import { isOpenShift } from '../util/kubeUtils';
+import { CommandText } from '../base/command';
+import { CliChannel } from '../cli';
 
 let clusterExplorer: k8s.ClusterExplorerV1 | undefined;
 
 let lastNamespace = '';
 
 async function initNamespaceName(node: k8s.ClusterExplorerV1.ClusterExplorerResourceNode): Promise<string | undefined> {
-  const kubectl = await k8s.extension.kubectl.v1;
-  if (kubectl.available) {
-      const result = await kubectl.api.invokeCommand('config view -o json');
-      const config = JSON.parse(result.stdout);
-      const currentContext = (config.contexts || []).find((ctx) => ctx.name === node.name);
-      if (!currentContext) {
-          return '';
-      }
-      return currentContext.context.namespace || 'default';
-  }
+    const result = await CliChannel.getInstance().executeTool(new CommandText('oc', 'config view -o json'));
+    const config = JSON.parse(result.stdout);
+    const currentContext = (config.contexts || []).find((ctx) => ctx.name === node.name);
+    if (!currentContext) {
+        return '';
+    }
+    return currentContext.context.namespace || 'default';
 }
 
 async function customizeAsync(node: k8s.ClusterExplorerV1.ClusterExplorerResourceNode, treeItem: vscode.TreeItem): Promise<void> {

--- a/src/serverlessFunction/knative.ts
+++ b/src/serverlessFunction/knative.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import * as k8s from 'vscode-kubernetes-tools-api';
+import { CommandText } from '../base/command';
+import { CliChannel } from '../cli';
 
 /**
  * Returns true if the cluster has the Knative Serving CRDs, and false otherwise.
@@ -11,16 +12,12 @@ import * as k8s from 'vscode-kubernetes-tools-api';
  * @returns true if the cluster has the Knative Serving CRDs, and false otherwise
  */
 export async function isKnativeServingAware(): Promise<boolean> {
-    const kubectl = await k8s.extension.kubectl.v1;
-    let isKnative = false;
-    if (kubectl.available) {
-        const sr = await kubectl.api.invokeCommand('api-versions');
-        isKnative =
-            sr &&
-            sr.code === 0 &&
-            (sr.stdout.includes('serving.knative.dev/v1') ||
-                sr.stdout.includes('serving.knative.dev/v1alpha1') ||
-                sr.stdout.includes('serving.knative.dev/v1beta1'));
+    try {
+        const stdout = await CliChannel.getInstance().executeSyncTool(new CommandText('oc', 'api-versions'), { timeout: 5000 });
+        return stdout.includes('serving.knative.dev/v1') ||
+            stdout.includes('serving.knative.dev/v1alpha1') ||
+            stdout.includes('serving.knative.dev/v1beta1')
+    } catch(error) {
+        return false;
     }
-    return isKnative;
 }

--- a/src/tekton/tekton.ts
+++ b/src/tekton/tekton.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import * as k8s from 'vscode-kubernetes-tools-api';
+import { CommandText } from '../base/command';
+import { CliChannel } from '../cli';
 
 /**
  * Returns true if the cluster has the Tekton CRDs, and false otherwise.
@@ -11,11 +12,10 @@ import * as k8s from 'vscode-kubernetes-tools-api';
  * @returns true if the cluster has the Tekton CRDs, and false otherwise
  */
 export async function isTektonAware(): Promise<boolean> {
-    const kubectl = await k8s.extension.kubectl.v1;
-    let isTekton = false;
-    if (kubectl.available) {
-        const sr = await kubectl.api.invokeCommand('api-versions');
-        isTekton = sr && sr.code === 0 && sr.stdout.includes('tekton.dev/v1beta1');
+    try {
+        const stdout = await CliChannel.getInstance().executeSyncTool(new CommandText('oc', 'api-versions'), { timeout: 5000 });
+        return stdout.includes('tekton.dev/v1beta1');
+    } catch(error) {
+        return false;
     }
-    return isTekton;
 }

--- a/src/util/kubeUtils.ts
+++ b/src/util/kubeUtils.ts
@@ -9,7 +9,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { QuickPickItem, window } from 'vscode';
 import { Platform } from './platform';
-import * as k8s from 'vscode-kubernetes-tools-api';
+import { CommandText } from '../base/command';
+import { CliChannel } from '../cli';
 
 function fileExists(file: string): boolean {
     try {
@@ -184,13 +185,12 @@ export async function setKubeConfig(): Promise<void> {
 }
 
 export async function isOpenShift(): Promise<boolean> {
-    const kubectl = await k8s.extension.kubectl.v1;
-    let isOS = false;
-    if (kubectl.available) {
-        const sr = await kubectl.api.invokeCommand('api-versions');
-        isOS = sr && sr.code === 0 && sr.stdout.includes('apps.openshift.io/v1');
+    try {
+        const stdout = await CliChannel.getInstance().executeSyncTool(new CommandText('oc', 'api-versions'), { timeout: 5000 });
+        return stdout.includes('apps.openshift.io/v1');
+    } catch(error) {
+        return false;
     }
-    return isOS;
   }
 
   export async function getNamespaceKind(): Promise<string> {


### PR DESCRIPTION
The 'oc' binary is used instead in non-blocking manner, especially when getting 'api-versions' values. Partially fixes #3987.

Issue: #3987