### PR TITLE
Reduce memory usage of build process

### DIFF
--- a/build/esbuild.mjs
+++ b/build/esbuild.mjs
@@ -23,33 +23,25 @@ const webviews = [
     'openshift-terminal',
 ];
 
-function kebabToCamel(text) {
-    return text.replace(/-./g, searchResult => searchResult.substring(1).toUpperCase());
-}
-
 await Promise.all([
+    esbuild.build({
+        entryPoints: webviews.map(webview => `./src/webview/${webview}/app/index.tsx`),
+        bundle: true,
+        outdir: 'out',
+        platform: 'browser',
+        target: 'chrome108',
+        sourcemap: true,
+        loader: {
+            '.png': 'file',
+        },
+        plugins: [
+            sassPlugin(),
+            svgr({
+                plugins: ['@svgr/plugin-jsx']
+            }),
+        ]
+    }),
     ...webviews.map(webview =>
-        esbuild.build({
-            entryPoints: [
-                `./src/webview/${webview}/app/index.tsx`,
-            ],
-            bundle: true,
-            outfile: `./out/${kebabToCamel(webview)}Viewer/index.js`,
-            platform: 'browser',
-            target: 'chrome108',
-            sourcemap: true,
-            loader: {
-                '.png': 'file',
-            },
-            plugins: [
-                sassPlugin(),
-                svgr({
-                    plugins: ['@svgr/plugin-jsx']
-                }),
-            ]
-        })
-    ),
-    ...webviews.map(webview =>
-        fs.cp(`./src/webview/${webview}/app/index.html`, `./out/${kebabToCamel(webview)}Viewer/index.html`)
+        fs.cp(`./src/webview/${webview}/app/index.html`, `./out/${webview}/app/index.html`)
     ),
 ]);

--- a/src/webview/add-service-binding/addServiceBindingViewLoader.ts
+++ b/src/webview/add-service-binding/addServiceBindingViewLoader.ts
@@ -53,7 +53,7 @@ export default class AddServiceBindingViewLoader {
         listenerFactory: (panel: vscode.WebviewPanel) => (event) => Promise<void>,
     ): Promise<vscode.WebviewPanel> {
         const localResourceRoot = vscode.Uri.file(
-            path.join(AddServiceBindingViewLoader.extensionPath, 'out', 'addServiceBindingViewer'),
+            path.join(AddServiceBindingViewLoader.extensionPath, 'out', 'add-service-binding', 'app'),
         );
 
         let panel: vscode.WebviewPanel = vscode.window.createWebviewPanel(
@@ -71,7 +71,7 @@ export default class AddServiceBindingViewLoader {
             path.join(AddServiceBindingViewLoader.extensionPath, 'images/context/cluster-node.png'),
         );
         panel.webview.html = await loadWebviewHtml(
-            'addServiceBindingViewer',
+            'add-service-binding',
             panel,
         );
         panel.webview.onDidReceiveMessage(listenerFactory(panel));

--- a/src/webview/cluster/clusterViewLoader.ts
+++ b/src/webview/cluster/clusterViewLoader.ts
@@ -359,7 +359,7 @@ export default class ClusterViewLoader {
     }
 
     static async loadView(title: string): Promise<vscode.WebviewPanel> {
-        const localResourceRoot = vscode.Uri.file(path.join(ClusterViewLoader.extensionPath, 'out', 'clusterViewer'));
+        const localResourceRoot = vscode.Uri.file(path.join(ClusterViewLoader.extensionPath, 'out', 'cluster', 'app'));
         if (panel) {
             // If we already have a panel, show it in the target column
             panel.reveal(vscode.ViewColumn.One);
@@ -370,7 +370,7 @@ export default class ClusterViewLoader {
                 retainContextWhenHidden: true
             });
             panel.iconPath = vscode.Uri.file(path.join(ClusterViewLoader.extensionPath, 'images/context/cluster-node.png'));
-            panel.webview.html = await loadWebviewHtml('clusterViewer', panel);
+            panel.webview.html = await loadWebviewHtml('cluster', panel);
             const messageListenerDisposable = panel.webview.onDidReceiveMessage(clusterEditorMessageListener);
             panel.onDidDispose(()=> {
                 messageListenerDisposable.dispose();

--- a/src/webview/common-ext/utils.ts
+++ b/src/webview/common-ext/utils.ts
@@ -5,12 +5,12 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import validator from 'validator';
 import { extensions, Uri, WebviewPanel, WebviewView } from 'vscode';
 import * as NameValidator from '../../openshift/nameValidator';
 import { ExtensionID } from '../../util/constants';
 import { gitUrlParse } from '../../util/gitParse';
 import { validateURLProps } from '../common/propertyTypes';
-import validator from 'validator';
 export type Message = {
     action: string;
     data: any;
@@ -20,7 +20,7 @@ export async function loadWebviewHtml(webviewName: string, webviewPanel: Webview
 
     const extensionPath = extensions.getExtension(ExtensionID).extensionPath;
 
-    const reactAppRootOnDisk = path.join(extensionPath, 'out', webviewName);
+    const reactAppRootOnDisk = path.join(extensionPath, 'out', webviewName, 'app');
     const reactJavascriptUri = webviewPanel.webview.asWebviewUri(
         Uri.file(path.join(reactAppRootOnDisk, 'index.js'))
     );

--- a/src/webview/create-component/createComponentLoader.ts
+++ b/src/webview/create-component/createComponentLoader.ts
@@ -58,7 +58,7 @@ export default class CreateComponentLoader {
             return;
         }
         const localResourceRoot = Uri.file(
-            path.join(CreateComponentLoader.extensionPath, 'out', 'createComponentViewer'),
+            path.join(CreateComponentLoader.extensionPath, 'out', 'create-component'),
         );
 
         const panel = window.createWebviewPanel('createComponentView', title, ViewColumn.One, {
@@ -105,7 +105,7 @@ export default class CreateComponentLoader {
         panel.iconPath = Uri.file(
             path.join(CreateComponentLoader.extensionPath, 'images/context/cluster-node.png'),
         );
-        panel.webview.html = await loadWebviewHtml('createComponentViewer', panel);
+        panel.webview.html = await loadWebviewHtml('create-component', panel);
         CreateComponentLoader.panel = panel;
 
         CreateComponentLoader.initFromRootFolderPath = folderPath;

--- a/src/webview/create-service/createServiceViewLoader.ts
+++ b/src/webview/create-service/createServiceViewLoader.ts
@@ -28,7 +28,7 @@ export default class CreateServiceViewLoader {
 
     static async loadView(): Promise<vscode.WebviewPanel> {
         const localResourceRoot = vscode.Uri.file(
-            path.join(CreateServiceViewLoader.extensionPath, 'out', 'createServiceViewer'),
+            path.join(CreateServiceViewLoader.extensionPath, 'out', 'create-service', 'app'),
         );
 
         if (CreateServiceViewLoader.panel) {
@@ -51,7 +51,7 @@ export default class CreateServiceViewLoader {
             path.join(CreateServiceViewLoader.extensionPath, 'images/context/cluster-node.png'),
         );
         CreateServiceViewLoader.panel.webview.html = await loadWebviewHtml(
-            'createServiceViewer',
+            'create-service',
             CreateServiceViewLoader.panel,
         );
 

--- a/src/webview/devfile-registry/registryViewLoader.ts
+++ b/src/webview/devfile-registry/registryViewLoader.ts
@@ -155,7 +155,7 @@ export default class RegistryViewLoader {
     }
 
     static async loadView(title: string, url?: string): Promise<vscode.WebviewPanel> {
-        const localResourceRoot = vscode.Uri.file(path.join(RegistryViewLoader.extensionPath, 'out', 'devfileRegistryViewer'));
+        const localResourceRoot = vscode.Uri.file(path.join(RegistryViewLoader.extensionPath, 'out', 'devfile-registry', 'app'));
         if (panel) {
             if (RegistryViewLoader.url !== url) {
                 RegistryViewLoader.url = url;
@@ -171,7 +171,7 @@ export default class RegistryViewLoader {
                 retainContextWhenHidden: true
             });
             panel.iconPath = vscode.Uri.file(path.join(RegistryViewLoader.extensionPath, 'images/context/devfile.png'));
-            panel.webview.html = await loadWebviewHtml('devfileRegistryViewer', panel);
+            panel.webview.html = await loadWebviewHtml('devfile-registry', panel);
             const messageDisposable = panel.webview.onDidReceiveMessage(devfileRegistryViewerMessageListener);
             panel.onDidDispose(() => {
                 messageDisposable.dispose();

--- a/src/webview/feedback/feedbackLoader.ts
+++ b/src/webview/feedback/feedbackLoader.ts
@@ -26,7 +26,7 @@ export default class FeedbackLoader {
     }
 
     static async loadView(title: string): Promise<vscode.WebviewPanel> {
-        const localResourceRoot = vscode.Uri.file(path.join(FeedbackLoader.extensionPath || '', 'out', 'feedbackViewer'));
+        const localResourceRoot = vscode.Uri.file(path.join(FeedbackLoader.extensionPath || ''));
         if (panel) {
             // If we already have a panel, show it in the target column
             panel.reveal(vscode.ViewColumn.One);
@@ -38,7 +38,7 @@ export default class FeedbackLoader {
                 retainContextWhenHidden: true
             });
             panel.iconPath = vscode.Uri.file(path.join(FeedbackLoader.extensionPath || '', 'images/openshift_extension.png'));
-            panel.webview.html = await loadWebviewHtml('feedbackViewer', panel);
+            panel.webview.html = await loadWebviewHtml('feedback', panel);
             panel.onDidDispose(() => {
                 panel = undefined;
             });

--- a/src/webview/helm-chart/helmChartLoader.ts
+++ b/src/webview/helm-chart/helmChartLoader.ts
@@ -2,19 +2,19 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
+import * as JSYAML from 'js-yaml';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as JSYAML from 'js-yaml';
 import { OpenShiftExplorer } from '../../explorer';
 import * as Helm from '../../helm/helm';
+import { Chart, ChartResponse, HelmRepo } from '../../helm/helmChartType';
 import sendTelemetry, { ExtCommandTelemetryEvent } from '../../telemetry';
 import { ExtensionID } from '../../util/constants';
+import { Progress } from '../../util/progress';
 import { vsCommand } from '../../vscommand';
+import { validateName } from '../common-ext/createComponentHelpers';
 import { loadWebviewHtml } from '../common-ext/utils';
 import fetch = require('make-fetch-happen');
-import { validateName } from '../common-ext/createComponentHelpers';
-import { Progress } from '../../util/progress';
-import { Chart, ChartResponse, HelmRepo } from '../../helm/helmChartType';
 
 let panel: vscode.WebviewPanel;
 const helmCharts: ChartResponse[] = [];
@@ -140,7 +140,7 @@ export default class HelmChartLoader {
     }
 
     static async loadView(title: string): Promise<vscode.WebviewPanel> {
-        const localResourceRoot = vscode.Uri.file(path.join(HelmChartLoader.extensionPath, 'out', 'helmChartViewer'));
+        const localResourceRoot = vscode.Uri.file(path.join(HelmChartLoader.extensionPath, 'out', 'helm-chart', 'app'));
         if (panel) {
             // If we already have a panel, show it in the target column
             panel.reveal(vscode.ViewColumn.One);
@@ -152,7 +152,7 @@ export default class HelmChartLoader {
                 retainContextWhenHidden: true
             });
             panel.iconPath = vscode.Uri.file(path.join(HelmChartLoader.extensionPath, 'images/helm/helm.svg'));
-            panel.webview.html = await loadWebviewHtml('helmChartViewer', panel);
+            panel.webview.html = await loadWebviewHtml('helm-chart', panel);
             const messageDisposable = panel.webview.onDidReceiveMessage(helmChartMessageListener);
             panel.onDidDispose(() => {
                 messageDisposable.dispose();

--- a/src/webview/helm-manage-repository/manageRepositoryLoader.ts
+++ b/src/webview/helm-manage-repository/manageRepositoryLoader.ts
@@ -34,7 +34,7 @@ export default class ManageRepositoryViewLoader {
             return;
         }
         const localResourceRoot = vscode.Uri.file(
-            path.join(ManageRepositoryViewLoader.extensionPath, 'out', 'helmManageRepositoryViewer'),
+            path.join(ManageRepositoryViewLoader.extensionPath, 'out', 'helm-manage-repository', 'app'),
         );
 
         const panel = vscode.window.createWebviewPanel('helmRepositoryView', title, vscode.ViewColumn.One, {
@@ -56,7 +56,7 @@ export default class ManageRepositoryViewLoader {
             path.join(ManageRepositoryViewLoader.extensionPath, 'images/context/cluster-node.png'),
         );
 
-        panel.webview.html = await loadWebviewHtml('helmManageRepositoryViewer', panel);
+        panel.webview.html = await loadWebviewHtml('helm-manage-repository', panel);
         ManageRepositoryViewLoader.panel = panel;
 
         return panel;

--- a/src/webview/openshift-terminal/openShiftTerminal.ts
+++ b/src/webview/openshift-terminal/openShiftTerminal.ts
@@ -435,7 +435,7 @@ export class OpenShiftTerminalManager implements WebviewViewProvider {
             enableScripts: true,
         };
 
-        const newHtml: string = await loadWebviewHtml('openshiftTerminalViewer', this.webviewView);
+        const newHtml: string = await loadWebviewHtml('openshift-terminal', this.webviewView);
         if (!token.isCancellationRequested) {
             this.webview.html = newHtml;
         }

--- a/src/webview/serverless-function/serverlessFunctionLoader.ts
+++ b/src/webview/serverless-function/serverlessFunctionLoader.ts
@@ -221,7 +221,7 @@ export default class ServerlessFunctionViewLoader {
     ): Promise<vscode.WebviewPanel> {
 
         const localResourceRoot = vscode.Uri.file(
-            path.join(ServerlessFunctionViewLoader.extensionPath, 'out', 'serverlessFunctionViewer'),
+            path.join(ServerlessFunctionViewLoader.extensionPath, 'out', 'serverless-function', 'app'),
         );
 
         let panel: vscode.WebviewPanel = vscode.window.createWebviewPanel(
@@ -239,7 +239,7 @@ export default class ServerlessFunctionViewLoader {
             path.join(ServerlessFunctionViewLoader.extensionPath, 'images/context/cluster-node.png'),
         );
         panel.webview.html = await loadWebviewHtml(
-            'serverlessFunctionViewer',
+            'serverless-function',
             panel,
         );
         panel.webview.onDidReceiveMessage((e) => messageListener(panel, e));

--- a/src/webview/serverless-manage-repository/manageRepositoryLoader.ts
+++ b/src/webview/serverless-manage-repository/manageRepositoryLoader.ts
@@ -33,7 +33,7 @@ export default class ManageRepositoryViewLoader {
             return;
         }
         const localResourceRoot = vscode.Uri.file(
-            path.join(ManageRepositoryViewLoader.extensionPath, 'out', 'serverlessManageRepositoryViewer'),
+            path.join(ManageRepositoryViewLoader.extensionPath, 'out', 'serverless-manage-repository', 'app'),
         );
 
         const panel = vscode.window.createWebviewPanel('manageRepositoryView', title, vscode.ViewColumn.One, {
@@ -55,7 +55,7 @@ export default class ManageRepositoryViewLoader {
             path.join(ManageRepositoryViewLoader.extensionPath, 'images/context/cluster-node.png'),
         );
 
-        panel.webview.html = await loadWebviewHtml('serverlessManageRepositoryViewer', panel);
+        panel.webview.html = await loadWebviewHtml('serverless-manage-repository', panel);
         ManageRepositoryViewLoader.panel = panel;
 
         return panel;

--- a/src/webview/welcome/welcomeViewLoader.ts
+++ b/src/webview/welcome/welcomeViewLoader.ts
@@ -76,7 +76,7 @@ export default class WelcomeViewLoader {
     }
 
     static async loadView(title: string): Promise<vscode.WebviewPanel> {
-        const localResourceRoot = vscode.Uri.file(path.join(WelcomeViewLoader.extensionPath, 'out', 'welcomeViewer'));
+        const localResourceRoot = vscode.Uri.file(path.join(WelcomeViewLoader.extensionPath, 'out'));
         const images = vscode.Uri.file(path.join(WelcomeViewLoader.extensionPath, 'images'));
         if (panel) {
             // If we already have a panel, show it in the target column
@@ -88,7 +88,7 @@ export default class WelcomeViewLoader {
                 retainContextWhenHidden: true
             });
             panel.iconPath = vscode.Uri.file(path.join(WelcomeViewLoader.extensionPath, 'images/openshift_extension.png'));
-            panel.webview.html = await loadWebviewHtml('welcomeViewer', panel);
+            panel.webview.html = await loadWebviewHtml('welcome', panel);
             panel.onDidDispose(() => {
                 panel = undefined;
             });


### PR DESCRIPTION
This takes the esbuild memory usage from 5 Gb to 1.8 Gb, for both the command line run and the background build process for VS Code. It accomplishes this by doing everything in one esbuild call instead of many parallel esbuild calls. The tradeoff is that the directory structure of the `out` folder has changed, so I had to change some webview code to accomidate this change.

Signed-off-by: David Thompson <davthomp@redhat.com>
