### PR TITLE
Improve set active or create new project/namespace workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1720,12 +1720,12 @@
 				},
 				{
 					"command": "openshift.project.set",
-					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sContext && canCreateNamespace && isOpenshiftCluster",
+					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sContext && isOpenshiftCluster",
 					"group": "c1@2"
 				},
 				{
 					"command": "openshift.namespace.set",
-					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sContext && canCreateNamespace && !isOpenshiftCluster",
+					"when": "view == openshiftProjectExplorer && viewItem == openshift.k8sContext && !isOpenshiftCluster",
 					"group": "c1@2"
 				},
 				{
@@ -1750,12 +1750,12 @@
 				},
 				{
 					"command": "openshift.project.set",
-					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && canCreateNamespace && isOpenshiftCluster",
+					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && isOpenshiftCluster",
 					"group": "p3@1"
 				},
 				{
 					"command": "openshift.namespace.set",
-					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && canCreateNamespace && !isOpenshiftCluster",
+					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && !isOpenshiftCluster",
 					"group": "p3@1"
 				},
 				{
@@ -1770,12 +1770,12 @@
 				},
 				{
 					"command": "openshift.project.set",
-					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && canCreateNamespace && isOpenshiftCluster",
+					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && isOpenshiftCluster",
 					"group": "inline"
 				},
 				{
 					"command": "openshift.namespace.set",
-					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && canCreateNamespace && !isOpenshiftCluster",
+					"when": "view == openshiftProjectExplorer && viewItem =~ /openshift.project.*/i && !isOpenshiftCluster",
 					"group": "inline"
 				},
 				{

--- a/src/oc/ocWrapper.ts
+++ b/src/oc/ocWrapper.ts
@@ -201,6 +201,25 @@ export class Oc {
     }
 
     /**
+     * Returns true if the current user is authorized to list namespaces on the cluster, and false otherwise.
+     *
+     * @returns true if the current user is authorized to list namespaces on the cluster, and false otherwise
+     */
+    public async canListNamespaces(): Promise<boolean> {
+        try {
+            const result = await CliChannel.getInstance().executeTool(
+                new CommandText('oc', 'auth can-i list projects'),
+            );
+            if (result.stdout === 'yes') {
+                return true;
+            }
+        } catch {
+            //ignore
+        }
+        return false;
+    }
+
+    /**
      * Returns true if the current user is authorized to delete a namespace on the cluster, and false otherwise.
      *
      * @param namespace the namespace to be deleted (defaults to the current namespace if none is provided)
@@ -504,8 +523,9 @@ export class Oc {
         }
     }
 
-    public async getProjects(): Promise<Project[]> {
-        return this._listProjects();
+    public async getProjects(onlyFromCluster: boolean = false): Promise<Project[]> {
+        return this._listProjects()
+            .then((projects) => onlyFromCluster ? projects : this.fixActiveProject(projects));
     }
 
     /**
@@ -514,51 +534,103 @@ export class Oc {
      * @returns the active project or null if no project is active
      */
     public async getActiveProject(): Promise<string> {
-        const projects = await this._listProjects();
-        if (!projects.length) {
-            return null;
-        }
-        let activeProject = projects.find((project) => project.active);
-        if (activeProject) return activeProject.name;
+        return this._listProjects()
+            .then((projects) => {
+                const fixedProjects = this.fixActiveProject(projects);
+                const activeProject = fixedProjects.find((project) => project.active);
+                return activeProject ? activeProject.name : null;
+            });
+    }
 
-        // If not found - use Kube Config current context or 'default'
+    /**
+     * Fixes the projects array by marking up an active project (if not set)
+     * by the following rules:
+     * - If there is only one single project - mark it as active
+     * - If there is already at least one project marked as active - return the projects "as is"
+     * - If Kube Config's current context has a namespace set - find an according project
+     *   and mark it as active
+     * - [fixup for Sandbox cluster] Get Kube Configs's curernt username and try finding a project,
+     *   which name is partially created from that username - if found, treat it as an active project
+     * - Try a 'default' as a project name, if found - use it as an active project name
+     * - Use first project as active
+     *
+     * @returns The array of Projects with at least one project marked as an active
+     */
+    public fixActiveProject(projects: Project[]): Project[] {
         const kcu = new KubeConfigUtils();
         const currentContext = kcu.findContext(kcu.currentContext);
+
+        let fixedProjects = projects.length ? projects : [];
+        let activeProject = undefined;
+
         if (currentContext) {
-            const active = currentContext.namespace || 'default';
-            activeProject = projects.find((project) => project.name ===active);
+            // Try Kube Config current context to find existing active project
+            if (currentContext.namespace) {
+                activeProject = fixedProjects.find((project) => project.name === currentContext.namespace);
+                if (activeProject) {
+                    activeProject.active = true;
+                    return fixedProjects;
+                }
+            }
+
+            // [fixup for Sandbox cluster] Get Kube Configs's curernt username and try finding a project,
+            // which name is partially created from that username
+            const currentUser = kcu.getCurrentUser();
+            if (currentUser) {
+                const projectPrefix = currentUser.name.substring(0, currentUser.name.indexOf('/'));
+                if (projectPrefix.length > 0) {
+                    activeProject = fixedProjects.find((project) => project.name.includes(projectPrefix));
+                    if (activeProject) {
+                        activeProject.active = true;
+                        void Oc.Instance.setProject(activeProject.name);
+                        return fixedProjects;
+                    }
+                }
+            }
+
+            // Add Kube Config current context to the proect list for cases where
+            // projects/namespaces cannot be listed due to the cluster config restrictions
+            // (such a project/namespace can be set active manually)
+            if (currentContext.namespace) {
+                fixedProjects = [
+                    {
+                        name: currentContext.namespace,
+                        active: true
+                    },
+                    ...projects
+                ]
+                void Oc.Instance.setProject(currentContext.namespace);
+                return fixedProjects;
+            }
         }
-        return activeProject ? activeProject.name : null;
+
+        // Try a 'default' as a project name, if found - use it as an active project name
+        activeProject = fixedProjects.find((project) => project.name === 'default');
+        if (activeProject) {
+            activeProject.active = true;
+            return fixedProjects;
+        }
+
+        // Set the first available project as active
+        if (fixedProjects.length > 0) {
+            fixedProjects[0].active = true;
+            void Oc.Instance.setProject(fixedProjects[0].name);
+        }
+
+        return fixedProjects;
     }
 
     private async _listProjects(): Promise<Project[]> {
-        const onlyOneProject = 'you have one project on this server:';
         const namespaces: Project[] = [];
         return await CliChannel.getInstance().executeTool(
-                new CommandText('oc', 'projects')
+                new CommandText('oc', 'projects -q')
             )
             .then( (result) => {
                 const lines = result.stdout && result.stdout.split(/\r?\n/g);
                 for (let line of lines) {
                     line = line.trim();
                     if (line === '') continue;
-                    if (line.toLocaleLowerCase().startsWith(onlyOneProject)) {
-                        const matches = line.match(/You\shave\sone\sproject\son\sthis\sserver:\s"([a-zA-Z0-9]+[a-zA-Z0-9.-]*)"./);
-                        if (matches) {
-                            namespaces.push({name: matches[1], active: true});
-                            break; // No more projects are to be listed
-                        }
-                    } else {
-                        const words: string[] = line.split(' ');
-                        if (words.length > 0 && words.length <= 2) {
-                            // The list of projects may have eithe 1 (project name) or 2 words
-                            // (an asterisk char, indicating that the project is active, and project name).
-                            // Otherwise, it's either a header or a footer text
-                            const active = words.length === 2 && words[0].trim() === '*';
-                            const projectName = words[words.length - 1] // The last word of array
-                            namespaces.push( {name: projectName, active });
-                        }
-                    }
+                    namespaces.push( {name: line, active: false });
                 }
                 return namespaces;
             })

--- a/src/util/loginUtil.ts
+++ b/src/util/loginUtil.ts
@@ -35,15 +35,9 @@ export class LoginUtil {
                 if (serverURI && !(`${serverCheck}`.toLowerCase().includes(serverURI.toLowerCase()))) return true;
 
                 return await CliChannel.getInstance().executeSyncTool(
-                        new CommandText('oc', 'whoami'), { timeout: 5000 })
-                    .then((user) => false) // Active user is set - no need to login
-                    .catch((error) => {
-                        if (!error.stderr) return true; // Error with no reason - require to login
-
-                        // if reason is "forbidden" or not determined - require to login, otherwise - no need to login
-                        const matches = error.stderr.match(/Error\sfrom\sserver\s\(([a-zA-Z]*)\):*/);
-                        return matches && matches[1].toLocaleLowerCase() !== 'forbidden' ? false : true;
-                    });
+                        new CommandText('oc', 'api-versions'), { timeout: 5000 })
+                    .then((response) => !response || response.trim().length === 0) // Active user is set - no need to login
+                    .catch((error) => true);
             })
             .catch((error) => true); // Can't get server - require to login
     }

--- a/test/integration/ocWrapper.test.ts
+++ b/test/integration/ocWrapper.test.ts
@@ -102,6 +102,15 @@ suite('./oc/ocWrapper.ts', function () {
             const project3 = 'my-test-project-3';
             await Oc.Instance.createProject(project3);
             await Oc.Instance.deleteProject(project3);
+
+            // Because 'my-test-project-3' namepace is still stays configured in Kube Config,
+            // it's been returned by `getProjects` in order to allow working with clusters that
+            // have a restriction on listing projects/namespaces.
+            // (see: https://github.com/redhat-developer/vscode-openshift-tools/issues/3999)
+            // So we need to set any other project as active before aqcuiring projects from the cluster,
+            // in order to make sure that required `my-test-projet-2` is deleted on the cluster:
+            await Oc.Instance.setProject('default');
+
             const projects = await Oc.Instance.getProjects();
             const projectNames = projects.map((project) => project.name);
             expect(projectNames).to.not.contain(project3);


### PR DESCRIPTION
- Now, when switching projects/namespaces, one can manually type in a project name to be set as an active one
- No more 'Missing project/namespace' item for a project/namespace that doesn't exist on a cluster. This allows
  working normally on clusters with restrictions on list for projects.

Fixes: #3999

- The project listing is fixed, so annotated projects are shown now

Fixes: #4101

- For a Sandbox cluster a project which name contains current user name is used as a default one when logging in (A follow up to #4109)

Issue: #4080 (?)