### PR TITLE
Trim token value from Clipboard

### DIFF
--- a/src/openshift/cluster.ts
+++ b/src/openshift/cluster.ts
@@ -1027,7 +1027,7 @@ export class Cluster extends OpenShiftItem {
     }
 
     static validateLoginToken(token: string): boolean {
-        const sha256Regex = new RegExp('^sha256~([A-Za-z0-9_]+)');
+        const sha256Regex = /^sha256~([A-Za-z0-9_-]+)$/;
         return sha256Regex.test(token);
     }
 

--- a/src/webview/cluster/clusterViewLoader.ts
+++ b/src/webview/cluster/clusterViewLoader.ts
@@ -117,7 +117,7 @@ async function clusterEditorMessageListener (event: any ): Promise<any> {
                     if (signupStatus.status.ready) {
                         const oauthInfo = await sandboxAPI.getOauthServerInfo(signupStatus.apiEndpoint);
                         let errCode = '';
-                        if (!Cluster.validateLoginToken(await vscode.env.clipboard.readText())) {
+                        if (!Cluster.validateLoginToken((await vscode.env.clipboard.readText()).trim())) {
                             errCode = 'invalidToken';
                         }
                         await panel.webview.postMessage({ action: 'sandboxPageProvisioned', statusInfo: signupStatus.username, consoleDashboard: signupStatus.consoleURL, apiEndpoint: signupStatus.apiEndpoint, oauthTokenEndpoint: oauthInfo.token_endpoint, errorCode: errCode });


### PR DESCRIPTION
Also the sha256-token validation is fixed.

When using 'Developer Sandbox` to login to the DevSandbox and a token is already stored in the Clipboard, its value isn't trimmed before its validation and usage:
 
![image](https://github.com/redhat-developer/vscode-openshift-tools/assets/620781/de887877-5e43-4bc5-81ba-01f6b26b0b51)

So, when the sha256-token value begins with a whitespace character the  `Login to DevSandbox` button is shown as disabled and its tooltip says: "Token in clibboard is invalid....":

![image](https://github.com/redhat-developer/vscode-openshift-tools/assets/620781/28afa5bc-a79e-482e-9f39-e03f6aa6daf1)

Also, the sha256 token validation RegEx incorrectly validates provided token - it doesn't accept `-` character as a part of token value and doesn't control the ending thus allowing a whitespaces or any text to be placed after  a whitespace or '-' character. 