### PR TITLE
A workaround for 'ODO' stopped working after Devfile schema update to v.2.2.2 #4183

### DIFF
--- a/src/odo/odoWrapper.ts
+++ b/src/odo/odoWrapper.ts
@@ -109,6 +109,7 @@ export class Odo {
         starter: string = undefined,
         useExistingDevfile = false,
         customDevfilePath = '',
+        devfileVersion?: string
     ): Promise<void> {
         await this.execute(
             Command.createLocalComponent(
@@ -119,6 +120,7 @@ export class Odo {
                 starter,
                 useExistingDevfile,
                 customDevfilePath,
+                devfileVersion
             ),
             location.fsPath,
         );

--- a/test/integration/odoWrapper.test.ts
+++ b/test/integration/odoWrapper.test.ts
@@ -66,6 +66,9 @@ suite('./odo/odoWrapper.ts', function () {
                 'component1',
                 tmpFolder1,
                 'nodejs-starter',
+                false,
+                '',
+                '2.2.0' // A workaround for odo v.3.15.0 not supporting schema v.>2.2.0
             );
             await Odo.Instance.createComponentFromFolder(
                 'go',
@@ -258,6 +261,9 @@ suite('./odo/odoWrapper.ts', function () {
                 'component1',
                 Uri.parse(componentFolder),
                 'nodejs-starter',
+                false,
+                '',
+                '2.2.0' // A workaround for odo v.3.15.0 not supporting schema v.>2.2.0
             );
         });
 


### PR DESCRIPTION
This is the only workaround limiting the devfile version for node.js component to v.2.2.0 when running the integration tests

Issue: #4183