### PR TITLE
Fixes the enablement for 'Login to DevSandbox' using token from Clipboard

### DIFF
--- a/src/webview/cluster/clusterViewLoader.ts
+++ b/src/webview/cluster/clusterViewLoader.ts
@@ -219,11 +219,13 @@ async function clusterEditorMessageListener (event: any ): Promise<any> {
 
 async function pollClipboard(signupStatus) {
     const oauthInfo = await sandboxAPI.getOauthServerInfo(signupStatus.apiEndpoint);
+    let coldStart = true; // To enforce clipboard token propagation on start
     while (panel) {
         const previousContent = (await vscode.env.clipboard.readText()).trim();
         await new Promise(r => setTimeout(r, 500));
         const currentContent = (await vscode.env.clipboard.readText()).trim();
-        if (previousContent && previousContent !== currentContent) {
+        if (coldStart || (previousContent && previousContent !== currentContent)) {
+            coldStart = false;
             let errCode = '';
             if (!Cluster.validateLoginToken(currentContent)){
                 errCode = 'invalidToken';


### PR DESCRIPTION
This fixes the validation/enablement for 'Login to DevSandbox' button in case of very first Clipboard Poll:
when a token is copied to the Clipboard before the polling starts such a token wasn't taken into account so, even if the token is valid the 'Login to DevSandbox' stayed 'disabled'.