### PR TITLE
[test] Fix Dervile Registry UI suite test

### DIFF
--- a/test/ui/suite/devfileRegistries.ts
+++ b/test/ui/suite/devfileRegistries.ts
@@ -125,7 +125,7 @@ export function testDevfileRegistries() {
             // initialize web view editor
             const webView = new RegistryWebViewEditor('Devfile Registry - DefaultDevfileRegistry');
             await webView.initializeEditor();
-            expect(await webView.getRegistryStackNames()).to.include.members(['Quarkus Java', 'Django', 'Go Runtime', 'Maven Java', 'Vue']);
+            expect(await webView.getRegistryStackNames()).to.include.members(['Quarkus Java', 'Django', 'Go Runtime', 'Vue']);
         });
 
         after(async function context() {


### PR DESCRIPTION
```
  1) Extension public-facing UI tests
       Devfile Registries
         open Devfile registry view from item's context menu and verify the content of the registry:

      AssertionError: expected [ 'Quarkus Java', 'Django', …(8) ] to be a superset of [ 'Quarkus Java', 'Django', …(3) ]
      + expected - actual

       [
         "Quarkus Java"
         "Django"
         "Go Runtime"
      -  "WildFly"
      -  ".NET 5.0"
      -  ".NET 6.0"
      -  "React"
      -  "Svelte"
      -  "Universal Developer Image"
      +  "Maven Java"
         "Vue"
       ]

      at Context.<anonymous> (test/ui/suite/devfileRegistries.ts:128:70)
      at Generator.next (<anonymous>)
      at fulfilled (out/test/ui/suite/devfileRegistries.js:5:58)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```