### PR TITLE
[build] Prevent 'make-fetch-happen' from being upgrated by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "make-fetch-happen"
+      versions: ["^13.x"]
   groups:
     typescript-eslint:
       patterns:


### PR DESCRIPTION
Due to #4233 we have to keep using the v12.x of 'make-fetch-happen'