### PR TITLE
Remove 'make-fetch-happen' dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-    - dependency-name: "make-fetch-happen"
-      versions: ["^13.x"]
   groups:
     typescript-eslint:
       patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 				"json-schema": "^0.4.0",
 				"json-to-ast": "^2.1.0",
 				"lodash": "^4.17.21",
-				"make-fetch-happen": "^12.0.0",
 				"mkdirp": "^3.0.1",
 				"node-yaml-parser": "^0.0.9",
 				"portfinder": "^1.0.32",
@@ -55,9 +54,8 @@
 				"@types/express": "^4.17.21",
 				"@types/fs-extra": "^11.0.4",
 				"@types/lodash": "^4.17.6",
-				"@types/make-fetch-happen": "^10.0.4",
 				"@types/mocha": "^10.0.7",
-				"@types/node": "^16.18.101",
+				"@types/node": "^18.19.39",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^17.0.80",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -70,7 +68,7 @@
 				"@types/tmp": "^0.2.6",
 				"@types/unzip-stream": "^0.3.4",
 				"@types/validator": "^13.12.0",
-				"@types/vscode": "1.64.0",
+				"@types/vscode": "1.82.0",
 				"@typescript-eslint/eslint-plugin": "^7.15.0",
 				"@typescript-eslint/parser": "^7.15.0",
 				"@vscode/test-electron": "^2.4.0",
@@ -124,9 +122,9 @@
 				"xterm-addon-webgl": "^0.16.0"
 			},
 			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=8.0.0",
-				"vscode": "^1.64.2"
+				"node": ">=18.0.0",
+				"npm": ">=8.6.0",
+				"vscode": "^1.82.3"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -2097,37 +2095,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/@npmcli/agent": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-1.1.0.tgz",
-			"integrity": "sha512-I9g/2XFOkflxm5IDrGSjCcR2d12Jmic0di9w/WpJBbzYuSXmfgoL+WwEV7zY/ajxzQr7o4vSkEJh6piyFLYtuQ==",
-			"dependencies": {
-				"lru-cache": "^7.18.3",
-				"socks": "^2.7.1"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@npmcli/fs": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
-			"integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -6140,17 +6107,6 @@
 			"integrity": "sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==",
 			"dev": true
 		},
-		"node_modules/@types/make-fetch-happen": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/@types/make-fetch-happen/-/make-fetch-happen-10.0.4.tgz",
-			"integrity": "sha512-jKzweQaEMMAi55ehvR1z0JF6aSVQm/h1BXBhPLOJriaeQBctjw5YbpIGs7zAx9dN0Sa2OO5bcXwCkrlgenoPEA==",
-			"dev": true,
-			"dependencies": {
-				"@types/node-fetch": "*",
-				"@types/retry": "*",
-				"@types/ssri": "*"
-			}
-		},
 		"node_modules/@types/mime": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
@@ -6172,9 +6128,12 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.101",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.101.tgz",
-			"integrity": "sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA=="
+			"version": "18.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
+			"integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/node-fetch": {
 			"version": "2.6.6",
@@ -6298,12 +6257,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/retry": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.3.tgz",
-			"integrity": "sha512-rkxEZUFIyDEZhC6EfHz6Hwos2zXewCOLBzhdgv7D55qu4OAySNwDZzxbaMpFI6XthdBa5oHhR5s6/9MSuTfw4g==",
-			"dev": true
-		},
 		"node_modules/@types/scheduler": {
 			"version": "0.16.3",
 			"dev": true,
@@ -6370,24 +6323,6 @@
 				"@types/node": "^18.11.18"
 			}
 		},
-		"node_modules/@types/ssh2/node_modules/@types/node": {
-			"version": "18.19.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
-			"integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
-			"dev": true,
-			"dependencies": {
-				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/@types/ssri": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.2.tgz",
-			"integrity": "sha512-Mbo/NaBiZlXNlOFTLK+PXeVEzKFxi+ZVELuzmk4VxdRz6aqKpmP9bhcNqsIB2c/s78355WBHwUCGYhQDydcfEg==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/tar-fs": {
 			"version": "2.0.1",
 			"dev": true,
@@ -6445,11 +6380,10 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.64.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-			"integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
-			"dev": true,
-			"license": "MIT"
+			"version": "1.82.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+			"integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+			"dev": true
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.5",
@@ -7333,18 +7267,6 @@
 				"node": ">= 6.0.0"
 			}
 		},
-		"node_modules/aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-			"dependencies": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -8220,44 +8142,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/cacache": {
-			"version": "17.1.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz",
-			"integrity": "sha512-/aJwG2l3ZMJ1xNAnqbMpA40of9dj/pIH3QfiuQSqjfPJF747VR0J/bHn+/KdNnHKc6XQcWt/AfRSBft82W1d2A==",
-			"dependencies": {
-				"@npmcli/fs": "^3.1.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^7.7.1",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^1.0.2",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/cacache/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/cacache/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/cacheable-lookup": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -8531,14 +8415,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.3",
 			"dev": true,
@@ -8554,14 +8430,6 @@
 			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/cli-cursor": {
 			"version": "3.1.0",
@@ -9670,6 +9538,7 @@
 			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"iconv-lite": "^0.6.2"
 			}
@@ -9680,6 +9549,7 @@
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
@@ -9726,12 +9596,6 @@
 			"resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
 			"integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/err-code": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
 			"license": "MIT"
 		},
 		"node_modules/error-ex": {
@@ -11156,25 +11020,6 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/fs-minipass": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/fs-minipass/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -12035,17 +11880,10 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
-			}
-		},
-		"node_modules/indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/inflight": {
@@ -12106,28 +11944,6 @@
 			"funding": {
 				"url": "https://github.com/sindresorhus/invert-kv?sponsor=1"
 			}
-		},
-		"node_modules/ip-address": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/ip-address/node_modules/jsbn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
-		},
-		"node_modules/ip-address/node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
 		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
@@ -12400,12 +12216,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/is-lambda": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-			"license": "MIT"
 		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.2",
@@ -13853,36 +13663,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/make-fetch-happen": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-12.0.0.tgz",
-			"integrity": "sha512-xpuA2kA8Z66uGQjaSXd7rffqJOv60iYpP8X0TsZl3uwXlqxUVmHETImjM71JOPA694TlcX37GhlaCsl6z6fNVg==",
-			"dependencies": {
-				"@npmcli/agent": "^1.1.0",
-				"cacache": "^17.0.0",
-				"http-cache-semantics": "^4.1.1",
-				"is-lambda": "^1.0.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.3",
-				"promise-retry": "^2.0.1",
-				"ssri": "^10.0.0"
-			},
-			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/make-fetch-happen/node_modules/minipass": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-			"integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/map-age-cleaner": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -14097,174 +13877,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/minipass-collect": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/minipass-collect/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-collect/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		},
-		"node_modules/minipass-fetch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.4.tgz",
-			"integrity": "sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==",
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.1.2"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/minipass-fetch/node_modules/minipass": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-			"integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/minipass-flush": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/minipass-flush/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-flush/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		},
-		"node_modules/minipass-pipeline": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-pipeline/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-pipeline/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		},
-		"node_modules/minipass-sized": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-sized/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-sized/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"license": "ISC"
-		},
-		"node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minizlib/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"license": "ISC"
 		},
 		"node_modules/mkdirp": {
 			"version": "3.0.1",
@@ -14494,6 +14106,7 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
 			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -15256,20 +14869,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-			"dependencies": {
-				"aggregate-error": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -15797,19 +15396,6 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"license": "MIT"
-		},
-		"node_modules/promise-retry": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-			"license": "MIT",
-			"dependencies": {
-				"err-code": "^2.0.2",
-				"retry": "^0.12.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/prop-types": {
 			"version": "15.8.1",
@@ -16484,15 +16070,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -17076,15 +16653,6 @@
 			"integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
 			"dev": true
 		},
-		"node_modules/smart-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-			"engines": {
-				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
 		"node_modules/snake-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -17094,19 +16662,6 @@
 			"dependencies": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/socks": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-			"dependencies": {
-				"ip-address": "^9.0.5",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
-				"npm": ">= 3.0.0"
 			}
 		},
 		"node_modules/source-map": {
@@ -17248,25 +16803,6 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/ssri": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/ssri/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/stacktrace-parser": {
@@ -17659,22 +17195,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/tar-fs": {
 			"version": "1.16.3",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
@@ -17722,44 +17242,6 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
-		},
-		"node_modules/tar/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/tar/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/tar/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/targz": {
 			"version": "1.0.1",
@@ -18272,8 +17754,7 @@
 		"node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"node_modules/unfetch": {
 			"version": "4.2.0",
@@ -18292,28 +17773,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/unique-filename": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-			"integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-			"dependencies": {
-				"unique-slug": "^4.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/unique-slug": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-			"integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/universalify": {
@@ -20704,30 +20163,6 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@npmcli/agent": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-1.1.0.tgz",
-			"integrity": "sha512-I9g/2XFOkflxm5IDrGSjCcR2d12Jmic0di9w/WpJBbzYuSXmfgoL+WwEV7zY/ajxzQr7o4vSkEJh6piyFLYtuQ==",
-			"requires": {
-				"lru-cache": "^7.18.3",
-				"socks": "^2.7.1"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "7.18.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-					"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
-				}
-			}
-		},
-		"@npmcli/fs": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
-			"integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
-			"requires": {
-				"semver": "^7.3.5"
-			}
-		},
 		"@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -22503,17 +21938,6 @@
 			"integrity": "sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==",
 			"dev": true
 		},
-		"@types/make-fetch-happen": {
-			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/@types/make-fetch-happen/-/make-fetch-happen-10.0.4.tgz",
-			"integrity": "sha512-jKzweQaEMMAi55ehvR1z0JF6aSVQm/h1BXBhPLOJriaeQBctjw5YbpIGs7zAx9dN0Sa2OO5bcXwCkrlgenoPEA==",
-			"dev": true,
-			"requires": {
-				"@types/node-fetch": "*",
-				"@types/retry": "*",
-				"@types/ssri": "*"
-			}
-		},
 		"@types/mime": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
@@ -22533,9 +21957,12 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.18.101",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.101.tgz",
-			"integrity": "sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA=="
+			"version": "18.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
+			"integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+			"requires": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"@types/node-fetch": {
 			"version": "2.6.6",
@@ -22652,12 +22079,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/retry": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.3.tgz",
-			"integrity": "sha512-rkxEZUFIyDEZhC6EfHz6Hwos2zXewCOLBzhdgv7D55qu4OAySNwDZzxbaMpFI6XthdBa5oHhR5s6/9MSuTfw4g==",
-			"dev": true
-		},
 		"@types/scheduler": {
 			"version": "0.16.3",
 			"dev": true
@@ -22719,26 +22140,6 @@
 			"dev": true,
 			"requires": {
 				"@types/node": "^18.11.18"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "18.19.15",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.15.tgz",
-					"integrity": "sha512-AMZ2UWx+woHNfM11PyAEQmfSxi05jm9OlkxczuHeEqmvwPkYj6MWv44gbzDPefYOLysTOFyI3ziiy2ONmUZfpA==",
-					"dev": true,
-					"requires": {
-						"undici-types": "~5.26.4"
-					}
-				}
-			}
-		},
-		"@types/ssri": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.2.tgz",
-			"integrity": "sha512-Mbo/NaBiZlXNlOFTLK+PXeVEzKFxi+ZVELuzmk4VxdRz6aqKpmP9bhcNqsIB2c/s78355WBHwUCGYhQDydcfEg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
 			}
 		},
 		"@types/tar-fs": {
@@ -22794,9 +22195,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.64.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-			"integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+			"version": "1.82.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+			"integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
 			"dev": true
 		},
 		"@types/ws": {
@@ -23403,15 +22804,6 @@
 				"debug": "4"
 			}
 		},
-		"aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-			"requires": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			}
-		},
 		"ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -23998,37 +23390,6 @@
 				}
 			}
 		},
-		"cacache": {
-			"version": "17.1.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz",
-			"integrity": "sha512-/aJwG2l3ZMJ1xNAnqbMpA40of9dj/pIH3QfiuQSqjfPJF747VR0J/bHn+/KdNnHKc6XQcWt/AfRSBft82W1d2A==",
-			"requires": {
-				"@npmcli/fs": "^3.1.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^7.7.1",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^1.0.2",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "7.18.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-					"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
-				},
-				"minipass": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-					"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
-				}
-			}
-		},
 		"cacheable-lookup": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -24217,11 +23578,6 @@
 				}
 			}
 		},
-		"chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-		},
 		"chrome-trace-event": {
 			"version": "1.0.3",
 			"dev": true,
@@ -24232,11 +23588,6 @@
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
 			"integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
 			"dev": true
-		},
-		"clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
 		},
 		"cli-cursor": {
 			"version": "3.1.0",
@@ -25053,6 +24404,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
 			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
 			"optional": true,
+			"peer": true,
 			"requires": {
 				"iconv-lite": "^0.6.2"
 			},
@@ -25062,6 +24414,7 @@
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 					"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
 					"optional": true,
+					"peer": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3.0.0"
 					}
@@ -25095,11 +24448,6 @@
 			"resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
 			"integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==",
 			"dev": true
-		},
-		"err-code": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -26131,21 +25479,6 @@
 				"universalify": "^2.0.0"
 			}
 		},
-		"fs-minipass": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-			"requires": {
-				"minipass": "^7.0.3"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-					"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
-				}
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -26737,12 +26070,8 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
-		},
-		"indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -26785,27 +26114,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.1.tgz",
 			"integrity": "sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw=="
-		},
-		"ip-address": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-			"requires": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
-			"dependencies": {
-				"jsbn": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-					"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
-				},
-				"sprintf-js": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-					"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
-				}
-			}
 		},
 		"ipaddr.js": {
 			"version": "1.9.1",
@@ -26972,11 +26280,6 @@
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
 			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
 			"dev": true
-		},
-		"is-lambda": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="
 		},
 		"is-negative-zero": {
 			"version": "2.0.2",
@@ -28041,31 +27344,6 @@
 				"semver": "^7.5.3"
 			}
 		},
-		"make-fetch-happen": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-12.0.0.tgz",
-			"integrity": "sha512-xpuA2kA8Z66uGQjaSXd7rffqJOv60iYpP8X0TsZl3uwXlqxUVmHETImjM71JOPA694TlcX37GhlaCsl6z6fNVg==",
-			"requires": {
-				"@npmcli/agent": "^1.1.0",
-				"cacache": "^17.0.0",
-				"http-cache-semantics": "^4.1.1",
-				"is-lambda": "^1.0.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.3",
-				"promise-retry": "^2.0.1",
-				"ssri": "^10.0.0"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-					"integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg=="
-				}
-			}
-		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -28209,140 +27487,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
 			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
-		},
-		"minipass-collect": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-			"requires": {
-				"minipass": "^3.0.0"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "3.3.6",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"minipass-fetch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.4.tgz",
-			"integrity": "sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==",
-			"requires": {
-				"encoding": "^0.1.13",
-				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.1.2"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-					"integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg=="
-				}
-			}
-		},
-		"minipass-flush": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-			"requires": {
-				"minipass": "^3.0.0"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "3.3.6",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"minipass-pipeline": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-			"requires": {
-				"minipass": "^3.0.0"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "3.3.6",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"minipass-sized": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-			"requires": {
-				"minipass": "^3.0.0"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "3.3.6",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"requires": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "3.3.6",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
 		},
 		"mkdirp": {
 			"version": "3.0.1",
@@ -28511,7 +27655,8 @@
 		"negotiator": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"dev": true
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -29043,14 +28188,6 @@
 				"p-limit": "^3.0.2"
 			}
 		},
-		"p-map": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-			"requires": {
-				"aggregate-error": "^3.0.0"
-			}
-		},
 		"package-json-from-dist": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -29450,15 +28587,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-		},
-		"promise-retry": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-			"requires": {
-				"err-code": "^2.0.2",
-				"retry": "^0.12.0"
-			}
 		},
 		"prop-types": {
 			"version": "15.8.1",
@@ -29957,11 +29085,6 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
-		"retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
-		},
 		"reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -30358,11 +29481,6 @@
 			"integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
 			"dev": true
 		},
-		"smart-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
-		},
 		"snake-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -30371,15 +29489,6 @@
 			"requires": {
 				"dot-case": "^3.0.4",
 				"tslib": "^2.0.3"
-			}
-		},
-		"socks": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-			"requires": {
-				"ip-address": "^9.0.5",
-				"smart-buffer": "^4.2.0"
 			}
 		},
 		"source-map": {
@@ -30485,21 +29594,6 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
-			}
-		},
-		"ssri": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-			"integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
-			"requires": {
-				"minipass": "^7.0.3"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-					"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
-				}
 			}
 		},
 		"stacktrace-parser": {
@@ -30761,49 +29855,6 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true
-		},
-		"tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"requires": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"requires": {
-						"minipass": "^3.0.0"
-					},
-					"dependencies": {
-						"minipass": {
-							"version": "3.3.6",
-							"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-							"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-							"requires": {
-								"yallist": "^4.0.0"
-							}
-						}
-					}
-				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
 		},
 		"tar-fs": {
 			"version": "1.16.3",
@@ -31207,8 +30258,7 @@
 		"undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"unfetch": {
 			"version": "4.2.0",
@@ -31221,22 +30271,6 @@
 			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
 			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
 			"dev": true
-		},
-		"unique-filename": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-			"integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-			"requires": {
-				"unique-slug": "^4.0.0"
-			}
-		},
-		"unique-slug": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-			"integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-			"requires": {
-				"imurmurhash": "^0.1.4"
-			}
 		},
 		"universalify": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
 	},
 	"bugs": "https://github.com/redhat-developer/vscode-openshift-tools/issues",
 	"engines": {
-		"vscode": "^1.64.2",
-		"npm": ">=8.0.0",
-		"node": ">=16.0.0"
+		"vscode": "^1.82.3",
+		"npm": ">=8.6.0",
+		"node": ">=18.0.0"
 	},
 	"badges": [
 		{
@@ -83,7 +83,6 @@
 		"json-schema": "^0.4.0",
 		"json-to-ast": "^2.1.0",
 		"lodash": "^4.17.21",
-		"make-fetch-happen": "^12.0.0",
 		"mkdirp": "^3.0.1",
 		"node-yaml-parser": "^0.0.9",
 		"portfinder": "^1.0.32",
@@ -117,9 +116,8 @@
 		"@types/express": "^4.17.21",
 		"@types/fs-extra": "^11.0.4",
 		"@types/lodash": "^4.17.6",
-		"@types/make-fetch-happen": "^10.0.4",
 		"@types/mocha": "^10.0.7",
-		"@types/node": "^16.18.101",
+		"@types/node": "^18.19.39",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^17.0.80",
 		"@types/react-copy-to-clipboard": "^5.0.7",
@@ -132,7 +130,7 @@
 		"@types/tmp": "^0.2.6",
 		"@types/unzip-stream": "^0.3.4",
 		"@types/validator": "^13.12.0",
-		"@types/vscode": "1.64.0",
+		"@types/vscode": "1.82.0",
 		"@typescript-eslint/eslint-plugin": "^7.15.0",
 		"@typescript-eslint/parser": "^7.15.0",
 		"@vscode/test-electron": "^2.4.0",

--- a/src/openshift/sandbox.ts
+++ b/src/openshift/sandbox.ts
@@ -4,7 +4,6 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { workspace } from 'vscode';
-import fetch = require('make-fetch-happen');
 
 // eslint-disable-next-line no-shadow
 export enum SBAPIEndpoint {
@@ -78,7 +77,7 @@ export async function getSignUpStatus(token: string): Promise<SBSignupResponse |
                 Authorization: `Bearer ${token}`
             },
             cache: 'no-cache',
-            timeout: getSandboxAPITimeout()
+            signal: AbortSignal.timeout(getSandboxAPITimeout())
         });
     return signupResponse.ok ? signupResponse.json() as Promise<SBSignupResponse> : undefined;
 }
@@ -89,23 +88,23 @@ export async function signUp(token: string): Promise<boolean> {
             headers: {
                 Authorization: `Bearer ${token}`
             },
-            timeout: getSandboxAPITimeout()
+            signal: AbortSignal.timeout(getSandboxAPITimeout())
         });
     return signupResponse.ok;
 }
 
 export async function requestVerificationCode(token: string, countryCode: string, phoneNumber: string) : Promise<VerificationCodeResponse> {
     const verificationCodeRequestResponse = await fetch(`${getSandboxAPIUrl()}${SBAPIEndpoint.VERIFICATION}`, {
-        method: 'PUT',
-        headers: {
-            Authorization: `Bearer ${token}`
-        },
-        timeout: getSandboxAPITimeout(),
-        body: JSON.stringify({
-            'country_code': countryCode,
-            'phone_number': phoneNumber
-        })
-    });
+            method: 'PUT',
+            headers: {
+                Authorization: `Bearer ${token}`
+            },
+            signal: AbortSignal.timeout(getSandboxAPITimeout()),
+            body: JSON.stringify({
+                'country_code': countryCode,
+                'phone_number': phoneNumber
+            })
+        });
     const responseText = await verificationCodeRequestResponse.text();
     return {
         ok: verificationCodeRequestResponse.ok,
@@ -115,21 +114,20 @@ export async function requestVerificationCode(token: string, countryCode: string
 
 export async function validateVerificationCode(token: string, code: string): Promise<boolean> {
     const validationRequestResponse = await fetch(`${getSandboxAPIUrl()}${SBAPIEndpoint.VERIFICATION}/${code}`, {
-        method: 'GET',
-        headers: {
-            Authorization: `Bearer ${token}`
-        },
-        timeout: getSandboxAPITimeout()
-    });
-
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${token}`
+            },
+            signal: AbortSignal.timeout(getSandboxAPITimeout())
+        });
     return validationRequestResponse.ok;
 }
 
 export async function getOauthServerInfo(apiEndpointUrl: string): Promise<OauthServerInfo> {
     const oauthServerInfoResponse = await fetch(`${apiEndpointUrl}/${OAUTH_SERVER_INFO_PATH}`, {
-        method: 'GET',
-        timeout: getSandboxAPITimeout()
-    });
+            method: 'GET',
+            signal: AbortSignal.timeout(getSandboxAPITimeout())
+        });
     const oauthInfoText = await oauthServerInfoResponse.text();
     return (oauthInfoText ? JSON.parse(oauthInfoText) : {}) as OauthServerInfo;
 }

--- a/src/registriesView.ts
+++ b/src/registriesView.ts
@@ -20,7 +20,6 @@ import { Odo } from './odo/odoWrapper';
 import { inputValue, quickBtn } from './util/inputValue';
 import { Progress } from './util/progress';
 import { vsCommand, VsCommandError } from './vscommand';
-import fetch = require('make-fetch-happen');
 
 type ComponentType = Registry;
 
@@ -348,9 +347,7 @@ export class ComponentTypesView implements TreeDataProvider<ComponentType> {
                     }
 
                     try {
-                        const response = await fetch(regURL, {
-                            method: 'GET',
-                        });
+                        const response = await fetch(regURL, { method: 'GET' });
                         const componentTypes = JSON.parse(await response.text()) as DevfileComponentType[];
                         if (componentTypes.length > 0) {
                             void Progress.execFunctionWithProgress('Devfile registry is updating',async () => {

--- a/src/webview/helm-chart/helmChartLoader.ts
+++ b/src/webview/helm-chart/helmChartLoader.ts
@@ -14,7 +14,6 @@ import { Progress } from '../../util/progress';
 import { vsCommand } from '../../vscommand';
 import { validateName } from '../common-ext/createComponentHelpers';
 import { loadWebviewHtml } from '../common-ext/utils';
-import fetch = require('make-fetch-happen');
 
 let panel: vscode.WebviewPanel;
 const helmCharts: ChartResponse[] = [];

--- a/src/webview/welcome/welcomeViewLoader.ts
+++ b/src/webview/welcome/welcomeViewLoader.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-import * as fetch from 'make-fetch-happen';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import sendTelemetry, { WelcomePageProps } from '../../telemetry';
@@ -15,12 +14,11 @@ async function welcomeViewerMessageListener(event: any): Promise<void> {
     switch (event?.action) {
         case 'getOpenShiftVersion':
             try {
-                const response = await fetch('https://api.github.com/repos/redhat-developer/vscode-openshift-tools/releases/latest',
-                {
-                    headers: {
-                        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36',
-                    }
-                });
+                const response = await fetch('https://api.github.com/repos/redhat-developer/vscode-openshift-tools/releases/latest', {
+                        headers: {
+                            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36',
+                        }
+                    });
                 const data = await response.json();
                 void panel?.webview.postMessage({
                     'action': 'getOpenShiftVersion',

--- a/test/unit/openshift/cluster.test.ts
+++ b/test/unit/openshift/cluster.test.ts
@@ -211,7 +211,7 @@ suite('Openshift/Cluster', function() {
             });
 
             test('checks cluster url name is valid url', async () => {
-                let result: string | Thenable<string>;
+                let result;
                 quickPickStub.onFirstCall().resolves({description: 'Current Context', label: '$(plus) Provide new URL...'});
                 inputStub.onFirstCall().callsFake((options?: vscode.InputBoxOptions): Thenable<string> => {
                     result = options.validateInput('http://127.0.0.1:9999');
@@ -222,7 +222,7 @@ suite('Openshift/Cluster', function() {
             });
 
             test('checks user name is not empty', async () => {
-                let result: string | Thenable<string>;
+                let result;
                 quickPickStub.onFirstCall().resolves({description: 'Current Context', label: testUrl});
                 quickPickStub.onSecondCall().resolves({label: 'Credentials'});
                 quickPickStub.onThirdCall().resolves({description: 'Current Context', label: '$(plus) Add new user...'});

--- a/test/unit/openshift/project.test.ts
+++ b/test/unit/openshift/project.test.ts
@@ -70,7 +70,7 @@ suite('OpenShift/Project', () => {
         });
 
         test('validator returns undefined for valid project name', async () => {
-            let result: string | Thenable<string>;
+            let result;
             inputStub.restore();
             inputStub = sandbox.stub(vscode.window, 'showInputBox').onFirstCall().callsFake(async (options?: vscode.InputBoxOptions): Promise<string> => {
                 result = await options.validateInput('goodvalue');
@@ -82,7 +82,7 @@ suite('OpenShift/Project', () => {
         });
 
         test('validator returns error message for empty project name', async () => {
-            let result: string | Thenable<string>;
+            let result;
             inputStub.restore();
             inputStub = sandbox.stub(vscode.window, 'showInputBox').onFirstCall().callsFake(async (options?: vscode.InputBoxOptions): Promise<string> => {
                 result = await options.validateInput('');
@@ -94,7 +94,7 @@ suite('OpenShift/Project', () => {
         });
 
         test('validator returns error message for none alphanumeric project name', async () => {
-            let result: string | Thenable<string>;
+            let result;
             inputStub.restore();
             inputStub = sandbox.stub(vscode.window, 'showInputBox').onFirstCall().callsFake(async (options?: vscode.InputBoxOptions): Promise<string> => {
                 result = await options.validateInput('name&name');
@@ -106,7 +106,7 @@ suite('OpenShift/Project', () => {
         });
 
         test('validator returns error message if same name of project found', async () => {
-            let result: string | Thenable<string>;
+            let result;
             inputStub.restore();
             inputStub = sandbox.stub(vscode.window, 'showInputBox').onFirstCall().callsFake(async (options?: vscode.InputBoxOptions): Promise<string> => {
                 result = await options.validateInput('project');
@@ -118,7 +118,7 @@ suite('OpenShift/Project', () => {
         });
 
         test('validator returns error message for project name longer than 63 characters', async () => {
-            let result: string | Thenable<string>;
+            let result;
             inputStub.restore();
             inputStub = sandbox.stub(vscode.window, 'showInputBox').onFirstCall().callsFake(async (options?: vscode.InputBoxOptions): Promise<string> => {
                 result = await options.validateInput('n123456789012345678901234567890123456789012345678901234567890123');


### PR DESCRIPTION
As Fetch API is compatible with Node.js >= v18, the engine and dependencies are accordingly updated:

- engines:
```
"npm": ">=8.6.0",
"node": ">=18.0.0"
```
- devDependencies:
```
"@types/node": "^18.19.39",
```