### PR TITLE
Fix issue opening Routes node in OpenShift explorer

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -340,7 +340,7 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
 
     private collectDeploymentErrors(deployment): string[] {
         const messages: string[] = [];
-        deployment.status.conditions.filter((c) => c.status === 'False')
+        deployment.status.conditions?.filter((c) => c.status === 'False')
             .forEach((c) => {
                 const message = `${c.reason}: ${c.message ? c.message.trim(): 'No valuable message'}`;
 


### PR DESCRIPTION
When opening the Routes node of my DevSandbox cluster, I get this error:
<img width="499" alt="Screenshot 2024-07-16 at 17 29 26" src="https://github.com/user-attachments/assets/54faedb6-60f7-417f-8a7b-276bc7307aa2">

<img width="980" alt="Screenshot 2024-07-16 at 17 35 57" src="https://github.com/user-attachments/assets/3f97cf3a-8d07-4a1a-a37f-37d9c947f690">

This PR provides a naive fix for this issue, allowing my route to be displayed:

<img width="442" alt="Screenshot 2024-07-16 at 17 44 09" src="https://github.com/user-attachments/assets/a9771f19-910d-42f9-be9b-e7e30da35607">
