### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
 				"@types/fs-extra": "^11.0.4",
 				"@types/lodash": "^4.17.7",
 				"@types/mocha": "^10.0.7",
-				"@types/node": "^18.19.39",
+				"@types/node": "^18.19.41",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^17.0.80",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3218,9 +3218,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-			"integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+			"version": "18.19.41",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
+			"integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -18253,9 +18253,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.19.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-			"integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+			"version": "18.19.41",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
+			"integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
 			"requires": {
 				"undici-types": "~5.26.4"
 			}

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
 		"@types/fs-extra": "^11.0.4",
 		"@types/lodash": "^4.17.7",
 		"@types/mocha": "^10.0.7",
-		"@types/node": "^18.19.39",
+		"@types/node": "^18.19.41",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^17.0.80",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                  18.19.39          18.19.41          20.14.11  node_modules/@types/node          vscode-openshift-tools
...
```