### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
 				"@types/fs-extra": "^11.0.4",
 				"@types/lodash": "^4.17.7",
 				"@types/mocha": "^10.0.7",
-				"@types/node": "^18.19.41",
+				"@types/node": "^18.19.42",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^17.0.80",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3218,9 +3218,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.41",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
-			"integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
+			"version": "18.19.42",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.42.tgz",
+			"integrity": "sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -18253,9 +18253,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.19.41",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.41.tgz",
-			"integrity": "sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==",
+			"version": "18.19.42",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.42.tgz",
+			"integrity": "sha512-d2ZFc/3lnK2YCYhos8iaNIYu9Vfhr92nHiyJHRltXWjXUBjEE+A4I58Tdbnw4VhggSW+2j5y5gTrLs4biNnubg==",
 			"requires": {
 				"undici-types": "~5.26.4"
 			}

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
 		"@types/fs-extra": "^11.0.4",
 		"@types/lodash": "^4.17.7",
 		"@types/mocha": "^10.0.7",
-		"@types/node": "^18.19.41",
+		"@types/node": "^18.19.42",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^17.0.80",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                      18.19.41          18.19.42          20.14.12  node_modules/@types/node              vscode-openshift-tools
...
```