### PR TITLE
Allow commands to work with .yml extension

### DIFF
--- a/src/yamlFileCommands.ts
+++ b/src/yamlFileCommands.ts
@@ -19,7 +19,8 @@ export class YamlFileCommands {
         let message: string;
 
         if (!document
-            || !(document.fileName.endsWith('.yaml') || document.fileName.endsWith('.json'))) {
+            || !(document.fileName.endsWith('.yaml') || document.fileName.endsWith('.yml')
+            || document.fileName.endsWith('.json'))) {
             message =
                 '\'OpenShift: Create\' command requires a .yaml or a .json file opened in editor.';
         }
@@ -62,7 +63,8 @@ export class YamlFileCommands {
         let message: string;
 
         if (!document
-            || !(document.fileName.endsWith('.yaml') || document.fileName.endsWith('.json'))) {
+            || !(document.fileName.endsWith('.yaml') || document.fileName.endsWith('.yml')
+            || document.fileName.endsWith('.json'))) {
             message =
                 '\'OpenShift: Delete\' command requires a .yaml or a .json file opened in editor.';
         }

--- a/src/yamlFileCommands.ts
+++ b/src/yamlFileCommands.ts
@@ -22,7 +22,7 @@ export class YamlFileCommands {
             || !(document.fileName.endsWith('.yaml') || document.fileName.endsWith('.yml')
             || document.fileName.endsWith('.json'))) {
             message =
-                '\'OpenShift: Create\' command requires a .yaml or a .json file opened in editor.';
+                '\'OpenShift: Create\' command requires a .yaml, .yml, or .json file opened in editor.';
         }
 
         if (!message && document.isUntitled) {
@@ -66,7 +66,7 @@ export class YamlFileCommands {
             || !(document.fileName.endsWith('.yaml') || document.fileName.endsWith('.yml')
             || document.fileName.endsWith('.json'))) {
             message =
-                '\'OpenShift: Delete\' command requires a .yaml or a .json file opened in editor.';
+                '\'OpenShift: Delete\' command requires a .yaml, .yml, or .json file opened in editor.';
         }
 
         if (!message && document.isUntitled) {


### PR DESCRIPTION
This change allows the "Apply YAML to cluster" and "Delete YAML from clsuter" commands to accpet a file ending in `.yml`. Using a `.yml` extension name for YAML files is common and widely used so it makes sense to support both the `.yaml` and `.yml` naming.