### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
 				"@types/fs-extra": "^11.0.4",
 				"@types/lodash": "^4.17.7",
 				"@types/mocha": "^10.0.7",
-				"@types/node": "^18.19.43",
+				"@types/node": "^18.19.44",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^17.0.80",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3219,9 +3219,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.43",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
-			"integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
+			"version": "18.19.44",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+			"integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -18290,9 +18290,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.19.43",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.43.tgz",
-			"integrity": "sha512-Mw/YlgXnyJdEwLoFv2dpuJaDFriX+Pc+0qOBJ57jC1H6cDxIj2xc5yUrdtArDVG0m+KV6622a4p2tenEqB3C/g==",
+			"version": "18.19.44",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
+			"integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
 			"requires": {
 				"undici-types": "~5.26.4"
 			}

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
 		"@types/fs-extra": "^11.0.4",
 		"@types/lodash": "^4.17.7",
 		"@types/mocha": "^10.0.7",
-		"@types/node": "^18.19.43",
+		"@types/node": "^18.19.44",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^17.0.80",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                      18.19.43          18.19.44            22.2.0  node_modules/@types/node              vscode-openshift-tools
...
```