### PR TITLE
Alizer's 'Version.SchemaVersion' property type is to be a 'string', not a 'number'

### DIFF
--- a/src/alizer/types.ts
+++ b/src/alizer/types.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 export interface Version {
-    SchemaVersion: number;
+    SchemaVersion: string;
     Default: boolean;
     Version: string;
 }


### PR DESCRIPTION
The Alizer's `Version.SchemaVersion` property type is to be of type `string` according to the binary output:

```
$ ./alizer-v1.6.0-linux-amd64 devfile ./nodejs-starter
[
	{
		"Name": "nodejs",
		"Language": "JavaScript",
		"ProjectType": "Node.js",
		"Tags": [
			"Node.js",
			"Express",
			"ubi8"
		],
		"Versions": [
			{
				"SchemaVersion": "2.2.2",
				"Default": true,
				"Version": "2.2.1"
			},
			{
				"SchemaVersion": "2.1.0",
				"Default": false,
				"Version": "2.2.0"
			},
			{
				"SchemaVersion": "2.1.0",
				"Default": false,
				"Version": "2.1.1"
			}
		]
	}
]
```