### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
 				"@types/fs-extra": "^11.0.4",
 				"@types/lodash": "^4.17.7",
 				"@types/mocha": "^10.0.7",
-				"@types/node": "^18.19.44",
+				"@types/node": "^18.19.45",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^17.0.80",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3225,9 +3225,10 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.44",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
-			"integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
+			"version": "18.19.45",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
+			"integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
+			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
@@ -18295,9 +18296,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.19.44",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.44.tgz",
-			"integrity": "sha512-ZsbGerYg72WMXUIE9fYxtvfzLEuq6q8mKERdWFnqTmOvudMxnz+CBNRoOwJ2kNpFOncrKjT1hZwxjlFgQ9qvQA==",
+			"version": "18.19.45",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
+			"integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
 			"requires": {
 				"undici-types": "~5.26.4"
 			}

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
 		"@types/fs-extra": "^11.0.4",
 		"@types/lodash": "^4.17.7",
 		"@types/mocha": "^10.0.7",
-		"@types/node": "^18.19.44",
+		"@types/node": "^18.19.45",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^17.0.80",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                   18.19.44          18.19.45            22.4.2  node_modules/@types/node           vscode-openshift-tools
...
```