### PR TITLE
[build] Update the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
 				"chai": "^4.5.0",
 				"chokidar": "^3.6.0",
 				"clipboardy": "^2.3.0",
-				"codecov": "^3.8.2",
+				"codecov": "^3.8.3",
 				"dpdm": "^3.14.0",
 				"esbuild": "^0.19.12",
 				"esbuild-plugin-svgr": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"chai": "^4.5.0",
 		"chokidar": "^3.6.0",
 		"clipboardy": "^2.3.0",
-		"codecov": "^3.8.2",
+		"codecov": "^3.8.3",
 		"dpdm": "^3.14.0",
 		"esbuild": "^0.19.12",
 		"esbuild-plugin-svgr": "^2.1.0",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
codecov                          3.8.3             3.8.2             3.8.2  node_modules/codecov               vscode-openshift-tools
...
```