### PR TITLE
[tests] Increase timeout to stabilize 'Debug Works' Public UI test

### DIFF
--- a/test/ui/suite/componentContextMenu.ts
+++ b/test/ui/suite/componentContextMenu.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
+import { expect } from 'chai';
 import {
     ActivityBar,
     BottomBarPanel,
@@ -15,11 +16,10 @@ import {
     ViewSection,
     VSBrowser,
 } from 'vscode-extension-tester';
-import { MENUS, VIEWS } from '../common/constants';
 import { itemDoesNotExist, itemExists, notificationDoesNotExist } from '../common/conditions';
-import { OpenshiftTerminalWebviewView } from '../common/ui/webviewView/openshiftTerminalWebviewView';
-import { expect } from 'chai';
+import { MENUS, VIEWS } from '../common/constants';
 import { collapse } from '../common/overdrives';
+import { OpenshiftTerminalWebviewView } from '../common/ui/webviewView/openshiftTerminalWebviewView';
 
 export function testComponentContextMenu() {
     describe('Component Context Menu', function () {
@@ -227,7 +227,7 @@ export function testComponentContextMenu() {
             await bottomBar.openDebugConsoleView();
 
             //wait for console to have text
-            await new Promise((res) => setTimeout(res, 1_000));
+            await new Promise((res) => setTimeout(res, 2_000));
             const bottomBarText = await bottomBar.getText();
             expect(bottomBarText).to.contain('App started on PORT');
 


### PR DESCRIPTION
```
Extension public-facing UI tests
       Extension public-facing UI tests with Kind cluster
         Component Context Menu
           Debug works:
     TimeoutError: Wait timed out after 1029ms
      at /home/runner/work/vscode-openshift-tools/vscode-openshift-tools/node_modules/selenium-webdriver/lib/webdriver.js:913:22
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```