### PR TITLE
[build] Fix vulnerability in @octokit/rest 16.0.0 - 16.43.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"@mui/lab": "^5.0.0-alpha.173",
 				"@mui/material": "^5.16.7",
 				"@mui/styles": "^5.16.7",
-				"@octokit/rest": "^16.30.1",
+				"@octokit/rest": "^21.0.2",
 				"@rjsf/core": "^5.20.1",
 				"@rjsf/mui": "^5.20.1",
 				"@rjsf/utils": "^5.20.1",
@@ -2201,12 +2201,13 @@
 			}
 		},
 		"node_modules/@octokit/auth-token": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-			"integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+			"integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
 			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^6.0.3"
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/@octokit/core": {
@@ -2214,7 +2215,7 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
 			"integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
 			"dev": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-token": "^5.0.0",
 				"@octokit/graphql": "^8.0.0",
@@ -2228,22 +2229,12 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/core/node_modules/@octokit/auth-token": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
-			"integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/core/node_modules/@octokit/endpoint": {
+		"node_modules/@octokit/endpoint": {
 			"version": "10.1.1",
 			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
 			"integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
 			"dev": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.0.0",
 				"universal-user-agent": "^7.0.2"
@@ -2252,98 +2243,12 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@octokit/core/node_modules/@octokit/request": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
-			"integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@octokit/endpoint": "^10.0.0",
-				"@octokit/request-error": "^6.0.1",
-				"@octokit/types": "^13.1.0",
-				"universal-user-agent": "^7.0.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/core/node_modules/@octokit/request-error": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
-			"integrity": "sha512-VpAhIUxwhWZQImo/dWAN/NpPqqojR6PSLgLYAituLM6U+ddx9hCioFGwBr5Mi+oi5CLeJkcAs3gJ0PYYzU6wUg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@octokit/types": "^13.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/core/node_modules/@octokit/types": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
-			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
-			}
-		},
-		"node_modules/@octokit/core/node_modules/before-after-hook": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-			"integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@octokit/core/node_modules/universal-user-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-			"integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@octokit/endpoint": {
-			"version": "6.0.12",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-			"integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^6.0.3",
-				"is-plain-object": "^5.0.0",
-				"universal-user-agent": "^6.0.0"
-			}
-		},
-		"node_modules/@octokit/endpoint/node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@octokit/endpoint/node_modules/universal-user-agent": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-			"dev": true
-		},
 		"node_modules/@octokit/graphql": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
 			"integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
 			"dev": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@octokit/request": "^9.0.0",
 				"@octokit/types": "^13.0.0",
@@ -2353,33 +2258,64 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/graphql/node_modules/@octokit/endpoint": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
-			"integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@octokit/types": "^13.0.0",
-				"universal-user-agent": "^7.0.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+		"node_modules/@octokit/openapi-types": {
 			"version": "22.2.0",
 			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
 			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
 			"dev": true,
-			"peer": true
+			"license": "MIT"
 		},
-		"node_modules/@octokit/graphql/node_modules/@octokit/request": {
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.3.tgz",
+			"integrity": "sha512-o4WRoOJZlKqEEgj+i9CpcmnByvtzoUYC6I8PD2SA95M+BJ2x8h7oLcVOg9qcowWXBOdcTRsMZiwvM3EyLm9AfA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.5.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-request-log": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+			"integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "13.2.4",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.4.tgz",
+			"integrity": "sha512-gusyAVgTrPiuXOdfqOySMDztQHv6928PQ3E4dqVGEtOvRXAKRbJR4b1zQyniIT9waqaWk/UDaoJ2dyPr7Bk7Iw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.5.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/request": {
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
 			"integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
 			"dev": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@octokit/endpoint": "^10.0.0",
 				"@octokit/request-error": "^6.0.1",
@@ -2390,12 +2326,12 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/graphql/node_modules/@octokit/request-error": {
+		"node_modules/@octokit/request-error": {
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
 			"integrity": "sha512-VpAhIUxwhWZQImo/dWAN/NpPqqojR6PSLgLYAituLM6U+ddx9hCioFGwBr5Mi+oi5CLeJkcAs3gJ0PYYzU6wUg==",
 			"dev": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.0.0"
 			},
@@ -2403,166 +2339,30 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
+		"node_modules/@octokit/rest": {
+			"version": "21.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.0.2.tgz",
+			"integrity": "sha512-+CiLisCoyWmYicH25y1cDfCrv41kRSvTq6pPWtRroRJzhsCZWZyCqGyI8foJT5LmScADSwRAnr/xo+eewL04wQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/core": "^6.1.2",
+				"@octokit/plugin-paginate-rest": "^11.0.0",
+				"@octokit/plugin-request-log": "^5.3.1",
+				"@octokit/plugin-rest-endpoint-methods": "^13.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/types": {
 			"version": "13.5.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
 			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
 			"dev": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^22.2.0"
-			}
-		},
-		"node_modules/@octokit/graphql/node_modules/universal-user-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-			"integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@octokit/openapi-types": {
-			"version": "12.11.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
-			"integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==",
-			"dev": true
-		},
-		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
-			"integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^2.0.1"
-			}
-		},
-		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
-			"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": ">= 8"
-			}
-		},
-		"node_modules/@octokit/plugin-request-log": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true,
-			"peerDependencies": {
-				"@octokit/core": ">=3"
-			}
-		},
-		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
-			"integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^2.0.1",
-				"deprecation": "^2.3.1"
-			}
-		},
-		"node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
-			"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": ">= 8"
-			}
-		},
-		"node_modules/@octokit/request": {
-			"version": "5.6.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-			"integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/endpoint": "^6.0.1",
-				"@octokit/request-error": "^2.1.0",
-				"@octokit/types": "^6.16.1",
-				"is-plain-object": "^5.0.0",
-				"node-fetch": "^2.6.7",
-				"universal-user-agent": "^6.0.0"
-			}
-		},
-		"node_modules/@octokit/request-error": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
-			"integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^2.0.0",
-				"deprecation": "^2.0.0",
-				"once": "^1.4.0"
-			}
-		},
-		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
-			"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": ">= 8"
-			}
-		},
-		"node_modules/@octokit/request/node_modules/@octokit/request-error": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-			"integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^6.0.3",
-				"deprecation": "^2.0.0",
-				"once": "^1.4.0"
-			}
-		},
-		"node_modules/@octokit/request/node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@octokit/request/node_modules/universal-user-agent": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-			"dev": true
-		},
-		"node_modules/@octokit/rest": {
-			"version": "16.43.2",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
-			"integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/auth-token": "^2.4.0",
-				"@octokit/plugin-paginate-rest": "^1.1.1",
-				"@octokit/plugin-request-log": "^1.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "2.4.0",
-				"@octokit/request": "^5.2.0",
-				"@octokit/request-error": "^1.0.2",
-				"atob-lite": "^2.0.0",
-				"before-after-hook": "^2.0.0",
-				"btoa-lite": "^1.0.0",
-				"deprecation": "^2.0.0",
-				"lodash.get": "^4.4.2",
-				"lodash.set": "^4.3.2",
-				"lodash.uniq": "^4.5.0",
-				"octokit-pagination-methods": "^1.1.0",
-				"once": "^1.4.0",
-				"universal-user-agent": "^4.0.0"
-			}
-		},
-		"node_modules/@octokit/types": {
-			"version": "6.41.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-			"integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/openapi-types": "^12.11.0"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -5005,12 +4805,6 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"license": "MIT"
 		},
-		"node_modules/atob-lite": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
-			"dev": true
-		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -5110,10 +4904,11 @@
 			}
 		},
 		"node_modules/before-after-hook": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-			"dev": true
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+			"integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/big.js": {
 			"version": "5.2.2",
@@ -5286,12 +5081,6 @@
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
-		},
-		"node_modules/btoa-lite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
-			"dev": true
 		},
 		"node_modules/buffer": {
 			"version": "5.7.1",
@@ -6481,12 +6270,6 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
-		},
-		"node_modules/deprecation": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-			"dev": true
 		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
@@ -11060,24 +10843,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.set": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
-			"dev": true
-		},
 		"node_modules/lodash.startswith": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
 			"integrity": "sha512-XClYR1h4/fJ7H+mmCKppbiBmljN/nGs73iq2SjCT9SF4CBPoUHzLvWmH1GtZMhMBZSiRkHXfeA2RY1eIlJ75ww==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/lodash.uniq": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-			"dev": true
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
@@ -11237,18 +11008,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
-			}
-		},
-		"node_modules/macos-release": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.1.tgz",
-			"integrity": "sha512-DXqXhEM7gW59OjZO8NIjBCz9AQ1BEMrfiOAl4AYByHCtVHRF4KoGNO8mqQeM8lRCtQe/UnJ4imO/d2HdkKsd+A==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/make-dir": {
@@ -12096,12 +11855,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/octokit-pagination-methods": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
-			"dev": true
-		},
 		"node_modules/oidc-token-hash": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
@@ -12406,19 +12159,6 @@
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
-			}
-		},
-		"node_modules/os-name": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
-			"integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
-			"dev": true,
-			"dependencies": {
-				"macos-release": "^2.2.0",
-				"windows-release": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/p-cancelable": {
@@ -15460,13 +15200,11 @@
 			}
 		},
 		"node_modules/universal-user-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
-			"integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+			"integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
 			"dev": true,
-			"dependencies": {
-				"os-name": "^3.1.0"
-			}
+			"license": "ISC"
 		},
 		"node_modules/universalify": {
 			"version": "2.0.0",
@@ -16246,21 +15984,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/windows-release": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.3.tgz",
-			"integrity": "sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==",
-			"dev": true,
-			"dependencies": {
-				"execa": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"@mui/lab": "^5.0.0-alpha.173",
 		"@mui/material": "^5.16.7",
 		"@mui/styles": "^5.16.7",
-		"@octokit/rest": "^16.30.1",
+		"@octokit/rest": "^21.0.2",
 		"@rjsf/core": "^5.20.1",
 		"@rjsf/mui": "^5.20.1",
 		"@rjsf/utils": "^5.20.1",


### PR DESCRIPTION
```

lodash.set  *
Severity: high
Prototype Pollution in lodash - https://github.com/advisories/GHSA-p6mc-m468-83gw
fix available via `npm audit fix --force`
Will install @octokit/rest@21.0.2, which is a breaking change
node_modules/lodash.set
  @octokit/rest  16.0.0 - 16.43.2
  Depends on vulnerable versions of lodash.set
  node_modules/@octokit/rest
```