### PR TITLE
Increasing timeout to fix instability in debug test

### DIFF
--- a/test/ui/suite/componentContextMenu.ts
+++ b/test/ui/suite/componentContextMenu.ts
@@ -245,6 +245,7 @@ export function testComponentContextMenu() {
             //refresh section
             await debugSession.expand();
             await collapse(debugSession);
+            await new Promise((res) => { setTimeout(res, 500) });
             await debugSession.expand();
 
             //click on item


### PR DESCRIPTION
This PR aims to stabilize frequently failing test "Component Context Menu - Debug works". I tried running the test multiple times and the instability seems to be solved by this change