### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.7",
 				"@types/mocha": "^10.0.7",
-				"@types/node": "^18.19.47",
+				"@types/node": "^18.19.48",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^17.0.80",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3241,9 +3241,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.47",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.47.tgz",
-			"integrity": "sha512-1f7dB3BL/bpd9tnDJrrHb66Y+cVrhxSOTGorRNdHwYTUlTay3HuTDPKo9a/4vX9pMQkhYBcAbL4jQdNlhCFP9A==",
+			"version": "18.19.48",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.48.tgz",
+			"integrity": "sha512-7WevbG4ekUcRQSZzOwxWgi5dZmTak7FaxXDoW7xVxPBmKx1rTzfmRLkeCgJzcbBnOV2dkhAPc8cCeT6agocpjg==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.7",
 		"@types/mocha": "^10.0.7",
-		"@types/node": "^18.19.47",
+		"@types/node": "^18.19.48",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^17.0.80",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                  18.19.47          18.19.48            22.5.2  node_modules/@types/node          vscode-openshift-tools
...
```