### PR TITLE
[build] Update xvbf to use Node 20

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Run tests
       - name: Build and Test
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 #v1.0.1
+        uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a #v1.0.1
         env:
             NODE_OPTIONS: --max_old_space_size=16384
         with:
@@ -72,7 +72,7 @@ jobs:
       # UI tests fail under linux
       # Run UI tests
       - name: Run UI Tests
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 #v1.0.1
+        uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a #v1.0.1
         env:
             NODE_OPTIONS: --max_old_space_size=16384
         if: runner.os == 'Linux'
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build and run integration tests
         if: (success() || failure()) && runner.os == 'Linux'
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 #v1.0.1
+        uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a #v1.0.1
         env:
           NODE_OPTIONS: --max_old_space_size=16384
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           npm install
           echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
       - name: Build And Run Unit Tests
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 #v1.0.1
+        uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a #v1.0.1
         with:
           run: npm run test
       - name: Package


### PR DESCRIPTION
When building on GH the following warning message appears:

`The following actions use a deprecated Node.js version and will be forced to run on node20: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/`