### PR TITLE
Use SSO account to configure sandbox in one click

### DIFF
--- a/src/oc/ocWrapper.ts
+++ b/src/oc/ocWrapper.ts
@@ -9,10 +9,10 @@ import * as tmp from 'tmp';
 import validator from 'validator';
 import { CommandOption, CommandText } from '../base/command';
 import { CliChannel, ExecutionContext } from '../cli';
+import { CliExitData } from '../util/childProcessUtil';
 import { isOpenShiftCluster, KubeConfigUtils } from '../util/kubeUtils';
 import { Project } from './project';
 import { ClusterType, KubernetesConsole } from './types';
-import { CliExitData } from '../util/childProcessUtil';
 
 /**
  * A wrapper around the `oc` CLI tool.
@@ -612,8 +612,10 @@ export class Oc {
             const currentUser = kcu.getCurrentUser();
             if (currentUser) {
                 const projectPrefix = currentUser.name.substring(0, currentUser.name.indexOf('/'));
-                if (projectPrefix.length > 0) {
-                    activeProject = fixedProjects.find((project) => project.name.includes(projectPrefix));
+                const matches = projectPrefix.match(/^system:serviceaccount:([a-zA-Z-_.]+-dev):pipeline$/);
+                const projectName = matches ? matches[1] : projectPrefix;
+                if (projectName.length > 0) {
+                    activeProject = fixedProjects.find((project) => project.name.includes(projectName));
                     if (activeProject) {
                         activeProject.active = true;
                         void Oc.Instance.setProject(activeProject.name, executionContext);

--- a/src/openshift/sandbox.ts
+++ b/src/openshift/sandbox.ts
@@ -28,6 +28,7 @@ export interface SBSignupResponse {
   givenName: string;
   status: SBStatus;
   username: string;
+  proxyURL: string;
 }
 
 export interface SBResponseData {

--- a/src/webview/cluster/clusterViewLoader.ts
+++ b/src/webview/cluster/clusterViewLoader.ts
@@ -2,19 +2,17 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
+import { CoreV1Api } from '@kubernetes/client-node';
 import { ChildProcess, spawn } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { clearInterval } from 'timers';
 import * as vscode from 'vscode';
 import { CommandText } from '../../base/command';
-import { Oc } from '../../oc/ocWrapper';
 import { Cluster } from '../../openshift/cluster';
 import { createSandboxAPI } from '../../openshift/sandbox';
 import { ExtCommandTelemetryEvent } from '../../telemetry';
 import { ChildProcessUtil } from '../../util/childProcessUtil';
 import { ExtensionID } from '../../util/constants';
-import { KubeConfigUtils } from '../../util/kubeUtils';
 import { vsCommand } from '../../vscommand';
 import { loadWebviewHtml } from '../common-ext/utils';
 import { OpenShiftTerminalManager } from '../openshift-terminal/openShiftTerminal';
@@ -116,12 +114,35 @@ async function clusterEditorMessageListener (event: any ): Promise<any> {
                 } else {
                     if (signupStatus.status.ready) {
                         const oauthInfo = await sandboxAPI.getOauthServerInfo(signupStatus.apiEndpoint);
+                        const makeCoreV1ApiClient = ((proxy: string, username: string, accessToken: string): CoreV1Api => {
+                            const kcu = Cluster.prepareSSOInKubeConfig(proxy, username, accessToken);
+                            const apiClient = new CoreV1Api(proxy);
+                                apiClient.setDefaultAuthentication(kcu);
+                                return apiClient;
+                            });
+                        const pipelineAccountToken = await Cluster.getPipelineServiceAccountToken(
+                                makeCoreV1ApiClient(signupStatus.proxyURL, signupStatus.compliantUsername,
+                                    (sessionCheck as any).idToken),
+                                signupStatus.compliantUsername);
                         let errCode = '';
-                        if (!Cluster.validateLoginToken((await vscode.env.clipboard.readText()).trim())) {
-                            errCode = 'invalidToken';
+                        if (!pipelineAccountToken) { // Try loging in using a token from the Clipboard
+                            if (!Cluster.validateLoginToken((await vscode.env.clipboard.readText()).trim())) {
+                                errCode = 'invalidToken';
+                            }
                         }
-                        await panel.webview.postMessage({ action: 'sandboxPageProvisioned', statusInfo: signupStatus.username, consoleDashboard: signupStatus.consoleURL, apiEndpoint: signupStatus.apiEndpoint, oauthTokenEndpoint: oauthInfo.token_endpoint, errorCode: errCode });
-                        await pollClipboard(signupStatus);
+                        await panel.webview.postMessage({
+                            action: 'sandboxPageProvisioned',
+                            statusInfo: signupStatus.compliantUsername,
+                            usePipelineToken: (pipelineAccountToken),
+                            consoleDashboard: signupStatus.consoleURL,
+                            apiEndpoint: signupStatus.apiEndpoint,
+                            apiEndpointProxy: signupStatus.proxyURL,
+                            oauthTokenEndpoint: oauthInfo.token_endpoint,
+                            errorCode: errCode
+                        });
+                        if (!pipelineAccountToken) { // Try loging in using a token from the Clipboard
+                            await pollClipboard(signupStatus);
+                        }
                     } else {
                         // cluster is not ready and the reason is
                         if (signupStatus.status.verificationRequired) {
@@ -189,22 +210,23 @@ async function clusterEditorMessageListener (event: any ): Promise<any> {
                 const result = await Cluster.loginUsingClipboardToken(event.payload.apiEndpointUrl, event.payload.oauthRequestTokenUrl);
                 if (result) void vscode.window.showInformationMessage(`${result}`);
                 telemetryEventLoginToSandbox.send();
-                const timeout = setInterval(() => {
-                    const currentUser = new KubeConfigUtils().getCurrentUser();
-                    if (currentUser) {
-                        clearInterval(timeout);
-                        const projectPrefix = currentUser.name.substring(
-                            0,
-                            currentUser.name.indexOf('/'),
-                        );
-                        void Oc.Instance.getProjects().then((projects) => {
-                            const userProject = projects.find((project) =>
-                                project.name.includes(projectPrefix),
-                            );
-                            void Oc.Instance.setProject(userProject.name);
-                        });
-                    }
-                }, 1000);
+            } catch (err) {
+                void vscode.window.showErrorMessage(err.message);
+                telemetryEventLoginToSandbox.sendError('Login into Sandbox Cluster failed.');
+            }
+            break;
+        }
+        case 'sandboxLoginUsingPipelineToken': {
+            const telemetryEventLoginToSandbox = new ExtCommandTelemetryEvent('openshift.explorer.addCluster.sandboxLoginUsingPipelineToken');
+            try {
+                const result = await Cluster.loginUsingPipelineServiceAccountToken(
+                    event.payload.apiEndpointUrl,
+                    event.payload.apiEndpointProxy,
+                    event.payload.username,
+                    (sessionCheck as any).idToken
+                );
+                if (result) void vscode.window.showInformationMessage(`${result}`);
+                telemetryEventLoginToSandbox.send();
             } catch (err) {
                 void vscode.window.showErrorMessage(err.message);
                 telemetryEventLoginToSandbox.sendError('Login into Sandbox Cluster failed.');
@@ -219,16 +241,27 @@ async function clusterEditorMessageListener (event: any ): Promise<any> {
 
 async function pollClipboard(signupStatus) {
     const oauthInfo = await sandboxAPI.getOauthServerInfo(signupStatus.apiEndpoint);
+    let firstPoll = true;
     while (panel) {
         const previousContent = (await vscode.env.clipboard.readText()).trim();
         await new Promise(r => setTimeout(r, 500));
         const currentContent = (await vscode.env.clipboard.readText()).trim();
-        if (previousContent && previousContent !== currentContent) {
+        if (firstPoll || (previousContent && previousContent !== currentContent)) {
+            firstPoll = false;
             let errCode = '';
             if (!Cluster.validateLoginToken(currentContent)){
                 errCode = 'invalidToken';
             }
-            void panel.webview.postMessage({action: 'sandboxPageProvisioned', statusInfo: signupStatus.username, consoleDashboard: signupStatus.consoleURL, apiEndpoint: signupStatus.apiEndpoint, oauthTokenEndpoint: oauthInfo.token_endpoint, errorCode: errCode});
+            void panel.webview.postMessage({
+                    action: 'sandboxPageProvisioned',
+                    statusInfo: signupStatus.username,
+                    usePipelineToken: false,
+                    consoleDashboard: signupStatus.consoleURL,
+                    apiEndpoint: signupStatus.apiEndpoint,
+                    apiEndpointProxy: signupStatus.proxyURL,
+                    oauthTokenEndpoint: oauthInfo.token_endpoint,
+                    errorCode: errCode
+                });
         }
     }
 }


### PR DESCRIPTION
Uses a POC ['feat: use sso account to configure sandbox in one click #4232'](https://github.com/redhat-developer/vscode-openshift-tools/pull/4232) by @dgolovin.

Allows logging in to the DevSandbox using a SSO account by creating a token and installing it into the pipeline Service Account, otherwise, if a token cannot be created/installed, a token from the Clipboard is to be used.



https://github.com/user-attachments/assets/61b612c3-a086-47a4-8619-66215f50370e



