### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.7",
 				"@types/mocha": "^10.0.7",
-				"@types/node": "^18.19.48",
+				"@types/node": "^18.19.50",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^17.0.80",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3372,9 +3372,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.48",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.48.tgz",
-			"integrity": "sha512-7WevbG4ekUcRQSZzOwxWgi5dZmTak7FaxXDoW7xVxPBmKx1rTzfmRLkeCgJzcbBnOV2dkhAPc8cCeT6agocpjg==",
+			"version": "18.19.50",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
+			"integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.7",
 		"@types/mocha": "^10.0.7",
-		"@types/node": "^18.19.48",
+		"@types/node": "^18.19.50",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^17.0.80",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                               18.19.48          18.19.50            22.5.4  node_modules/@types/node                       vscode-openshift-tools
...
```