### PR TITLE
[build] Fix vulnerability in path-to-regexp >=0.2.0 <=7.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11557,23 +11557,18 @@
 			"license": "MIT"
 		},
 		"node_modules/nise": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-6.0.0.tgz",
-			"integrity": "sha512-K8ePqo9BFvN31HXwEtTNGzgrPpmvgciDsFz8aztFjt4LqKO/JeFD8tBOeuDiCMXrIl/m1YvfH8auSpxfaD09wg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-6.0.1.tgz",
+			"integrity": "sha512-DAyWGPQEuJVlL2eqKw6gdZKT+E/jo/ZrjEUDAslJLluCz81nWy+KSYybNp3KFm887Yvp7hv12jSM82ld8BmLxg==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.0",
 				"@sinonjs/fake-timers": "^11.2.2",
 				"@sinonjs/text-encoding": "^0.7.2",
 				"just-extend": "^6.2.0",
-				"path-to-regexp": "^6.2.1"
+				"path-to-regexp": "^8.1.0"
 			}
-		},
-		"node_modules/nise/node_modules/path-to-regexp": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-			"dev": true
 		},
 		"node_modules/no-case": {
 			"version": "3.0.4",


### PR DESCRIPTION
```
path-to-regexp  0.2.0 - 7.2.0
Severity: high
path-to-regexp outputs backtracking regular expressions - https://github.com/advisories/GHSA-9wv6-86v2-598j
fix available via `npm audit fix`
node_modules/nise/node_modules/path-to-regexp
  nise  <=6.0.0
  Depends on vulnerable versions of path-to-regexp
  node_modules/nise
```