### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.5",
 				"@types/react-copy-to-clipboard": "^5.0.7",
-				"@types/react-dom": "^17.0.25",
+				"@types/react-dom": "^18.3.0",
 				"@types/semver": "^7.5.8",
 				"@types/shelljs": "^0.8.15",
 				"@types/sinon": "^17.0.3",
@@ -3491,23 +3491,13 @@
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "17.0.25",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
-			"integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
+			"version": "18.3.0",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@types/react": "^17"
-			}
-		},
-		"node_modules/@types/react-dom/node_modules/@types/react": {
-			"version": "17.0.80",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-			"integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
-			"dev": true,
-			"dependencies": {
-				"@types/prop-types": "*",
-				"@types/scheduler": "^0.16",
-				"csstype": "^3.0.2"
+				"@types/react": "*"
 			}
 		},
 		"node_modules/@types/react-transition-group": {
@@ -3553,12 +3543,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/scheduler": {
-			"version": "0.16.8",
-			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-			"integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-			"dev": true
 		},
 		"node_modules/@types/selenium-webdriver": {
 			"version": "4.1.26",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.5",
 		"@types/react-copy-to-clipboard": "^5.0.7",
-		"@types/react-dom": "^17.0.25",
+		"@types/react-dom": "^18.3.0",
 		"@types/semver": "^7.5.8",
 		"@types/shelljs": "^0.8.15",
 		"@types/sinon": "^17.0.3",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/react-dom              17.0.25           17.0.25            18.3.0  node_modules/@types/react-dom     vscode-openshift-tools
...
```