### PR TITLE
[build] Fix vulnerability in tough-cookie <4.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13109,12 +13109,6 @@
 				"resolve": "^1.11.1"
 			}
 		},
-		"node_modules/psl": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-			"integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-			"license": "MIT"
-		},
 		"node_modules/pump": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
@@ -15177,6 +15171,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tldts": {
+			"version": "6.1.47",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.47.tgz",
+			"integrity": "sha512-R/K2tZ5MiY+mVrnSkNJkwqYT2vUv1lcT6wJvd2emGaMJ7PHUGRY4e3tUsdFCXgqxi2QgbHjL3yJgXCo40v9Hxw==",
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^6.1.47"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.47",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.47.tgz",
+			"integrity": "sha512-6SWyFMnlst1fEt7GQVAAu16EGgFK0cLouH/2Mk6Ftlwhv3Ol40L0dlpGMcnnNiiOMyD2EV/aF3S+U2nKvvLvrA==",
+			"license": "MIT"
+		},
 		"node_modules/tmp": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -15230,16 +15242,15 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+			"integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
+				"tldts": "^6.1.32"
 			},
 			"engines": {
-				"node": ">=0.8"
+				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -188,6 +188,9 @@
 		"xterm-addon-web-links": "^0.9.0",
 		"xterm-addon-webgl": "^0.16.0"
 	},
+	"overrides": {
+		"tough-cookie": "^5.0.0"
+	},
 	"activationEvents": [
 		"onView:openshiftProjectExplorer",
 		"onView:extension.vsKubernetesExplorer",


### PR DESCRIPTION
```
...
tough-cookie  <4.1.3
Severity: moderate
tough-cookie Prototype Pollution vulnerability - https://github.com/advisories/GHSA-72xf-g2v4-qvf3
No fix available
node_modules/tough-cookie
...
```