### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 				"@rjsf/validator-ajv8": "^5.21.1",
 				"@segment/analytics-next": "^1.73.0",
 				"@svgr/plugin-jsx": "^8.1.0",
-				"@types/chai": "^4.3.19",
+				"@types/chai": "^4.3.20",
 				"@types/dockerode": "^3.3.31",
 				"@types/express": "^4.17.21",
 				"@types/fs-extra": "^11.0.4",
@@ -3328,9 +3328,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/chai": {
-			"version": "4.3.19",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.19.tgz",
-			"integrity": "sha512-2hHHvQBVE2FiSK4eN0Br6snX9MtolHaTo/batnLjlGRhoQzlCL61iVpxoqO7SfFyOw+P/pwv+0zNHzKoGWz9Cw==",
+			"version": "4.3.20",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+			"integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"@rjsf/validator-ajv8": "^5.21.1",
 		"@segment/analytics-next": "^1.73.0",
 		"@svgr/plugin-jsx": "^8.1.0",
-		"@types/chai": "^4.3.19",
+		"@types/chai": "^4.3.20",
 		"@types/dockerode": "^3.3.31",
 		"@types/express": "^4.17.21",
 		"@types/fs-extra": "^11.0.4",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/chai                    4.3.19            4.3.20             5.0.0  node_modules/@types/chai          vscode-openshift-tools
...
```