### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.9",
 				"@types/mocha": "^10.0.8",
-				"@types/node": "^18.19.53",
+				"@types/node": "^18.19.54",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.11",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3519,9 +3519,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.53",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.53.tgz",
-			"integrity": "sha512-GLxgUgHhDKO1Edw9Q0lvMbiO/IQXJwJlMaqxSGBXMpPy8uhkCs2iiPFaB2Q/gmobnFkckD3rqTBMVjXdwq+nKg==",
+			"version": "18.19.54",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.54.tgz",
+			"integrity": "sha512-+BRgt0G5gYjTvdLac9sIeE0iZcJxi4Jc4PV5EUzqi+88jmQLr+fRZdv2tCTV7IHKSGxM6SaLoOXQWWUiLUItMw==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.9",
 		"@types/mocha": "^10.0.8",
-		"@types/node": "^18.19.53",
+		"@types/node": "^18.19.54",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.11",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                  18.19.53          18.19.54            22.7.4  node_modules/@types/node          vscode-openshift-tools
...
```