### PR TITLE
[build] Fix vulnerability in cookie <0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6380,10 +6380,11 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}

--- a/package.json
+++ b/package.json
@@ -190,7 +190,8 @@
 		"xterm-addon-webgl": "^0.16.0"
 	},
 	"overrides": {
-		"tough-cookie": "^5.0.0"
+		"tough-cookie": "^5.0.0",
+		"cookie": "0.7.1"
 	},
 	"activationEvents": [
 		"onView:openshiftProjectExplorer",


### PR DESCRIPTION
```
# npm audit report

cookie  <0.7.0
cookie accepts cookie name, path, and domain with out of bounds characters - https://github.com/advisories/GHSA-pxg6-pf52-xh8x
fix available via `npm audit fix --force`
Will install express@2.5.11, which is a breaking change
node_modules/cookie
  express  >=3.0.0-alpha1
  Depends on vulnerable versions of cookie
  node_modules/express
```