### PR TITLE
Fix Devfile Registry editor views for cases where the current Devfile…

### DIFF
--- a/src/webview/common/devfileSearch.tsx
+++ b/src/webview/common/devfileSearch.tsx
@@ -37,6 +37,7 @@ import { DevfileData, DevfileInfo, DevfileRegistryInfo } from '../../devfile-reg
 import { TemplateProjectIdentifier } from '../common/devfile';
 import { DevfileExplanation } from './devfileExplanation';
 import { DevfileListItem } from './devfileListItem';
+import { ErrorPage } from './errorPage';
 import { LoadScreen } from './loading';
 import { vsDarkCodeMirrorTheme, vsLightCodeMirrorTheme } from './vscode-theme';
 
@@ -648,6 +649,7 @@ export function DevfileSearch(props: DevfileSearchProps) {
     const [searchText, setSearchText] = React.useState('');
 
     const [showMore, setShowMore] = React.useState(false);
+    const [createComponentErrorMessage, setCreateComponentErrorMessage] = React.useState('');
 
     function respondToMessage(messageEvent: MessageEvent) {
         const message = messageEvent.data as Message;
@@ -655,6 +657,7 @@ export function DevfileSearch(props: DevfileSearchProps) {
             case 'devfileRegistries': {
                 setDevfileRegistries((_devfileRegistries) => message.data);
                 setDevfileInfos((_devfileInfos) => []);
+                setSelectedDevfileInfo((_unused) => undefined);
                 setSomeDevfileInfoRetrieved(_unused => false);
                 window.vscodeApi.postMessage({ action: 'getDevfileInfos' });
                 break;
@@ -670,6 +673,11 @@ export function DevfileSearch(props: DevfileSearchProps) {
             }
             case 'devfileTags': {
                 setDevfileTags((_devfileTags) => message.data);
+                break;
+            }
+            case 'createComponentFailed': {
+                setSomeDevfileInfoRetrieved(_unused => true);
+                setCreateComponentErrorMessage(message.data);
                 break;
             }
             default:
@@ -756,6 +764,18 @@ export function DevfileSearch(props: DevfileSearchProps) {
 
     if (!devfileTags) {
         return <LoadScreen title="Retrieving list of Devfile Tags..." />;
+    }
+
+    if (createComponentErrorMessage) {
+        return (
+            <>
+                <Stack direction="column" height="100%" spacing={0.5}>
+                    <ErrorPage
+                        message={`${createComponentErrorMessage}`}
+                    />
+                </Stack>
+            </>
+        );
     }
 
     const activeRegistries = registryEnabled //

--- a/src/webview/create-component/createComponentLoader.ts
+++ b/src/webview/create-component/createComponentLoader.ts
@@ -87,7 +87,7 @@ export default class CreateComponentLoader {
             void sendUpdatedRegistries(CreateComponentLoader.panel);
         });
 
-        const capabiliiesySubscription = ComponentTypesView.instance.subject.subscribe(() => {
+        const capabilitiesSubscription = ComponentTypesView.instance.subject.subscribe(() => {
             sendUpdatedCapabilities(CreateComponentLoader.panel);
         });
 
@@ -98,7 +98,7 @@ export default class CreateComponentLoader {
         panel.onDidDispose(() => {
             void sendTelemetry('newComponentClosed');
             tagsSubscription.unsubscribe();
-            capabiliiesySubscription.unsubscribe();
+            capabilitiesSubscription.unsubscribe();
             registriesSubscription.unsubscribe();
             colorThemeDisposable.dispose();
             messageHandlerDisposable.dispose();


### PR DESCRIPTION
… Registry is removed

This will show an error instead of Devfile search form, a Devfile selection dialog, etc. and will ask if user wants to close the view when the current Devfile Registry is removed.

The following cases where fixed:

- Switching between displaying a specified Devfile Registry contents to displaying the contents of all the available registries:

https://github.com/user-attachments/assets/15eb4007-8913-4a2d-b79b-af5b95bcab31

- Closing a Devfile Registry view when a devfile registry is removed while a devfile from that registry is selected:

https://github.com/user-attachments/assets/9b20b380-0710-4de6-a871-4f4addbed8ee

- Closing a Devfile Registry view when a devfile registry is removed while a devfile from that registry is selected and promoted to 'Select Name and Folder' page:

https://github.com/user-attachments/assets/c8dadec1-8ced-4612-9208-65b543839259



