### PR TITLE
[build] Use Node 20 in release-job only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: |
           npm install -g typescript "vsce" "ovsx"
@@ -91,7 +91,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
     - name: Install dependencies
       run: |
         npm install -g typescript "vsce" "ovsx"


### PR DESCRIPTION
- ovsx 0.10.0 requires Node >= 20

```
$ nvm use 18
$ npm install -g ovsx
$ ovsx --version
ovsx requires at least NodeJS version 20. Check your installed version with `node --version`.
```