### PR TITLE
[tests] Increase timeout for openning  create component from template dialog

### DIFF
--- a/test/ui/suite/createComponent.ts
+++ b/test/ui/suite/createComponent.ts
@@ -147,7 +147,7 @@ export function testCreateComponent(path: string) {
             await devfileView.initializeEditor();
             await devfileView.selectRegistryStack('Node.js Runtime');
             await new Promise((res) => {
-                setTimeout(res, 1_000);
+                setTimeout(res, 1_500);
             });
 
             //Initialize stack window and click Use Devfile


### PR DESCRIPTION
This PR aims to make the `Create component from template project` UI test to pass more stably as it frequently fails with:
```
  1) Extension public-facing UI tests
       Non-cluster tests
         Create Component Wizard
           Create component from template project:
     NoSuchElementError: no such element: Unable to locate element: {"method":"xpath","selector":"//button[contains(text(), "Use Devfile")]"}
  (Session info: chrome=124.0.6367.243)
      at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:521:15)
      at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:514:13)
      at Executor.execute (node_modules/selenium-webdriver/lib/http.js:446:28)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at Driver.execute (node_modules/selenium-webdriver/lib/webdriver.js:744:17)
      at WebViewBase.findWebElement (node_modules/@redhat-developer/page-objects/out/components/WebviewMixin.js:43:20)
```