### PR TITLE
Fix port validation in Create Component from Local Codebase

### DIFF
--- a/src/webview/common-ext/createComponentHelpers.ts
+++ b/src/webview/common-ext/createComponentHelpers.ts
@@ -160,7 +160,7 @@ export function validateName(name: string, isComponentBasedValidation = true): s
  */
 export function validatePortNumber(portNumber: number): string {
     let validationMessage: string | null;
-    const port = portNumber.toString();
+    const port = portNumber ? portNumber.toString() : '';
     if (NameValidator.emptyName('Empty', port) === null) {
         validationMessage = NameValidator.lengthName(
             'Port number length should be between 1-5 digits',


### PR DESCRIPTION
```
rejected promise not handled within 1 second: TypeError: Cannot read properties of undefined (reading 'toString')
extensionHostProcess.js:162
stack trace: TypeError: Cannot read properties of undefined (reading 'toString')
	at validatePortNumber (/home/jeremy/projects/vscode-openshift-tools/source/vscode-openshift-tools/out/src/webview/common-ext/createComponentHelpers.js:170:29)
	at gh.<anonymous> (/home/jeremy/projects/vscode-openshift-tools/source/vscode-openshift-tools/out/src/webview/create-component/createComponentLoader.js:193:95)
	at Generator.next (<anonymous>)
	at /home/jeremy/projects/vscode-openshift-tools/source/vscode-openshift-tools/out/src/webview/create-component/createComponentLoader.js:8:71
	at new Promise (<anonymous>)
	at __awaiter (/home/jeremy/projects/vscode-openshift-tools/source/vscode-openshift-tools/out/src/webview/create-component/createComponentLoader.js:4:12)
	at gh.messageHandler [as value] (/home/jeremy/projects/vscode-openshift-tools/source/vscode-openshift-tools/out/src/webview/create-component/createComponentLoader.js:91:16)
```