### PR TITLE
[build] Fix vulnerability in jsonpath-plus <10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1740,6 +1740,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
 			"integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 10.16.0"
 			},
@@ -1751,6 +1752,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
 			"integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 10.16.0"
 			},
@@ -1759,9 +1761,10 @@
 			}
 		},
 		"node_modules/@kubernetes/client-node": {
-			"version": "0.22.0",
-			"resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.22.0.tgz",
-			"integrity": "sha512-K86G5S/V+qMmg/Ht26CtEvTbedsD1u6RaYfIR4V4DphyNBLc3rY20mFNvXVE43MFbQrd5rDOvtOjTCsaVoBiEg==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.22.1.tgz",
+			"integrity": "sha512-bNz2uoxJTA/m10h2TsM5e021I9OndpxYYj5hGdHnrmhA+Dk56ohhbbvnJz7TADTEgyBHQ6NAT0QrILypbdFusQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/js-yaml": "^4.0.1",
 				"@types/node": "^22.0.0",
@@ -1770,13 +1773,13 @@
 				"byline": "^5.0.0",
 				"isomorphic-ws": "^5.0.0",
 				"js-yaml": "^4.1.0",
-				"jsonpath-plus": "^9.0.0",
+				"jsonpath-plus": "^10.0.0",
 				"request": "^2.88.0",
 				"rfc4648": "^1.3.0",
 				"stream-buffers": "^3.0.2",
 				"tar": "^7.0.0",
 				"tslib": "^2.4.1",
-				"ws": "^8.11.0"
+				"ws": "^8.18.0"
 			},
 			"optionalDependencies": {
 				"openid-client": "^5.3.0"
@@ -10520,6 +10523,7 @@
 			"version": "1.3.9",
 			"resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
 			"integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 10.16.0"
 			}
@@ -10657,20 +10661,21 @@
 			}
 		},
 		"node_modules/jsonpath-plus": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-9.0.0.tgz",
-			"integrity": "sha512-bqE77VIDStrOTV/czspZhTn+o27Xx9ZJRGVkdVShEtPoqsIx5yALv3lWVU6y+PqYvWPJNWE7ORCQheQkEe0DDA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz",
+			"integrity": "sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==",
+			"license": "MIT",
 			"dependencies": {
 				"@jsep-plugin/assignment": "^1.2.1",
 				"@jsep-plugin/regex": "^1.0.3",
-				"jsep": "^1.3.8"
+				"jsep": "^1.3.9"
 			},
 			"bin": {
 				"jsonpath": "bin/jsonpath-cli.js",
 				"jsonpath-plus": "bin/jsonpath-cli.js"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/jsonpointer": {


### PR DESCRIPTION
See: [JSONPath Plus Remote Code Execution (RCE) Vulnerability #69](https://github.com/redhat-developer/vscode-openshift-tools/security/dependabot/69)

```
jsonpath-plus  <10.0.0
Severity: critical
JSONPath Plus Remote Code Execution (RCE) Vulnerability - https://github.com/advisories/GHSA-pppg-cpfq-h7wr
fix available via `npm audit fix`
node_modules/jsonpath-plus
  @kubernetes/client-node  <=1.0.0-rc6
  Depends on vulnerable versions of jsonpath-plus
  Depends on vulnerable versions of request
  node_modules/@kubernetes/client-node
```

Fixes: https://github.com/redhat-developer/vscode-openshift-tools/security/dependabot/69
