### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/lang-yaml": "^6.1.1",
-				"@kubernetes/client-node": "^0.22.0",
+				"@kubernetes/client-node": "^0.22.1",
 				"@redhat-developer/vscode-redhat-telemetry": "^0.9.0",
 				"@uiw/codemirror-theme-github": "^4.23.5",
 				"@uiw/react-codemirror": "^4.23.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 	},
 	"dependencies": {
 		"@codemirror/lang-yaml": "^6.1.1",
-		"@kubernetes/client-node": "^0.22.0",
+		"@kubernetes/client-node": "^0.22.1",
 		"@redhat-developer/vscode-redhat-telemetry": "^0.9.0",
 		"@uiw/codemirror-theme-github": "^4.23.5",
 		"@uiw/react-codemirror": "^4.23.5",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@kubernetes/client-node            0.22.0            0.22.1            0.22.1  node_modules/@kubernetes/client-node  vscode-openshift-tools
...
```