### PR TITLE
removed ODO log command

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,10 +230,6 @@
 		"onCommand:openshift.component.describe",
 		"onCommand:openshift.component.openInBrowser",
 		"onCommand:openshift.component.describe.palette",
-		"onCommand:openshift.component.log",
-		"onCommand:openshift.component.log.palette",
-		"onCommand:openshift.component.followLog",
-		"onCommand:openshift.component.followLog.palette",
 		"onCommand:openshift.componentTypesView.registry.closeView",
 		"onCommand:openshift.component.debug",
 		"onCommand:openshift.component.debug.palette",
@@ -561,26 +557,6 @@
 			{
 				"command": "openshift.component.describe.palette",
 				"title": "Describe Component",
-				"category": "OpenShift"
-			},
-			{
-				"command": "openshift.component.log",
-				"title": "Show Log",
-				"category": "OpenShift"
-			},
-			{
-				"command": "openshift.component.log.palette",
-				"title": "Show Component Log",
-				"category": "OpenShift"
-			},
-			{
-				"command": "openshift.component.followLog",
-				"title": "Follow Log",
-				"category": "OpenShift"
-			},
-			{
-				"command": "openshift.component.followLog.palette",
-				"title": "Follow Component Log",
 				"category": "OpenShift"
 			},
 			{
@@ -1182,14 +1158,6 @@
 					"when": "view == openshiftComponentsView"
 				},
 				{
-					"command": "openshift.component.log",
-					"when": "view == openshiftProjectExplorer"
-				},
-				{
-					"command": "openshift.component.followLog",
-					"when": "view == openshiftProjectExplorer"
-				},
-				{
 					"command": "openshift.component.commands.command.run",
 					"when": "view == openshiftComponentsView"
 				},
@@ -1283,14 +1251,6 @@
 				},
 				{
 					"command": "openshift.component.describe.palette",
-					"when": "false"
-				},
-				{
-					"command": "openshift.component.followLog.palette",
-					"when": "false"
-				},
-				{
-					"command": "openshift.component.log.palette",
 					"when": "false"
 				},
 				{
@@ -1814,16 +1774,6 @@
 					"group": "c3@1"
 				},
 				{
-					"command": "openshift.component.log",
-					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-run.*/",
-					"group": "c3@2"
-				},
-				{
-					"command": "openshift.component.followLog",
-					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-run.*/",
-					"group": "c3@3"
-				},
-				{
 					"command": "openshift.component.deleteConfigurationFiles",
 					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-nrn.*/",
 					"group": "c3@4"
@@ -1959,7 +1909,7 @@
 				},
 				{
 					"command": "openshift.resource.watchLogs",
-					"when": "view == openshiftProjectExplorer && viewItem =~ /^openshift\\.k8sObject\\.(?!helm|pod)/"
+					"when": "view == openshiftProjectExplorer && viewItem =~ /^openshift\\.k8sObject\\.(?!helm)/"
 				},
 				{
 					"command": "openshift.deployment.shell",

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -773,7 +773,7 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
                 let intervalId: ReturnType<typeof setInterval> | undefined = undefined;
 
                 function checkForPod() {
-                    void Oc.Instance.getLogs('Deployment', component.metadata.name, namespace).then((logs) => {
+                    void Oc.Instance.getLogs(`${component.kind}`, component.metadata.name, namespace).then((logs) => {
                         clearInterval(intervalId);
                         resolve();
                     }).catch(_e => { });

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -46,20 +46,6 @@ export class Command {
         return Command.describeComponent().addOption(new CommandOption('-o', 'json', false));
     }
 
-    static showLog(platform?: string): CommandText {
-        const result = new CommandText('odo', 'logs', [
-            new CommandOption('--dev'),
-        ]);
-        if (platform) {
-            result.addOption(new CommandOption('--platform', platform));
-        }
-        return result;
-    }
-
-    static showLogAndFollow(platform?: string): CommandText {
-        return Command.showLog(platform).addOption(new CommandOption('--follow'));
-    }
-
     @verbose
     static createLocalComponent(
         devfileType = '', // will use empty string in case of undefined devfileType passed in

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -430,26 +430,6 @@ export class Component extends OpenShiftItem {
             `Describe '${componentFolder.component.devfileData.devfile.metadata.name}' Component`);
     }
 
-    @vsCommand('openshift.component.log', true)
-    static async log(componentFolder: ComponentWorkspaceFolder): Promise<void> {
-        const componentName = componentFolder.component.devfileData.devfile.metadata.name;
-        const showLogCmd = Command.showLog(Component.getDevPlatform(componentFolder));
-        await OpenShiftTerminalManager.getInstance().executeInTerminal(
-            showLogCmd,
-            componentFolder.contextPath,
-            `Show '${componentName}' Component Log`);
-    }
-
-    @vsCommand('openshift.component.followLog', true)
-    static async followLog(componentFolder: ComponentWorkspaceFolder): Promise<void> {
-        const componentName = componentFolder.component.devfileData.devfile.metadata.name;
-        const showLogCmd = Command.showLogAndFollow(Component.getDevPlatform(componentFolder));
-        await OpenShiftTerminalManager.getInstance().executeInTerminal(
-            showLogCmd,
-            componentFolder.contextPath,
-            `Follow '${componentName}' Component Log`);
-    }
-
     @vsCommand('openshift.component.openCreateComponent')
     static async createComponent(): Promise<void> {
         await CreateComponentLoader.loadView('Create Component');

--- a/test/integration/command.test.ts
+++ b/test/integration/command.test.ts
@@ -165,48 +165,6 @@ suite('odo commands integration', function () {
             term.dispose();
         });
 
-        test('showLog()', async function () {
-            await ODO.execute(Command.showLog(), componentLocation);
-        });
-
-        test('showLogAndFollow()', async function() {
-            const outputEmitter = new EventEmitter<string>();
-            let devProcess: ChildProcess;
-            function failListener(_error) {
-                assert.fail('showLogAndFollow() errored before it was closed');
-            }
-            const term = window.createTerminal({
-                name: 'test terminal',
-                pty: {
-                    open: () => {
-                        void CliChannel.getInstance().spawnTool(Command.showLogAndFollow()) //
-                            .then(childProcess => {
-                                devProcess = childProcess
-                                devProcess.on('error', failListener);
-                            });
-                    },
-                    close: () => {
-                        if (devProcess) {
-                            devProcess.removeListener('error', failListener);
-                            devProcess.kill('SIGINT');
-                        }
-                    },
-                    handleInput: (data: string) => {
-                        if (data.length) {
-                            if (devProcess) {
-                                devProcess.removeListener('error', failListener);
-                                devProcess.kill('SIGINT');
-                            }
-                        }
-                    },
-                    onDidWrite: outputEmitter.event
-                }
-            });
-            await new Promise<void>(resolve => setTimeout(resolve, 1000));
-            // we instruct the pseudo terminal to close the dev session when any text is sent
-            term.sendText('a');
-            term.dispose();
-        });
     });
 
     suite('component dev', function() {

--- a/test/ui/suite/componentContextMenu.ts
+++ b/test/ui/suite/componentContextMenu.ts
@@ -191,36 +191,6 @@ export function testComponentContextMenu() {
             expect(tabName).to.contain(expectedTabName);
         });
 
-        it('Show log works', async () => {
-            //open menu and select show log
-            const contextMenu = await component.openContextMenu();
-            await contextMenu.select(MENUS.showLog);
-
-            //check for active tab name
-            const tabName = await openshiftTerminal.getActiveTabName();
-            expect(tabName).to.contain(`Show '${componentName}' Component Log`);
-
-            //check for terminal content
-            const terminalText = await openshiftTerminal.getTerminalText();
-            expect(terminalText).to.contain('runtime: App started on PORT');
-            expect(terminalText).to.contain('Press any key to close this terminal');
-        });
-
-        it('Follow log works', async () => {
-            //open menu and select follow log
-            const contextMenu = await component.openContextMenu();
-            await contextMenu.select(MENUS.followLog);
-
-            //check for active tab name
-            const tabName = await openshiftTerminal.getActiveTabName();
-            expect(tabName).to.contain(`Follow '${componentName}' Component Log`);
-
-            //check for terminal text
-            const terminalText = await openshiftTerminal.getTerminalText();
-            expect(terminalText).to.contain('runtime: App started on PORT');
-            expect(terminalText).not.to.contain('Press any key to close this terminal');
-        });
-
         it('Debug works', async () => {
             this.timeout(80_000);
 

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -30,7 +30,6 @@ const { expect } = chai;
 chai.use(sinonChai);
 
 suite('OpenShift/Component', function () {
-    let quickPickStub: sinon.SinonStub;
     let sandbox: sinon.SinonSandbox;
     let termStub: sinon.SinonStub; let execStub: sinon.SinonStub;
     const fixtureFolder = path.join(__dirname, '..', '..', '..', 'test', 'fixtures').normalize();
@@ -299,39 +298,6 @@ suite('OpenShift/Component', function () {
                 const commandProvider = componentCommandsCommandNode as unknown as CommandProvider;
                 expect(commandProvider.getCommand).not.null;
             }
-        });
-    });
-
-    suite.skip('log', function () {
-
-        test('log calls the correct odo command', async function () {
-            await Component.log(componentItem1);
-            expect(termStub).calledOnceWith(Command.showLog());
-        });
-
-        test('works with no context', async () => {
-            await Component.log(null);
-            expect(termStub).calledOnceWith(Command.showLog());
-        });
-    });
-
-    suite.skip('followLog', function() {
-
-        test('returns null when cancelled', async function () {
-            quickPickStub.onFirstCall().resolves();
-            const result = await Component.followLog(null);
-
-            expect(result).null;
-        });
-
-        test('followLog calls the correct odo command', async function () {
-            await Component.followLog(componentItem1);
-            expect(termStub).calledOnceWith(Command.showLogAndFollow());
-        });
-
-        test('works with no context', async function () {
-            await Component.followLog(null);
-            expect(termStub).calledOnceWith(Command.showLogAndFollow());
         });
     });
 


### PR DESCRIPTION
Ref: https://github.com/redhat-developer/vscode-openshift-tools/issues/4396

Removed `Show Log` and `Follow Log` on the dropdown of component. We can use `Watch Logs` on `Deployments` and `Pods` in application explorer view.