### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.11",
 				"@types/mocha": "^10.0.9",
-				"@types/node": "^18.19.55",
+				"@types/node": "^18.19.56",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.11",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3558,9 +3558,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.55",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.55.tgz",
-			"integrity": "sha512-zzw5Vw52205Zr/nmErSEkN5FLqXPuKX/k5d1D7RKHATGqU7y6YfX9QxZraUzUrFGqH6XzOzG196BC35ltJC4Cw==",
+			"version": "18.19.56",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.56.tgz",
+			"integrity": "sha512-4EMJlWwwGnVPflJAtM14p9eVSa6BOv5b92mCsh5zcM1UagNtEtrbbtaE6WE1tw2TabavatnwqXjlIpcAEuJJNg==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.11",
 		"@types/mocha": "^10.0.9",
-		"@types/node": "^18.19.55",
+		"@types/node": "^18.19.56",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.11",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                  18.19.55          18.19.56            22.7.6  node_modules/@types/node          vscode-openshift-tools
...