### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.12",
 				"@types/mocha": "^10.0.9",
-				"@types/node": "^18.19.57",
+				"@types/node": "^18.19.60",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.12",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3558,9 +3558,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.57",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.57.tgz",
-			"integrity": "sha512-I2ioBd/IPrYDMv9UNR5NlPElOZ68QB7yY5V2EsLtSrTO0LM0PnCEFF9biLWHf5k+sIy4ohueCV9t4gk1AEdlVA==",
+			"version": "18.19.60",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.60.tgz",
+			"integrity": "sha512-cYRj7igVqgxhlHFdBHHpU2SNw3+dN2x0VTZJtLYk6y/ieuGN4XiBgtDjYVktM/yk2y/8pKMileNc6IoEzEJnUw==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.12",
 		"@types/mocha": "^10.0.9",
-		"@types/node": "^18.19.57",
+		"@types/node": "^18.19.60",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.12",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                  18.19.57          18.19.60            22.8.2  node_modules/@types/node          vscode-openshift-tools
...
```