### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.12",
 				"@types/mocha": "^10.0.9",
-				"@types/node": "^18.19.60",
+				"@types/node": "^18.19.61",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.12",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3516,9 +3516,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.60",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.60.tgz",
-			"integrity": "sha512-cYRj7igVqgxhlHFdBHHpU2SNw3+dN2x0VTZJtLYk6y/ieuGN4XiBgtDjYVktM/yk2y/8pKMileNc6IoEzEJnUw==",
+			"version": "18.19.61",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.61.tgz",
+			"integrity": "sha512-z8fH66NcVkDzBItOao+Nyh0fiy7CYdxIyxnNCcZ60aY0I+EA/y4TSi/S/W9i8DIQvwVo7a0pgzAxmDeNnqrpkw==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.12",
 		"@types/mocha": "^10.0.9",
-		"@types/node": "^18.19.60",
+		"@types/node": "^18.19.61",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.12",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                  18.19.60          18.19.61            22.8.4  node_modules/@types/node          vscode-openshift-tools
...
```