### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.13",
 				"@types/mocha": "^10.0.9",
-				"@types/node": "^18.19.61",
+				"@types/node": "^18.19.63",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.12",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3482,9 +3482,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.61",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.61.tgz",
-			"integrity": "sha512-z8fH66NcVkDzBItOao+Nyh0fiy7CYdxIyxnNCcZ60aY0I+EA/y4TSi/S/W9i8DIQvwVo7a0pgzAxmDeNnqrpkw==",
+			"version": "18.19.63",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.63.tgz",
+			"integrity": "sha512-hcUB7THvrGmaEcPcvUZCZtQ2Z3C+UR/aOcraBLCvTsFMh916Gc1kCCYcfcMuB76HM2pSerxl1PoP3KnmHzd9Lw==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.13",
 		"@types/mocha": "^10.0.9",
-		"@types/node": "^18.19.61",
+		"@types/node": "^18.19.63",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.12",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                  18.19.61          18.19.63            22.8.6  node_modules/@types/node          vscode-openshift-tools
...
```