### PR TITLE
[build] Fix vulnerability in cross-spawn <7.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8169,22 +8169,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/execa/node_modules/cross-spawn": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-			"dev": true,
-			"dependencies": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			},
-			"engines": {
-				"node": ">=4.8"
-			}
-		},
 		"node_modules/execa/node_modules/is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -8213,36 +8197,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/execa/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/execa/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-			"dev": true,
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/execa/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/expand-template": {
@@ -11783,13 +11737,6 @@
 				"@segment/isodate": "1.0.3"
 			}
 		},
-		"node_modules/nice-try": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/nise": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
@@ -11942,65 +11889,6 @@
 			},
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"node_modules/npm-run-all/node_modules/cross-spawn": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-			"integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
-			"dev": true,
-			"dependencies": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			},
-			"engines": {
-				"node": ">=4.8"
-			}
-		},
-		"node_modules/npm-run-all/node_modules/path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-run-all/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/npm-run-all/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/npm-run-all/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
 	},
 	"overrides": {
 		"tough-cookie": "^5.0.0",
+		"cross-spawn": "^7.0.6",
 		"cookie": "^1.0.1"
 	},
 	"activationEvents": [


### PR DESCRIPTION
See: https://github.com/advisories/GHSA-3xgq-45jj-v275

```
cross-spawn  <7.0.5
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix --force`
Will install npm-run-all@2.1.0, which is a breaking change
node_modules/execa/node_modules/cross-spawn
node_modules/npm-run-all/node_modules/cross-spawn
  execa  0.5.0 - 2.0.5
  Depends on vulnerable versions of cross-spawn
  node_modules/execa
    clipboardy  <=2.3.0
    Depends on vulnerable versions of execa
    node_modules/clipboardy
  npm-run-all  >=2.1.1
  Depends on vulnerable versions of cross-spawn
  node_modules/npm-run-all
```