### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.13",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^18.19.64",
+				"@types/node": "^18.19.66",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.12",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3576,9 +3576,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.64",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.64.tgz",
-			"integrity": "sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==",
+			"version": "18.19.66",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.66.tgz",
+			"integrity": "sha512-14HmtUdGxFUalGRfLLn9Gc1oNWvWh5zNbsyOLo5JV6WARSeN1QcEBKRnZm9QqNfrutgsl/hY4eJW63aZ44aBCg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.13",
 		"@types/mocha": "^10.0.10",
-		"@types/node": "^18.19.64",
+		"@types/node": "^18.19.66",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.12",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                  18.19.64          18.19.66           22.10.0  node_modules/@types/node          vscode-openshift-tools
...
```