### PR TITLE
Fix code scanning alert no. 28: Client-side cross-site scripting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
 				"codecov": "^3.8.3",
 				"codemirror": "^6.0.1",
 				"dockerode": "^4.0.2",
+				"dompurify": "^3.2.1",
 				"dpdm": "^3.14.0",
 				"esbuild": "^0.19.12",
 				"esbuild-node-externals": "^1.15.0",
@@ -3795,6 +3796,14 @@
 			"integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
 			"dev": true
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/@types/unzip-stream": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/@types/unzip-stream/-/unzip-stream-0.3.4.tgz",
@@ -6989,6 +6998,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.1.tgz",
+			"integrity": "sha512-NBHEsc0/kzRYQd+AY6HR6B/IgsqzBABrqJbpCDQII/OK6h7B7LXzweZTDsqSW2LkTRpoxf18YUP+YjGySk6B3w==",
+			"dev": true,
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
 		"public-ui-test": "extest setup-tests -e ./test-resources/extensions -c max -i && npm run test:prepare && extest run-tests out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max"
 	},
 	"dependencies": {
-		"shelljs": "^0.8.5"
+		"shelljs": "^0.8.5",
+		"dompurify": "^3.2.1"
 	},
 	"devDependencies": {
 		"@codemirror/lang-yaml": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
 		"public-ui-test": "extest setup-tests -e ./test-resources/extensions -c max -i && npm run test:prepare && extest run-tests out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max"
 	},
 	"dependencies": {
-		"shelljs": "^0.8.5",
-		"dompurify": "^3.2.1"
+		"shelljs": "^0.8.5"
 	},
 	"devDependencies": {
 		"@codemirror/lang-yaml": "^6.1.1",
@@ -128,6 +127,7 @@
 		"codecov": "^3.8.3",
 		"codemirror": "^6.0.1",
 		"dockerode": "^4.0.2",
+		"dompurify": "^3.2.1",
 		"dpdm": "^3.14.0",
 		"esbuild": "^0.19.12",
 		"esbuild-node-externals": "^1.15.0",

--- a/src/webview/common/devfileListItem.tsx
+++ b/src/webview/common/devfileListItem.tsx
@@ -6,6 +6,7 @@ import { Check } from '@mui/icons-material';
 import { Box, Chip, Stack, Tooltip, Typography } from '@mui/material';
 import * as React from 'react';
 import validator from 'validator';
+import DOMPurify from 'dompurify';
 import DevfileLogo from '../../../images/context/devfile.png';
 import { DevfileData, DevfileInfo } from '../../devfile-registry/devfileInfo';
 
@@ -18,7 +19,7 @@ export type DevfileListItemProps = {
 
 function checkedDevfileLogoUrl(logoUrl?: string) {
     if (logoUrl && validator.isURL(logoUrl)) {
-        return logoUrl;
+        return DOMPurify.sanitize(logoUrl);
     }
     return DevfileLogo;
 }


### PR DESCRIPTION
Fixes [https://github.com/redhat-developer/vscode-openshift-tools/security/code-scanning/28](https://github.com/redhat-developer/vscode-openshift-tools/security/code-scanning/28)

To fix the problem, we need to ensure that the URL used in the `src` attribute of the `img` element is sanitized to prevent XSS attacks. The best way to do this is to use a library that provides robust sanitization functions. One such library is `DOMPurify`, which can sanitize HTML and URLs to prevent XSS.

We will modify the `checkedDevfileLogoUrl` function to use `DOMPurify` to sanitize the URL before returning it. This will ensure that any user-provided URL is safe to use in the `src` attribute of the `img` element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
