### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.13",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^18.19.66",
+				"@types/node": "^18.19.67",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.12",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3577,9 +3577,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.66",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.66.tgz",
-			"integrity": "sha512-14HmtUdGxFUalGRfLLn9Gc1oNWvWh5zNbsyOLo5JV6WARSeN1QcEBKRnZm9QqNfrutgsl/hY4eJW63aZ44aBCg==",
+			"version": "18.19.67",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.67.tgz",
+			"integrity": "sha512-wI8uHusga+0ZugNp0Ol/3BqQfEcCCNfojtO6Oou9iVNGPTL6QNSdnUdqq85fRgIorLhLMuPIKpsN98QE9Nh+KQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.13",
 		"@types/mocha": "^10.0.10",
-		"@types/node": "^18.19.66",
+		"@types/node": "^18.19.67",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.12",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                  18.19.66          18.19.67           22.10.1  node_modules/@types/node          vscode-openshift-tools
...
```