### PR TITLE
Cannot login if my kube config doesn't exist #3872

### DIFF
--- a/src/util/kubeUtils.ts
+++ b/src/util/kubeUtils.ts
@@ -162,7 +162,17 @@ export function getKubeConfigFiles(): string[] {
         }
         return filesThatExist;
     }
-    return [path.join(Platform.getUserHomePath(), '.kube', 'config')];
+
+    const defaultKubeConfigFile = path.join(Platform.getUserHomePath(), '.kube', 'config');
+    if (!fs.existsSync(defaultKubeConfigFile)) {
+        try {
+            fs.appendFileSync(defaultKubeConfigFile, 'apiVersion: v1'); // Create Kube Config with minimal content
+        } catch (err) {
+            void window.showErrorMessage(`Kubernetes configuration file cannot be created at '${defaultKubeConfigFile}': ${err}`);
+        }
+    }
+
+    return [defaultKubeConfigFile];
 }
 
 /**


### PR DESCRIPTION
Creates a minimalistic Kube config file in `~/.kube/` directory needed for `@kubernetes/client-node` API.
The file contents doesn't define any clusters/users/contexts/etc. properties.

Fixes: #3872