### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.14",
 				"@types/react-copy-to-clipboard": "^5.0.7",
-				"@types/react-dom": "^18.3.2",
+				"@types/react-dom": "^18.3.3",
 				"@types/semver": "^7.5.8",
 				"@types/shelljs": "^0.8.15",
 				"@types/sinon": "^17.0.3",
@@ -3643,13 +3643,13 @@
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "18.3.2",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.2.tgz",
-			"integrity": "sha512-Fqp+rcvem9wEnGr3RY8dYNvSQ8PoLqjZ9HLgaPUOjJJD120uDyOxOjc/39M4Kddp9JQCxpGQbnhVQF0C0ncYVg==",
+			"version": "18.3.3",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.3.tgz",
+			"integrity": "sha512-uTYkxTLkYp41nq/ULXyXMtkNT1vu5fXJoqad6uTNCOGat5t9cLgF4vMNLBXsTOXpdOI44XzKPY1M5RRm0bQHuw==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"@types/react": "^18"
+			"peerDependencies": {
+				"@types/react": "^18.0.0"
 			}
 		},
 		"node_modules/@types/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.14",
 		"@types/react-copy-to-clipboard": "^5.0.7",
-		"@types/react-dom": "^18.3.2",
+		"@types/react-dom": "^18.3.3",
 		"@types/semver": "^7.5.8",
 		"@types/shelljs": "^0.8.15",
 		"@types/sinon": "^17.0.3",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/react-dom                 18.3.2            18.3.3            19.0.2  node_modules/@types/react-dom       vscode-openshift-tools
...
```