### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"@types/mocha": "^10.0.10",
 				"@types/node": "^18.19.68",
 				"@types/proxyquire": "^1.3.31",
-				"@types/react": "^18.3.16",
+				"@types/react": "^18.3.17",
 				"@types/react-copy-to-clipboard": "^5.0.7",
 				"@types/react-dom": "^18.3.5",
 				"@types/semver": "^7.5.8",
@@ -3639,9 +3639,9 @@
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.16",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.16.tgz",
-			"integrity": "sha512-oh8AMIC4Y2ciKufU8hnKgs+ufgbA/dhPTACaZPM86AbwX9QwnFtSoPWEeRUj8fge+v6kFt78BXcDhAU1SrrAsw==",
+			"version": "18.3.17",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.17.tgz",
+			"integrity": "sha512-opAQ5no6LqJNo9TqnxBKsgnkIYHozW9KSTlFVoSUJYh1Fl/sswkEoqIugRSm7tbh6pABtYjGAjW+GOS23j8qbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.68",
 		"@types/proxyquire": "^1.3.31",
-		"@types/react": "^18.3.16",
+		"@types/react": "^18.3.17",
 		"@types/react-copy-to-clipboard": "^5.0.7",
 		"@types/react-dom": "^18.3.5",
 		"@types/semver": "^7.5.8",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/react                     18.3.16           18.3.17            19.0.1  node_modules/@types/react            vscode-openshift-tools
...
```