### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.14",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^18.19.68",
+				"@types/node": "^18.19.69",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.18",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3776,9 +3776,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.68",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.68.tgz",
-			"integrity": "sha512-QGtpFH1vB99ZmTa63K4/FU8twThj4fuVSBkGddTp7uIL/cuoLWIUSL2RcOaigBhfR+hg5pgGkBnkoOxrTVBMKw==",
+			"version": "18.19.69",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.69.tgz",
+			"integrity": "sha512-ECPdY1nlaiO/Y6GUnwgtAAhLNaQ53AyIVz+eILxpEo5OvuqE6yWkqWBIb5dU0DqhKQtMeny+FBD3PK6lm7L5xQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.14",
 		"@types/mocha": "^10.0.10",
-		"@types/node": "^18.19.68",
+		"@types/node": "^18.19.69",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.18",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                      18.19.68          18.19.69           22.10.5  node_modules/@types/node              vscode-openshift-tools
...
```