### PR TITLE
[build] Remove outdated 'setup-xvfb' action usage

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -40,13 +40,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Run tests
-      - name: Build and Test
-        uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a #v1.0.1
+      # Run tests without xvfb, if not running on ubuntu
+      - name: Build and Test (non-Linux)
+        if: (success() || failure()) && runner.os != 'Linux'
+        env:
+          NODE_OPTIONS: --max_old_space_size=16384
+        run: npm run test:coverage --silent
+
+      # Run tests directly running xvfb, if running on ubuntu
+      - name: Build and Test (Linux)
+        if: (success() || failure()) && runner.os == 'Linux'
         env:
             NODE_OPTIONS: --max_old_space_size=16384
-        with:
-          run: npm run test:coverage --silent
+        run: xvfb-run npm run test:coverage --silent
 
       - uses: engineerd/setup-kind@v0.6.2
         if: (success() || failure()) && runner.os == 'Linux'
@@ -72,21 +78,16 @@ jobs:
       # UI tests fail under linux
       # Run UI tests
       - name: Run UI Tests
-        uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a #v1.0.1
         env:
             NODE_OPTIONS: --max_old_space_size=16384
         if: runner.os == 'Linux'
-        with:
-          run: npm run public-ui-test
-          options: -screen 0 1920x1080x24
+        run: xvfb-run --server-args="-screen 0 1920x1080x24" npm run public-ui-test
 
       - name: Build and run integration tests
         if: (success() || failure()) && runner.os == 'Linux'
-        uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a #v1.0.1
         env:
           NODE_OPTIONS: --max_old_space_size=16384
-        with:
-          run: npm run test-integration:coverage --silent
+        run: xvfb-run npm run test-integration:coverage --silent
 
       # Archiving integration tests artifacts
       - name: Upload test artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,8 @@ jobs:
           npm install
           echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
       - name: Build And Run Unit Tests
-        uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a #v1.0.1
-        with:
-          run: npm run test
+        run: xvfb-run npm run test
+
       - name: Package
         run: |
           node ./out/build/update-readme.js


### PR DESCRIPTION
GitHub Actions (ubuntu) ships with xvfb, so the 'setup-xvfb' action is no longer needed. See: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md