### PR TITLE
Cannot login to existing cluster #3935

### DIFF
--- a/package.json
+++ b/package.json
@@ -2226,6 +2226,11 @@
 					"openshiftToolkit.disable-namespace-info-status-bar": {
 						"type": "boolean",
 						"description": "Disable displaying the active namespace in VS Code's status bar."
+					},
+					"openshiftToolkit.failOnBrokenKubeConfigEntry": {
+						"type": "boolean",
+						"default": false,
+						"description": "Fail on broken Kube config entry"
 					}
 				}
 			},

--- a/src/util/kubeUtils.ts
+++ b/src/util/kubeUtils.ts
@@ -4,10 +4,10 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { KubeConfig, findHomeDir, loadYaml } from '@kubernetes/client-node';
-import { Cluster, Context, User } from '@kubernetes/client-node/dist/config_types';
+import { ActionOnInvalid, Cluster, Context, User } from '@kubernetes/client-node/dist/config_types';
 import * as fs from 'fs';
 import * as path from 'path';
-import { QuickPickItem, window } from 'vscode';
+import { QuickPickItem, window, workspace } from 'vscode';
 import { CommandText } from '../base/command';
 import { CliChannel, ExecutionContext } from '../cli';
 import { Platform } from './platform';
@@ -27,8 +27,11 @@ export class KubeConfigUtils extends KubeConfig {
     constructor() {
         super();
         try {
-            this.loadFromDefault();
-        } catch {
+            const failOnBrokenEntry: boolean = workspace.getConfiguration('openshiftToolkit')
+                .get('failOnBrokenKubeConfigEntry');
+            const onInvalidEntry = failOnBrokenEntry ? ActionOnInvalid.THROW : ActionOnInvalid.FILTER;
+            this.loadFromDefault({onInvalidEntry});
+         } catch {
             throw new Error('Kubernetes configuration cannot be loaded. Please check configuration files for errors and fix them to continue.');
         }
         // k8s nodejs-client ignores all unknown properties,


### PR DESCRIPTION
The `openshiftToolkit.failOnBrokenKubeConfigEntry` (boolean) option is added with the
default set to `false` in order to make Kube config loading more robust.
If it's required to fully check the correctness of the Kube config on startup, users can
set its value to `true`, so Kubernetes Client will throw errors if any.

Fixes: #3935