### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.15",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^18.19.69",
+				"@types/node": "^18.19.74",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.18",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3722,9 +3722,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.69",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.69.tgz",
-			"integrity": "sha512-ECPdY1nlaiO/Y6GUnwgtAAhLNaQ53AyIVz+eILxpEo5OvuqE6yWkqWBIb5dU0DqhKQtMeny+FBD3PK6lm7L5xQ==",
+			"version": "18.19.74",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.74.tgz",
+			"integrity": "sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.15",
 		"@types/mocha": "^10.0.10",
-		"@types/node": "^18.19.69",
+		"@types/node": "^18.19.74",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.18",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                      18.19.69          18.19.74           22.12.0  node_modules/@types/node              vscode-openshift-tools
...
```