### PR TITLE
Fix code scanning alert no. 32: Client-side cross-site scripting

### DIFF
--- a/src/webview/helm-chart/app/helmListItem.tsx
+++ b/src/webview/helm-chart/app/helmListItem.tsx
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 import { Box, Button, Chip, Link, Stack, SvgIcon, Tooltip, Typography } from '@mui/material';
+import DOMPurify from 'dompurify';
 import * as React from 'react';
 import HelmIcon from '../../../../images/helm/helm.svg';
 import { Chart, ChartResponse } from '../../../helm/helmChartType';
@@ -97,7 +98,7 @@ function HelmChartListContent(props: HelmListItemProps) {
             >
                 {
                     props.selectedVersion.icon ?
-                        <img src={props.selectedVersion.icon} style={{
+                        <img src={DOMPurify.sanitize(props.selectedVersion.icon)} style={{
                             maxWidth: !props.isDetailedPage ? '3em' : '6em',
                             maxHeight: !props.isDetailedPage ? '3em' : '6em'
                         }} />


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-developer/vscode-openshift-tools/security/code-scanning/32](https://github.com/redhat-developer/vscode-openshift-tools/security/code-scanning/32)

To fix the problem, we need to ensure that the `props.selectedVersion.icon` value is properly sanitized before being used as the `src` attribute of an `img` tag. One way to achieve this is by using a library like `DOMPurify` to sanitize the URL. This will help prevent any malicious scripts from being executed.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the relevant file.
3. Use `DOMPurify` to sanitize the `props.selectedVersion.icon` value before using it in the `img` tag.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
