### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.15",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^18.19.75",
+				"@types/node": "^18.19.76",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.18",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3907,9 +3907,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.75",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.75.tgz",
-			"integrity": "sha512-UIksWtThob6ZVSyxcOqCLOUNg/dyO1Qvx4McgeuhrEtHTLFTf7BBhEazaE4K806FGTPtzd/2sE90qn4fVr7cyw==",
+			"version": "18.19.76",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.76.tgz",
+			"integrity": "sha512-yvR7Q9LdPz2vGpmpJX5LolrgRdWvB67MJKDPSgIIzpFbaf9a1j/f5DnLp5VDyHGMR0QZHlTr1afsD87QCXFHKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.15",
 		"@types/mocha": "^10.0.10",
-		"@types/node": "^18.19.75",
+		"@types/node": "^18.19.76",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.18",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                      18.19.75          18.19.76           22.13.4  node_modules/@types/node              vscode-openshift-tools
...
```