### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.16",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^18.19.78",
+				"@types/node": "^18.19.79",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.18",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3908,9 +3908,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.78",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.78.tgz",
-			"integrity": "sha512-m1ilZCTwKLkk9rruBJXFeYN0Bc5SbjirwYX/Td3MqPfioYbgun3IvK/m8dQxMCnrPGZPg1kvXjp3SIekCN/ynw==",
+			"version": "18.19.79",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.79.tgz",
+			"integrity": "sha512-90K8Oayimbctc5zTPHPfZloc/lGVs7f3phUAAMcTgEPtg8kKquGZDERC8K4vkBYkQQh48msiYUslYtxTWvqcAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.16",
 		"@types/mocha": "^10.0.10",
-		"@types/node": "^18.19.78",
+		"@types/node": "^18.19.79",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.18",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                      18.19.78          18.19.79           22.13.9  node_modules/@types/node              vscode-openshift-tools
...
```