### PR TITLE
[tests] Use Mocha's built-in 'spec' reporter for better test results …

### DIFF
--- a/build/run-tests.ts
+++ b/build/run-tests.ts
@@ -18,6 +18,21 @@ async function main(): Promise<void> {
     const extensionTestsPath = path.resolve(extensionRootPath, 'out', 'test', tests);
     const integrationWorkspacePath = path.resolve(extensionRootPath, 'test', 'fixtures', 'components', 'components.code-workspace');
     const unitTestWorkspacePath = path.resolve(extensionRootPath, 'test', 'fixtures', 'components', 'empty.code-workspace');
+
+    // On some environments, the Mocha reporters do not make amy output to the console when running tests locally if
+    // tests are invoked without '--verbose' argument. Set the VERBOSE environment variable to any positive boolean value ('true', or 'yes')
+    // before running the tests to make tests to report to the console, for example:
+    // ```
+    // $ export VERBOSE=true
+    // $ npm test
+    // ```
+    // or
+    // ```
+    // $ VERBOSE=yes npm test
+    // ```
+    //
+    const boolPattern = /^(true|1|yes)$/i;
+    const verbose = boolPattern.test(process.env.VERBOSE);
     try {
         await etest.runTests({
             extensionDevelopmentPath,
@@ -25,6 +40,7 @@ async function main(): Promise<void> {
             launchArgs: [
                 tests === 'integration' ? integrationWorkspacePath : unitTestWorkspacePath,
                 '--disable-workspace-trust',
+                verbose ? '--verbose' : ''
             ],
         });
     } catch (err) {

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -13,7 +13,14 @@ import { CoverageRunner, TestRunnerOptions } from '../coverage';
 sourceMapSupport.install();
 
 const config: Mocha.MochaOptions = {
-    reporter: 'xunit',
+    // Previously used reporter ('mocha-jenkins-reporter') has been removed as deprecated.
+    // We're currently not using Jenkins, but if needed, it's probably better to use `xunit` reporter instead
+    // when we're testing on Jenkins. Also, probably this will need an adoption on how the test report is to be
+    // stored on Jenkins (something like `reporterOptions: { output: 'report.xml' }` is to be added to MochaOptions
+    // in order to output xunit results to the file to be processed on Jenkins).
+    //
+    // reporter: process.env.JUNIT_REPORT_PATH ? 'mocha-jenkins-reporter' : 'spec',
+    reporter: 'spec',
     ui: 'tdd',
     timeout: 120000,
     color: true,

--- a/test/ui/.mocharc.js
+++ b/test/ui/.mocharc.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = {
-    reporter: process.env.JUNIT_REPORT_PATH ? 'xunit' : 'spec',
+    reporter: 'spec',
     timeout: 7000,
 };

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -14,7 +14,7 @@ sourceMapSupport.install();
 
 
 const config: Mocha.MochaOptions = {
-    reporter: 'xunit',
+    reporter: 'spec',
     ui: 'tdd',
     timeout: 60000,
     color: true,

--- a/test/vsix-test/index.ts
+++ b/test/vsix-test/index.ts
@@ -9,7 +9,7 @@ import Mocha from 'mocha';
 import * as paths from 'path';
 
 const config: Mocha.MochaOptions = {
-    reporter: 'xunit',
+    reporter: 'spec',
     ui: 'tdd',
     timeout: 15000,
     color: true


### PR DESCRIPTION
…output...

... instead of 'xunit' and outdated 'mocha-jenkins-reporter'.

Also this PR adds a possibility to use `VERBOSE` (boolean) environment variable to force the output of the test results to console when executing the tests locally, f.e.:

```
$ VERBOSE=yes npm test
```