### PR TITLE
[build] Update dependency overrides to the latest available versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
 				"rxjs": "^7.8.2",
 				"semver": "^7.7.1",
 				"showdown": "^2.1.0",
-				"shx": "^0.3.3",
+				"shx": "^0.3.4",
 				"sinon": "^19.0.2",
 				"sinon-chai": "^3.7.0",
 				"source-map-support": "^0.5.21",
@@ -6466,9 +6466,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.1.tgz",
-			"integrity": "sha512-Xd8lFX4LM9QEEwxQpF9J9NTUh8pmdJO0cyRJhFiDoLTk2eH8FXlRv2IFGYVadZpqI3j8fhNrSdKCeYPxiAhLXw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+			"integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9157,9 +9157,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "15.14.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
-			"integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
+			"integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15561,9 +15561,9 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
-			"integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
 		"rxjs": "^7.8.2",
 		"semver": "^7.7.1",
 		"showdown": "^2.1.0",
-		"shx": "^0.3.3",
+		"shx": "^0.3.4",
 		"sinon": "^19.0.2",
 		"sinon-chai": "^3.7.0",
 		"source-map-support": "^0.5.21",
@@ -195,10 +195,10 @@
 		"xterm-headless": "^5.3.0"
 	},
 	"overrides": {
-		"cookie": "^1.0.1",
+		"cookie": "^1.0.2",
 		"cross-spawn": "^7.0.6",
-		"tough-cookie": "^5.0.0",
-		"globals": "^15.14.0"
+		"tough-cookie": "^5.1.2",
+		"globals": "^16.0.0"
 	},
 	"activationEvents": [
 		"onView:openshiftProjectExplorer",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available versions:
- shx
- cookie
- tough-cookie
- globals