### PR TITLE
[tests] Update Kind to 0.24.0

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -58,7 +58,7 @@ jobs:
         if: (success() || failure()) && runner.os == 'Linux'
         name: Start cluster
         with:
-          version: v0.20.0
+          version: v0.24.0
 
       - name: Configure cluster
         if: (success() || failure()) && runner.os == 'Linux'


### PR DESCRIPTION
The 'engineerd/setup-kind@v0.6.2' Github Action reports:
```
Warning: Kind v0.24.0 is available, have you considered using it ? See https://github.com/kubernetes-sigs/kind/releases/tag/v0.24.0
```