### PR TITLE
[build] Fix vulnerability in @babel/helpers and @babel/runtime <7.26.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -358,13 +358,15 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+			"version": "7.26.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.22.13",
-				"chalk": "^2.4.2"
+				"@babel/helper-validator-identifier": "^7.25.9",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -551,9 +553,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+			"integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -561,10 +563,11 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -578,37 +581,28 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.22.6",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+			"integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.22.5",
-				"@babel/traverse": "^7.22.6",
-				"@babel/types": "^7.22.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
+				"@babel/template": "^7.26.9",
+				"@babel/types": "^7.26.10"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+			"integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.26.10"
+			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -617,10 +611,11 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-			"integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+			"integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -629,14 +624,15 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"version": "7.26.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+			"integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/code-frame": "^7.26.2",
+				"@babel/parser": "^7.26.9",
+				"@babel/types": "^7.26.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -664,14 +660,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+			"integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -15491,16 +15487,6 @@
 			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",


### PR DESCRIPTION
```
$ npm audit report

@babel/helpers  <7.26.10
Severity: moderate
Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups - https://github.com/advisories/GHSA-968p-4wvh-cqc8
fix available via `npm audit fix`
node_modules/@babel/helpers

@babel/runtime  <7.26.10
Severity: moderate
Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups - https://github.com/advisories/GHSA-968p-4wvh-cqc8
fix available via `npm audit fix`
node_modules/@babel/runtime
```