### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
 				"@types/mocha": "^10.0.10",
 				"@types/node": "^18.19.80",
 				"@types/proxyquire": "^1.3.31",
-				"@types/react": "^18.3.18",
+				"@types/react": "^18.3.19",
 				"@types/react-copy-to-clipboard": "^5.0.7",
 				"@types/react-dom": "^18.3.5",
 				"@types/semver": "^7.5.8",
@@ -4020,9 +4020,9 @@
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.18",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-			"integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+			"version": "18.3.19",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.19.tgz",
+			"integrity": "sha512-fcdJqaHOMDbiAwJnXv6XCzX0jDW77yI3tJqYh1Byn8EL5/S628WRx9b/y3DnNe55zTukUQKrfYxiZls2dHcUMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^18.19.80",
 		"@types/proxyquire": "^1.3.31",
-		"@types/react": "^18.3.18",
+		"@types/react": "^18.3.19",
 		"@types/react-copy-to-clipboard": "^5.0.7",
 		"@types/react-dom": "^18.3.5",
 		"@types/semver": "^7.5.8",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/react                      18.3.18           18.3.19           19.0.12  node_modules/@types/react             vscode-openshift-tools
...
```