### PR TITLE
[build] Use Node.js v20 engine as minimum version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ There are only a few guidelines that we need contributors to follow.
 ## First Time Setup
 1. Install prerequisites:
    * latest [Visual Studio Code](https://code.visualstudio.com/)
-   * [Node.js](https://nodejs.org/) v18.17.0 or higher
+   * [Node.js](https://nodejs.org/) v20 or higher
      * It is recommended to set up `nvm` to manage different versions of node, which can be installed by following the instructions [here](https://github.com/nvm-sh/nvm#installing-and-updating).
      * To use the current recommended version for this project (in`./nvmrc`), run `nvm use`.
    * [Red Hat Authentication](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-redhat-account) VS Code plugin (VS Code will prompt to install this when you launch the extension if you don't have it)

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"@types/git-url-parse": "^9.0.3",
 				"@types/lodash": "^4.17.16",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^18.19.85",
+				"@types/node": "^20.14.8",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.20",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -130,8 +130,8 @@
 				"xterm-headless": "^5.3.0"
 			},
 			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">=8.6.0",
+				"node": ">=20.0.0",
+				"npm": ">=9.6.4",
 				"vscode": "^1.82.3"
 			}
 		},
@@ -3953,13 +3953,13 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.19.85",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.85.tgz",
-			"integrity": "sha512-61sLB7tXUMpkHJagZQAzPV4xGyqzulLvphe0lquRX80rZG24VupRv9p6Qo06V9VBNeGBM8Sv8rRVVLji6pi7QQ==",
+			"version": "20.17.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.29.tgz",
+			"integrity": "sha512-6rbekrnsa5WWCo5UnPYEKfNuoF2yqAmigUKXM8wBzfEbZc+E/CITqjCrHqiq+6QBifsw0ZDaA5VdTFONOtG7+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.19.2"
 			}
 		},
 		"node_modules/@types/node-fetch": {
@@ -4144,6 +4144,23 @@
 			"dependencies": {
 				"@types/node": "^18.11.18"
 			}
+		},
+		"node_modules/@types/ssh2/node_modules/@types/node": {
+			"version": "18.19.85",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.85.tgz",
+			"integrity": "sha512-61sLB7tXUMpkHJagZQAzPV4xGyqzulLvphe0lquRX80rZG24VupRv9p6Qo06V9VBNeGBM8Sv8rRVVLji6pi7QQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/@types/ssh2/node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/tar-fs": {
 			"version": "2.0.1",
@@ -16005,10 +16022,11 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unfetch": {
 			"version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 	"bugs": "https://github.com/redhat-developer/vscode-openshift-tools/issues",
 	"engines": {
 		"vscode": "^1.82.3",
-		"npm": ">=8.6.0",
-		"node": ">=18.0.0"
+		"npm": ">=9.6.4",
+		"node": ">=20.0.0"
 	},
 	"badges": [
 		{
@@ -100,7 +100,7 @@
 		"@types/git-url-parse": "^9.0.3",
 		"@types/lodash": "^4.17.16",
 		"@types/mocha": "^10.0.10",
-		"@types/node": "^18.19.85",
+		"@types/node": "^20.14.8",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.20",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The reasons:
- The mainenance of Node.js v18 (LTS) ends 2025-04-30, so it's time to update the engine
- A lot of used dependencies declare Node.js v20 as minimum version, it doesn't make sence to continue using v18 as minimum Node.js engine version, f.i.:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'glob@11.0.1',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v18.17.1', npm: '9.6.7' }
npm WARN EBADENGINE }
...
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'path-scurry@2.0.0',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v18.17.1', npm: '9.6.7' }
npm WARN EBADENGINE }
...
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'lru-cache@11.0.0',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v18.17.1', npm: '9.6.7' }
npm WARN EBADENGINE }
```