### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@types/fs-extra": "^11.0.4",
 				"@types/lodash": "^4.17.16",
 				"@types/mocha": "^10.0.10",
-				"@types/node": "^20.17.30",
+				"@types/node": "^20.17.31",
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.20",
 				"@types/react-copy-to-clipboard": "^5.0.7",
@@ -3943,9 +3943,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.17.30",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-			"integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
+			"version": "20.17.31",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.31.tgz",
+			"integrity": "sha512-quODOCNXQAbNf1Q7V+fI8WyErOCh0D5Yd31vHnKu4GkSztGQ7rlltAaqXhHhLl33tlVyUXs2386MkANSwgDn6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"@types/fs-extra": "^11.0.4",
 		"@types/lodash": "^4.17.16",
 		"@types/mocha": "^10.0.10",
-		"@types/node": "^20.17.30",
+		"@types/node": "^20.17.31",
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.20",
 		"@types/react-copy-to-clipboard": "^5.0.7",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/node                                       20.17.30                           20.17.31           22.15.2  node_modules/@types/node              vscode-openshift-tools
...
```