### PR TITLE
[build] Update to the latest available 'wanted' dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"@types/proxyquire": "^1.3.31",
 				"@types/react": "^18.3.20",
 				"@types/react-copy-to-clipboard": "^5.0.7",
-				"@types/react-dom": "^18.3.6",
+				"@types/react-dom": "^18.3.7",
 				"@types/semver": "^7.7.0",
 				"@types/shelljs": "^0.8.15",
 				"@types/sinon": "^17.0.4",
@@ -4021,9 +4021,9 @@
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "18.3.6",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.6.tgz",
-			"integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
+			"version": "18.3.7",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"@types/proxyquire": "^1.3.31",
 		"@types/react": "^18.3.20",
 		"@types/react-copy-to-clipboard": "^5.0.7",
-		"@types/react-dom": "^18.3.6",
+		"@types/react-dom": "^18.3.7",
 		"@types/semver": "^7.7.0",
 		"@types/shelljs": "^0.8.15",
 		"@types/sinon": "^17.0.4",


### PR DESCRIPTION
The PR updates the following NPM dependencies to their latest available "wanted" versions:

```
$ npm outdated
Package                                  Current                  Wanted                  Latest  Location                               Depended by
...
@types/react-dom                                    18.3.6                             18.3.7            19.1.3  node_modules/@types/react-dom         vscode-openshift-tools
...
```