### PR TITLE
[build] Fix vulnerability in brace-expansion >=2.0.1 <=4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,15 +2011,6 @@
 				"openid-client": "^6.1.3"
 			}
 		},
-		"node_modules/@kubernetes/client-node/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/@kubernetes/client-node/node_modules/chownr": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -4467,16 +4458,6 @@
 				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -5917,11 +5898,14 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-3.0.1.tgz",
+			"integrity": "sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			}
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -6036,14 +6020,16 @@
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.1.tgz",
+			"integrity": "sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/braces": {
@@ -6793,13 +6779,6 @@
 				"validate.io-integer-array": "^1.0.0"
 			}
 		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/content-disposition": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -7436,15 +7415,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/dpdm/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/dpdm/node_modules/chalk": {
@@ -9413,15 +9383,6 @@
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"peer": true
-		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
 			"version": "10.0.1",
@@ -12010,15 +11971,6 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/mocha/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/mocha/node_modules/glob": {
@@ -15425,15 +15377,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/test-exclude/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,8 @@
 		"cross-spawn": "^7.0.6",
 		"globals": "^16.0.0",
 		"tough-cookie": "^5.1.2",
-		"tar-fs": "^2.1.2"
+		"tar-fs": "^2.1.2",
+		"brace-expansion": "^4.0.1"
 	},
 	"activationEvents": [
 		"onView:openshiftProjectExplorer",


### PR DESCRIPTION
```
> npm audit report

brace-expansion  2.0.1 - 4.0.0
brace-expansion Regular Expression Denial of Service vulnerability - https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
No fix available
node_modules/@kubernetes/client-node/node_modules/brace-expansion
node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion
node_modules/dpdm/node_modules/brace-expansion
node_modules/glob/node_modules/brace-expansion
node_modules/mocha/node_modules/brace-expansion
node_modules/test-exclude/node_modules/brace-expansion
  minimatch  5.0.0 - 9.0.5 || >=10.0.1
  Depends on vulnerable versions of brace-expansion
  node_modules/@kubernetes/client-node/node_modules/minimatch
  node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch
  node_modules/dpdm/node_modules/minimatch
  node_modules/glob/node_modules/minimatch
  node_modules/mocha/node_modules/minimatch
  node_modules/test-exclude/node_modules/minimatch
    @typescript-eslint/typescript-estree  >=6.16.0
    Depends on vulnerable versions of minimatch
    node_modules/@typescript-eslint/typescript-estree
      @typescript-eslint/parser  >=6.16.0
      Depends on vulnerable versions of @typescript-eslint/typescript-estree
      node_modules/@typescript-eslint/parser
        @typescript-eslint/eslint-plugin  >=6.16.0
        Depends on vulnerable versions of @typescript-eslint/parser
        Depends on vulnerable versions of @typescript-eslint/type-utils
        Depends on vulnerable versions of @typescript-eslint/utils
        node_modules/@typescript-eslint/eslint-plugin
          typescript-eslint  *
          Depends on vulnerable versions of @typescript-eslint/eslint-plugin
          Depends on vulnerable versions of @typescript-eslint/parser
          Depends on vulnerable versions of @typescript-eslint/utils
          node_modules/typescript-eslint
      @typescript-eslint/type-utils  >=6.16.0
      Depends on vulnerable versions of @typescript-eslint/typescript-estree
      Depends on vulnerable versions of @typescript-eslint/utils
      node_modules/@typescript-eslint/type-utils
      @typescript-eslint/utils  >=6.16.0
      Depends on vulnerable versions of @typescript-eslint/typescript-estree
      node_modules/@typescript-eslint/utils
    glob  8.0.1 - 10.4.5
    Depends on vulnerable versions of minimatch
    node_modules/@kubernetes/client-node/node_modules/glob
    node_modules/dpdm/node_modules/glob
    node_modules/mocha/node_modules/glob
    node_modules/test-exclude/node_modules/glob
      dpdm  >=3.10.0
      Depends on vulnerable versions of glob
      node_modules/dpdm
      mocha  >=10.0.0
      Depends on vulnerable versions of glob
      Depends on vulnerable versions of minimatch
      node_modules/mocha
      rimraf  4.2.0 - 5.0.10
      Depends on vulnerable versions of glob
      node_modules/@kubernetes/client-node/node_modules/rimraf
        minizlib  3.0.0 - 3.0.1
        Depends on vulnerable versions of rimraf
        node_modules/@kubernetes/client-node/node_modules/minizlib
    test-exclude  >=7.0.0
    Depends on vulnerable versions of glob
    Depends on vulnerable versions of minimatch
    node_modules/test-exclude
      c8  >=10.0.0
      Depends on vulnerable versions of test-exclude
      node_modules/c8
        vscode-extension-tester  >=8.3.0
        Depends on vulnerable versions of c8
        node_modules/vscode-extension-tester
```