### PR TITLE
[deps] Undo the last DB config changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  allow:
-    - dependency-type: "direct"
-  versioning-strategy: increase
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: "@types/node"


### PR DESCRIPTION
The "auto" DB update strategy still looks working much better than when "increase" and "direct" are forced. We don't need to bump transitive deps unless there is a security issue, while using "increase" makes it to update all kind of deps.