### PR TITLE
Devfile Registries list need not contain Default Devfile Registry.

### DIFF
--- a/src/odo/odoPreference.ts
+++ b/src/odo/odoPreference.ts
@@ -120,16 +120,11 @@ export class OdoPreference {
             const odoPreferenceFile = await fs.readFile(odoPreferenceFilePath, 'utf8');
             const odoPreferences = parse(odoPreferenceFile) as OdoPreferenceObject;
 
-            // If `odoPreferences.OdoSettings.RegistryList` is `null` or doesn't contain the `DefaultDevfileRegistry` item
-            // we have to recover at least the 'DefaultDevfileRegistry` item on it because this whole list will be replaced
-            if (!odoPreferences.OdoSettings.RegistryList) {
+            // If `odoPreferences.OdoSettings.RegistryList` is `null` or doesn't contain any registry item
+            // we should recover the 'DefaultDevfileRegistry` item on it
+            if (!odoPreferences.OdoSettings.RegistryList || odoPreferences.OdoSettings.RegistryList.length === 0) {
                 odoPreferences.OdoSettings.RegistryList = OdoPreference.DefaultOdoPreference.OdoSettings.RegistryList;
                 isToBeReWritten = true;
-            } else {
-                if (!odoPreferences.OdoSettings.RegistryList.find((r) => r.Name === OdoPreference.DEFAULT_DEVFILE_REGISTRY_NAME)) {
-                    odoPreferences.OdoSettings.RegistryList.push(OdoPreference.DefaultOdoPreference.OdoSettings.RegistryList[0]);
-                    isToBeReWritten = true;
-                }
             }
 
             mergedPreference = { ...mergedPreference, ...odoPreferences };


### PR DESCRIPTION
- When the Devfile Registries list contains other registries, it should be permitted to remove the Default Devfile Registry
- Replace usage of https.get(..) with fetch


- [ ] Need to test this more thoroughly
- [x] I can probably adjust https://github.com/redhat-developer/vscode-openshift-tools/blob/0ceadd98c8fc5e5d61e01ebf786a182fc6cd3045/src/openshift/cluster.ts#L671 as well