### PR TITLE
Release 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.21.1 (November 4, 2025)
+
+ * [#5453](https://github.com/redhat-developer/vscode-openshift-tools/issues/5453) Remove Git URL validation to support non-standard git repository locations
+
 ## 1.21.0 (September 22, 2025)
 
  * [#5361](https://github.com/redhat-developer/vscode-openshift-tools/pull/5361) Devfile Registries list needs not contain Default Devfile Registry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-openshift-connector",
-	"version": "1.21.0",
+	"version": "1.21.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-openshift-connector",
-			"version": "1.21.0",
+			"version": "1.21.1",
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-openshift-connector",
 	"displayName": "OpenShift Toolkit",
 	"description": "Fast iterative application development on Red Hat OpenShift and Kubernetes",
-	"version": "1.21.0",
+	"version": "1.21.1",
 	"license": "MIT",
 	"publisher": "redhat",
 	"author": "Red Hat",


### PR DESCRIPTION
Update CRC CLI to 2.55.1 by @github-actions in https://github.com/redhat-developer/vscode-openshift-tools/pull/5434
Update OC CLI to 4.20.0 by @github-actions in https://github.com/redhat-developer/vscode-openshift-tools/pull/5432
Update FUNC CLI to 1.19.5 by @github-actions in https://github.com/redhat-developer/vscode-openshift-tools/pull/5451
Update ODO CLI to 3.16.1 (8e8b56891-nightly) by @github-actions in https://github.com/redhat-developer/vscode-openshift-tools/pull/5441

@vrubezhny , I noticed the dependency updates aren't in the CHANGELOG but are included in the release notes so I've included them above.