### PR TITLE
Fix the "Debug UI Tests" launch configuration.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -84,50 +84,22 @@
             "request": "launch",
             "program": "${workspaceFolder}/node_modules/.bin/extest",
             "args": [
-                "setup-and-run",
-                "${workspaceFolder}/out/test/ui/public-ui-test.js",
-                "-o",
-                "${workspaceFolder}/test/ui/settings.json",
-                "-m",
-                "${workspaceFolder}/test/ui/.mocharc.js",
-                "-c",
-                "max",
-                "-e",
-                "./test-resources/extensions",
-                "-i"
-            ],
-            "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
-            ],
-            "sourceMaps": true,
-            "preLaunchTask": "compile",
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "env": {
-                "NODE_OPTIONS": "--max_old_space_size=4096"
-            }
-        },
-        {
-            "name": "Debug UI Tests (Fast)",
-            "type": "node",
-            "request": "launch",
-            "program": "${workspaceFolder}/node_modules/.bin/extest",
-            "args": [
                 "run-tests",
                 "${workspaceFolder}/out/test/ui/public-ui-test.js",
                 "-o",
                 "${workspaceFolder}/test/ui/settings.json",
                 "-m",
-                "--mocha_config",
                 "${workspaceFolder}/test/ui/.mocharc.js",
                 "-e",
-                "./test-resources/extensions"
+                "${workspaceFolder}/test-resources/extensions",
+                "-c",
+                "max"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
             ],
             "sourceMaps": true,
-            "preLaunchTask": "compile",
+            "preLaunchTask": "setup-tests",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -45,6 +45,15 @@
             },
         },
         {
+            "label": "setup-tests",
+            "type": "shell",
+            "command": "${workspaceFolder}/node_modules/.bin/extest setup-tests -e ${workspaceFolder}/test-resources/extensions -c max -i && npm run test:prepare",
+            "problemMatcher": "$tsc",
+            "presentation": {
+                "reveal": "silent",
+            },
+        },
+        {
             "label": "instrument",
             "type": "shell",
             "command": ["${workspaceFolder}/node_modules/.bin/shx rm -rf ${workspaceFolder}/out/src-orig && ${workspaceFolder}/node_modules/.bin/shx mv ${workspaceFolder}/out/src ${workspaceFolder}/out/src-orig && ${workspaceFolder}/node_modules/.bin/istanbul instrument --complete-copy --embed-source --output out/src out/src-orig"],


### PR DESCRIPTION
- The `Debug UI Tests` & `Debug UI Tests (Fast)` are currently broken. This PR fixes them.

One still needs to run `npm install` prior to using them but this was always the case for nearly all commands. I've removed the "Fast" configuration because that can just be achieved now by commenting out the `preLaunchTask`. It only needs to be run once per "session" assuming dependencies/underlying extension code isn't changing.