### PR TITLE
[build] Fix vulnerability in uuid < 14.0.0

### DIFF
--- a/build/esbuild.settings.cjs
+++ b/build/esbuild.settings.cjs
@@ -23,6 +23,7 @@ const webviews = [
 const esmImportTargets = {
   'clipboardy': { entry: 'node_modules/clipboardy/index.js', outfile: 'out/esm/clipboardy.cjs' },
   'got': { entry: 'node_modules/got/dist/source/index.js', outfile: 'out/esm/got.cjs' },
+  'uuid': { entry: 'node_modules/uuid/dist/index.js', outfile: 'out/esm/uuid.cjs' },
   '@kubernetes/client-node': { entry: 'node_modules/@kubernetes/client-node/dist/index.js', outfile: 'out/esm/k8s-client-node.cjs' },
   '@apidevtools/json-schema-ref-parser': { entry: 'node_modules/@apidevtools/json-schema-ref-parser/dist/lib/index.js', outfile: 'out/esm/apidevtools-json-schema-ref-parser.cjs' }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3031,19 +3031,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/@redhat-developer/vscode-redhat-telemetry/node_modules/uuid": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
-			"integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"bin": {
-				"uuid": "dist/esm/bin/uuid"
-			}
-		},
 		"node_modules/@rjsf/core": {
 			"version": "5.24.13",
 			"resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.24.13.tgz",
@@ -18470,13 +18457,17 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -200,7 +200,8 @@
 		"tough-cookie": "^6.0.1",
 		"tar-fs": "^3.1.2",
 		"diff": "^8.0.3",
-		"serialize-javascript": "^7.0.5"
+		"serialize-javascript": "^7.0.5",
+		"uuid": "^14.0.0"
 	},
 	"activationEvents": [
 		"onView:openshiftProjectExplorer",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "clipboardy": [ "out/esm/clipboardy.cjs" ],
       "got": [ "out/esm/got.cjs" ],
+      "uuid": [ "out/esm/uuid.cjs"],
       "@kubernetes/client-node": [ "out/esm/k8s-client-node.cjs" ],
       "@apidevtools/json-schema-ref-parser": [ "out/esm/apidevtools-json-schema-ref-parser.cjs" ]
     },


### PR DESCRIPTION
```
npm audit report

uuid  <14.0.0
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
fix available via `npm audit fix --force`
Will install @redhat-developer/vscode-redhat-telemetry@0.0.3, which is a breaking change
node_modules/@redhat-developer/vscode-redhat-telemetry/node_modules/uuid
node_modules/uuid
  @azure/msal-node  <=5.1.4
  Depends on vulnerable versions of uuid
  node_modules/@azure/msal-node
  @redhat-developer/vscode-redhat-telemetry  >=0.0.5
  Depends on vulnerable versions of uuid
  node_modules/@redhat-developer/vscode-redhat-telemetry
```

Fixes: https://github.com/redhat-developer/vscode-openshift-tools/security/dependabot/155