### PR TITLE
[build] Fix vulnerability in js-cookie <=3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11925,13 +11925,13 @@
 			}
 		},
 		"node_modules/js-cookie": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-			"integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+			"integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
 			}
 		},
 		"node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
 		"cookie": "^1.1.1",
 		"cross-spawn": "^7.0.6",
 		"globals": "^17.4.0",
+		"js-cookie": "^3.0.7",
 		"tough-cookie": "^6.0.1",
 		"tar-fs": "^3.1.2",
 		"diff": "^8.0.3",


### PR DESCRIPTION
```
$ npm audit report

js-cookie  <=3.0.5
Severity: high
JavaScript Cookie: Per-instance prototype hijack in assign() enables cookie-attribute injection - https://github.com/advisories/GHSA-qjx8-664m-686j
No fix available
node_modules/js-cookie
  @segment/analytics-next  *
  Depends on vulnerable versions of js-cookie
  node_modules/@segment/analytics-next
```

Fixes: https://github.com/redhat-developer/vscode-openshift-tools/security/dependabot/169