### PR TITLE
[tests] Running Public UI tests using the latest ExTester supported vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 test/fixtures/workspace/.vscode/
 *.vsix
 coverage/
+.vscode-version
 toFile
 cache
 dist/

--- a/build/install-vscode.cjs
+++ b/build/install-vscode.cjs
@@ -7,6 +7,7 @@
 const testElectron = require('@vscode/test-electron');
 const { platform } = require('os');
 const cp = require('child_process');
+const fs = require('fs');
 const path = require('path');
 const packageJson = require('../package.json');
 
@@ -27,6 +28,12 @@ void testElectron.downloadAndUnzipVSCode().then((executable) => {
             )}'`;
         } else {
             vsCodeExecutable = path.join(path.dirname(executable), 'bin', 'code');
+        }
+
+        // Save VSCode executable version for ExTester
+        const match = executable.match(/(\d+\.\d+\.\d+)/);
+        if (match) {
+            fs.writeFileSync('.vscode-version', match[1]);
         }
 
         const extensionRootPath = path.resolve(__dirname, '..');

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "vscode-openshift-connector",
 			"version": "1.21.1",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.3.1",
@@ -92,6 +93,7 @@
 				"module-alias": "^2.3.4",
 				"node-yaml-parser": "^0.0.9",
 				"npm-run-all": "^4.1.5",
+				"patch-package": "^8.0.1",
 				"portfinder": "^1.0.38",
 				"prettier": "^3.8.3",
 				"pretty-bytes": "^7.1.0",
@@ -5823,6 +5825,13 @@
 			"license": "Apache-2.0",
 			"peer": true
 		},
+		"node_modules/@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/abbrev": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -7037,6 +7046,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/classnames": {
@@ -9846,6 +9871,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/find-yarn-workspace-root": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"micromatch": "^4.0.2"
+			}
+		},
 		"node_modules/flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -11141,6 +11176,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-extendable": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -12042,10 +12093,37 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-stable-stringify": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+			"integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"isarray": "^2.0.5",
+				"jsonify": "^0.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-stable-stringify/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12101,6 +12179,16 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+			"integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+			"dev": true,
+			"license": "Public Domain",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/jsonpath-plus": {
@@ -12317,6 +12405,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"node_modules/lcid": {
@@ -14261,6 +14359,167 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/patch-package": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+			"integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^3.7.0",
+				"cross-spawn": "^7.0.3",
+				"find-yarn-workspace-root": "^2.0.0",
+				"fs-extra": "^10.0.0",
+				"json-stable-stringify": "^1.0.2",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.6",
+				"open": "^7.4.2",
+				"semver": "^7.5.3",
+				"slash": "^2.0.0",
+				"tmp": "^0.2.4",
+				"yaml": "^2.2.2"
+			},
+			"bin": {
+				"patch-package": "index.js"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">5"
+			}
+		},
+		"node_modules/patch-package/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/patch-package/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/patch-package/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/patch-package/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/patch-package/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/patch-package/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/patch-package/node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/patch-package/node_modules/open": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/patch-package/node_modules/slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/patch-package/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -69,8 +69,9 @@
 		"test:coverage": "npm run test:prepare && npm run test:instrument && node ./build/install-vscode.cjs && node ./build/run-tests.cjs unit",
 		"test-integration": "npm run test:prepare && node ./build/run-tests.cjs integration",
 		"test-integration:coverage": "npm run test:prepare && npm run test:instrument && node ./build/run-tests.cjs integration",
-		"cluster-ui-test": "extest setup-tests -e ./test-resources/extensions -c max -i && npm run test:prepare && extest run-tests out/test/ui/cluster-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max",
-		"public-ui-test": "extest setup-tests -e ./test-resources/extensions -c max -i && npm run test:prepare && extest run-tests out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions -c max"
+		"postinstall": "patch-package",
+		"cluster-ui-test": ". test/ui/extester.env && extest setup-tests -e ./test-resources/extensions -i && npm run test:prepare && extest run-tests out/test/ui/cluster-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions",
+		"public-ui-test": ". test/ui/extester.env && extest setup-tests -e ./test-resources/extensions -i && npm run test:prepare && extest run-tests out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions"
 	},
 	"dependencies": {
 		"jsonc-parser": "^3.3.1",
@@ -156,6 +157,7 @@
 		"module-alias": "^2.3.4",
 		"node-yaml-parser": "^0.0.9",
 		"npm-run-all": "^4.1.5",
+		"patch-package": "^8.0.1",
 		"portfinder": "^1.0.38",
 		"prettier": "^3.8.3",
 		"pretty-bytes": "^7.1.0",

--- a/patches/vscode-extension-tester+8.23.0.patch
+++ b/patches/vscode-extension-tester+8.23.0.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/vscode-extension-tester/out/browser.js b/node_modules/vscode-extension-tester/out/browser.js
+index f8e667e..5265d27 100644
+--- a/node_modules/vscode-extension-tester/out/browser.js
++++ b/node_modules/vscode-extension-tester/out/browser.js
+@@ -139,7 +139,8 @@ class VSBrowser {
+         else if (process.env.EXTENSION_DEV_PATH) {
+             args.push(`--extensionDevelopmentPath=${process.env.EXTENSION_DEV_PATH}`);
+         }
+-        let options = new chrome_1.Options().setChromeBinaryPath(codePath).addArguments(...args);
++        const extraArgs = [ "--skip-welcome", "--skip-sessions-welcome", "--skip-release-notes" ];
++        let options = new chrome_1.Options().setChromeBinaryPath(codePath).addArguments(...args, ...extraArgs);
+         options['options_'].windowTypes = ['webview'];
+         options = options;
+         const prefs = new page_objects_1.logging.Preferences();

--- a/test/ui/extester.env
+++ b/test/ui/extester.env
@@ -1,0 +1,9 @@
+CODE_VERSION=$(cat .vscode-version 2>/dev/null)
+: "${CODE_VERSION:=max}"
+
+export CODE_VERSION
+
+if [ ! -f .vscode-version ]; then
+    echo "WARNING: .vscode-version not found, falling back to 'max'"
+fi
+echo "VSCODE VERSION to use in ExTester: ${CODE_VERSION}"


### PR DESCRIPTION
This PR syncs ExTester VS Code version with @vscode/test-electron by exporting the resolved version
into .vscode-version and reusing it via CODE_VERSION, ensuring both Electron and UI tests run against
the exact same VS Code build.
    
Previously,  when running ExTester@8.23.0 with `-c max` it downloads and uses vscode 1.111.0:
```
    WARNING: You are using the outdated VS Code version '1.111.0'. The latest stable version is '1.122.1'.
    
    Downloading VS Code: 1.111.0 / stable
    Downloading VS Code from: https://update.code.visualstudio.com/1.111.0/linux-x64/stable
```
    
But it's still possible to use a newer vscode version for testing. At the moment the latest
vscode version that is supported by ExTester is 1.115.0:
```
    WARNING: You are using the outdated VS Code version '1.115.0'. The latest stable version is '1.123.0'.
    
    Downloading VS Code: 1.115.0 / stable
    Downloading VS Code from: https://update.code.visualstudio.com/1.115.0/linux-x64/stable
```
...which is, not the latest due to the [ExTester limitations while catching up for vscode changes](https://github.com/redhat-developer/vscode-extension-tester/issues/2345),
but still a bit closer to what's used for non-UI tests (Electron) which uses the latest stable vscode version:
```
    - Resolving version...
    ✔ Validated version: 1.123.0
    - Found at https://update.code.visualstudio.com/1.123.0/linux-x64/stable?released=true
    ✔ Found at https://update.code.visualstudio.com/1.123.0/linux-x64/stable?released=true
```

Note: vscode-extension-tester was patched to support the latest vscode version (at least while API allows this)