### PR TITLE
[build] Fix warning on possible vilnerability when installing vscode …

### DIFF
--- a/build/install-vscode.cjs
+++ b/build/install-vscode.cjs
@@ -43,9 +43,11 @@ void testElectron.downloadAndUnzipVSCode().then((executable) => {
         for (const extension of extensionsToInstall) {
             console.log('Installing extension: ', extension );
             try {
+                const options = (process.platform === 'win32' || process.platform === 'darwin') ? { shell: true } : {};
+
                 cp.execFileSync(vsCodeExecutable,
                     ['--install-extension', extension, '--user-data-dir', userDataDir, '--extensions-dir', extDir],
-                    { shell: true }
+                    options
                 );
             } catch (err) {
                 console.error(`❌ Failed to install "${extension}" extension: `, err);


### PR DESCRIPTION
…extensions

```
Installing extension:  redhat.vscode-redhat-account
(node:280566) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
    at normalizeSpawnArguments (node:child_process:644:15)
    at spawnSync (node:child_process:870:8)
    at Object.execFileSync (node:child_process:954:15)
    at ~/projects/vscode-openshift-tools/build/install-vscode.cjs:46:20
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```