### PR TITLE
[build] Fix vulnerability in js-yaml <=4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11741,16 +11741,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/istanbul/node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
 		"node_modules/istanbul/node_modules/async": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -11784,34 +11774,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/istanbul/node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/istanbul/node_modules/js-yaml/node_modules/esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"bin": {
-				"esparse": "bin/esparse.js",
-				"esvalidate": "bin/esvalidate.js"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/istanbul/node_modules/mkdirp": {
@@ -16853,13 +16815,6 @@
 			"integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true,
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/ssh2": {
 			"version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
 		"diff": "^9.0.0",
 		"globals": "^17.6.0",
 		"js-cookie": "^3.0.7",
+		"js-yaml": "^4.2.0",
 		"serialize-javascript": "^7.0.5",
 		"tar-fs": "^3.1.2",
 		"tough-cookie": "^6.0.1",


### PR DESCRIPTION
```
$ npm audit report

js-yaml  <=4.1.1
Severity: moderate
JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases - https://github.com/advisories/GHSA-h67p-54hq-rp68
No fix available
node_modules/istanbul/node_modules/js-yaml
  istanbul  >=0.2.3
  Depends on vulnerable versions of js-yaml
  node_modules/istanbul
    remap-istanbul  *
    Depends on vulnerable versions of istanbul
    node_modules/remap-istanbul
```

Fixes: https://github.com/redhat-developer/vscode-openshift-tools/security/dependabot/177