### PR TITLE
[deps] Upgrade xterm to @xterm/* scoped packages (v6.0.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,12 @@
 				"@uiw/codemirror-theme-vscode": "^4.25.10",
 				"@uiw/react-codemirror": "^4.25.10",
 				"@vscode/test-electron": "^3.0.0",
+				"@xterm/addon-fit": "^0.11.0",
+				"@xterm/addon-serialize": "^0.14.0",
+				"@xterm/addon-web-links": "^0.12.0",
+				"@xterm/addon-webgl": "^0.19.0",
+				"@xterm/headless": "^6.0.0",
+				"@xterm/xterm": "^6.0.0",
 				"chai": "^6.2.2",
 				"chokidar": "^5.0.0",
 				"clipboardy": "^5.3.1",
@@ -121,12 +127,6 @@
 				"validator": "^13.15.35",
 				"vscode-extension-tester": "^8.23.0",
 				"vscode-kubernetes-tools-api": "^1.3.0",
-				"xterm": "^5.3.0",
-				"xterm-addon-fit": "^0.8.0",
-				"xterm-addon-serialize": "^0.11.0",
-				"xterm-addon-web-links": "^0.9.0",
-				"xterm-addon-webgl": "^0.16.0",
-				"xterm-headless": "^5.3.0",
 				"yaml": "^2.9.0"
 			},
 			"engines": {
@@ -5815,6 +5815,54 @@
 				"@webassemblyjs/ast": "1.14.1",
 				"@xtuc/long": "4.2.2"
 			}
+		},
+		"node_modules/@xterm/addon-fit": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+			"integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@xterm/addon-serialize": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
+			"integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@xterm/addon-web-links": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+			"integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@xterm/addon-webgl": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
+			"integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@xterm/headless": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+			"integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"addons/*"
+			]
+		},
+		"node_modules/@xterm/xterm": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+			"integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"addons/*"
+			]
 		},
 		"node_modules/@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -19362,54 +19410,6 @@
 			"engines": {
 				"node": ">=0.4"
 			}
-		},
-		"node_modules/xterm": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-			"integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-			"dev": true
-		},
-		"node_modules/xterm-addon-fit": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
-			"integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
-			"dev": true,
-			"peerDependencies": {
-				"xterm": "^5.0.0"
-			}
-		},
-		"node_modules/xterm-addon-serialize": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/xterm-addon-serialize/-/xterm-addon-serialize-0.11.0.tgz",
-			"integrity": "sha512-2CNDnmLdLkNWfsxNFkGsI5FE9W/BbsMzeOrbu59yNqH9L6k1gmL+Ab6VXxEp2NQUJSzaiqi6t0nFR5k5EDkVIg==",
-			"dev": true,
-			"peerDependencies": {
-				"xterm": "^5.0.0"
-			}
-		},
-		"node_modules/xterm-addon-web-links": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/xterm-addon-web-links/-/xterm-addon-web-links-0.9.0.tgz",
-			"integrity": "sha512-LIzi4jBbPlrKMZF3ihoyqayWyTXAwGfu4yprz1aK2p71e9UKXN6RRzVONR0L+Zd+Ik5tPVI9bwp9e8fDTQh49Q==",
-			"dev": true,
-			"peerDependencies": {
-				"xterm": "^5.0.0"
-			}
-		},
-		"node_modules/xterm-addon-webgl": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/xterm-addon-webgl/-/xterm-addon-webgl-0.16.0.tgz",
-			"integrity": "sha512-E8cq1AiqNOv0M/FghPT+zPAEnvIQRDbAbkb04rRYSxUym69elPWVJ4sv22FCLBqM/3LcrmBLl/pELnBebVFKgA==",
-			"dev": true,
-			"peerDependencies": {
-				"xterm": "^5.0.0"
-			}
-		},
-		"node_modules/xterm-headless": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/xterm-headless/-/xterm-headless-5.3.0.tgz",
-			"integrity": "sha512-HjKkEgvjlyXfZvI0LdQChOqGL5nDiXge6X2IvoQbOn+oavAKUCX9hKHtDxmWVwxgNCCvXDnfQCYL+3wyHQ9PXA==",
-			"dev": true
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -185,12 +185,12 @@
 		"validator": "^13.15.35",
 		"vscode-extension-tester": "^8.23.0",
 		"vscode-kubernetes-tools-api": "^1.3.0",
-		"xterm": "^5.3.0",
-		"xterm-addon-fit": "^0.8.0",
-		"xterm-addon-serialize": "^0.11.0",
-		"xterm-addon-web-links": "^0.9.0",
-		"xterm-addon-webgl": "^0.16.0",
-		"xterm-headless": "^5.3.0",
+		"@xterm/xterm": "^6.0.0",
+		"@xterm/addon-fit": "^0.11.0",
+		"@xterm/addon-serialize": "^0.14.0",
+		"@xterm/addon-web-links": "^0.12.0",
+		"@xterm/addon-webgl": "^0.19.0",
+		"@xterm/headless": "^6.0.0",
 		"yaml": "^2.9.0"
 	},
 	"overrides": {

--- a/src/webview/openshift-terminal/app/terminalInstance.tsx
+++ b/src/webview/openshift-terminal/app/terminalInstance.tsx
@@ -6,11 +6,11 @@
 import { Box, Button, Paper, Stack, Typography, debounce } from '@mui/material';
 import React from 'react';
 import { VSCodeMessage } from './vscodeMessage';
-import { Terminal, ITheme } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { WebLinksAddon } from 'xterm-addon-web-links';
-import { WebglAddon } from 'xterm-addon-webgl';
-import 'xterm/css/xterm.css';
+import { Terminal, ITheme } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
+import { WebglAddon } from '@xterm/addon-webgl';
+import '@xterm/xterm/css/xterm.css';
 import '../../common/scrollbar.scss';
 
 /**

--- a/src/webview/openshift-terminal/openShiftTerminal.ts
+++ b/src/webview/openshift-terminal/openShiftTerminal.ts
@@ -20,8 +20,8 @@ import {
     window,
     workspace
 } from 'vscode';
-import { SerializeAddon } from 'xterm-addon-serialize';
-import { Terminal } from 'xterm-headless';
+import { SerializeAddon } from '@xterm/addon-serialize';
+import { Terminal } from '@xterm/headless';
 import { CommandText } from '../../base/command';
 import { CliChannel } from '../../cli';
 import { ToolsConfig } from '../../tools';


### PR DESCRIPTION
The following deprecated packages were replaced by the modern @xterm/* scoped equivalents:

- xterm ^5.3.0 → @xterm/xterm ^6.0.0
- xterm-addon-fit ^0.8.0 → @xterm/addon-fit ^0.11.0
- xterm-addon-serialize ^0.11.0 → @xterm/addon-serialize ^0.14.0
- xterm-addon-web-links ^0.9.0 → @xterm/addon-web-links ^0.12.0
- xterm-addon-webgl ^0.16.0 → @xterm/addon-webgl ^0.19.0
- xterm-headless ^5.3.0 → @xterm/headless ^6.0.0

Updated import statements in:
- src/webview/openshift-terminal/app/terminalInstance.tsx
- src/webview/openshift-terminal/openShiftTerminal.ts


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>