### PR TITLE
[security] Fix incomplete regex escaping in command-about test

### DIFF
--- a/test/ui/suite/command-about.ts
+++ b/test/ui/suite/command-about.ts
@@ -103,7 +103,9 @@ export function checkAboutCommand(clusterIsSet: boolean) {
 
                     // Check that the tool name and version appear together on the same line
                     // Format: "toolname            : version" or "toolname            : Unknown"
-                    const toolLineRegex = new RegExp(`${toolName}\\s*:\\s*${expectedVersion.replace(/\./g, '\\.')}`);
+                    // Escape special regex characters in version string to prevent regex injection
+                    const escapedVersion = expectedVersion.replace(/[\\.*+?^${}()|[\]]/g, '\\$&');
+                    const toolLineRegex = new RegExp(`${toolName}\\s*:\\s*${escapedVersion}`);
                     const unknownLineRegex = new RegExp(`${toolName}\\s*:\\s*Unknown`);
 
                     const hasExpectedVersion = toolLineRegex.test(terminalText);


### PR DESCRIPTION
Fixed CodeQL warning about incomplete string escaping in regex construction. The previous code only escaped dots but didn't escape backslashes, which could lead to regex injection or incorrect pattern matching.

Changed from:
  expectedVersion.replace(/\./g, '\\.')

To proper regex escaping of all special characters:
  expectedVersion.replace(/[\\.*+?^${}()|[\]]/g, '\\$&')

This ensures backslashes and all other regex metacharacters are properly escaped before being used in the RegExp constructor.


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>