### PR TITLE
[deps] Bump @mui/lab from 6.0.0-dev.240424162023-9968b4889d to 6.0.1-beta.36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@devfile/api": "^2.2.2-1716821574",
 				"@kubernetes/client-node": "^1.4.0",
 				"@mui/icons-material": "^6.5.0",
-				"@mui/lab": "^6.0.0-dev.240424162023-9968b4889d",
+				"@mui/lab": "^6.0.1-beta.36",
 				"@mui/material": "^6.4.12",
 				"@mui/styles": "^6.5.0",
 				"@mui/x-tree-view": "^7.29.10",
@@ -1630,34 +1630,34 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-			"integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+			"integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-			"integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+			"version": "1.7.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+			"integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.3",
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/core": "^1.7.5",
+				"@floating-ui/utils": "^0.2.11"
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-			"integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/dom": "^1.7.4"
+				"@floating-ui/dom": "^1.7.6"
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0",
@@ -1665,9 +1665,9 @@
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+			"integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2069,32 +2069,32 @@
 			}
 		},
 		"node_modules/@mui/base": {
-			"version": "5.0.0-beta.42",
-			"resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.42.tgz",
-			"integrity": "sha512-fWRiUJVCHCPF+mxd5drn08bY2qRw3jj5f1SSQdUXmaJ/yKpk23ys8MgLO2KGVTRtbks/+ctRfgffGPbXifj0Ug==",
-			"deprecated": "This package has been replaced by @base-ui-components/react",
+			"version": "5.0.0-beta.70",
+			"resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.70.tgz",
+			"integrity": "sha512-Tb/BIhJzb0pa5zv/wu7OdokY9ZKEDqcu1BDFnohyvGCoHuSXbEr90rPq1qeNW3XvTBIbNWHEF7gqge+xpUo6tQ==",
+			"deprecated": "This package has been replaced by @base-ui/react",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.24.4",
-				"@floating-ui/react-dom": "^2.0.8",
-				"@mui/types": "^7.2.14",
-				"@mui/utils": "^6.0.0-alpha.1",
+				"@babel/runtime": "^7.26.0",
+				"@floating-ui/react-dom": "^2.1.1",
+				"@mui/types": "~7.2.24",
+				"@mui/utils": "^6.4.8",
 				"@popperjs/core": "^2.11.8",
-				"clsx": "^2.1.0",
+				"clsx": "^2.1.1",
 				"prop-types": "^15.8.1"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=14.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/mui-org"
 			},
 			"peerDependencies": {
-				"@types/react": "^17.0.0 || ^18.0.0",
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
+				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -2141,22 +2141,22 @@
 			}
 		},
 		"node_modules/@mui/lab": {
-			"version": "6.0.0-dev.240424162023-9968b4889d",
-			"resolved": "https://registry.npmjs.org/@mui/lab/-/lab-6.0.0-dev.240424162023-9968b4889d.tgz",
-			"integrity": "sha512-iKFAz7/EeWI4PaFsP4jK2FcYJmUYDBkn3XZwpQSAl5806yYq5J2U2mPQLuZBdhrH50gT2O98p95i3vwL4YBwAg==",
+			"version": "6.0.1-beta.36",
+			"resolved": "https://registry.npmjs.org/@mui/lab/-/lab-6.0.1-beta.36.tgz",
+			"integrity": "sha512-af9lDmA9SZGEWF1XXk0EVBpfCITk9IKsvh9lLOZGdYaaHfQeCsqxGEDMvNO66j0P8EYoxpyry84LFCJYuLVtVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.24.4",
-				"@mui/base": "5.0.0-beta.42",
-				"@mui/system": "^6.0.0-dev.240424162023-9968b4889d",
-				"@mui/types": "^7.2.14",
-				"@mui/utils": "^6.0.0-alpha.3",
-				"clsx": "^2.1.0",
+				"@babel/runtime": "^7.26.0",
+				"@mui/base": "5.0.0-beta.70",
+				"@mui/system": "^6.5.0",
+				"@mui/types": "~7.2.24",
+				"@mui/utils": "^6.4.9",
+				"clsx": "^2.1.1",
 				"prop-types": "^15.8.1"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=14.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2165,16 +2165,20 @@
 			"peerDependencies": {
 				"@emotion/react": "^11.5.0",
 				"@emotion/styled": "^11.3.0",
-				"@mui/material": "^6.0.0-dev.240424162023-9968b4889d",
-				"@types/react": "^17.0.0 || ^18.0.0",
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
+				"@mui/material": "^6.5.0",
+				"@mui/material-pigment-css": "^6.5.0",
+				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@emotion/react": {
 					"optional": true
 				},
 				"@emotion/styled": {
+					"optional": true
+				},
+				"@mui/material-pigment-css": {
 					"optional": true
 				},
 				"@types/react": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"@devfile/api": "^2.2.2-1716821574",
 		"@kubernetes/client-node": "^1.4.0",
 		"@mui/icons-material": "^6.5.0",
-		"@mui/lab": "^6.0.0-dev.240424162023-9968b4889d",
+		"@mui/lab": "^6.0.1-beta.36",
 		"@mui/material": "^6.4.12",
 		"@mui/styles": "^6.5.0",
 		"@mui/x-tree-view": "^7.29.10",


### PR DESCRIPTION
- Updates @mui/base from 5.0.0-beta.42 to 5.0.0-beta.70
- Reduces npm deprecation warnings by using latest v6 beta release
- Maintains compatibility with @mui/material ^6.4.12

The @mui/base deprecation warning will persist until MUI fully migrates to @base-ui/react, but this update uses the latest compatible version.