### PR TITLE
Fix TypeScript 6 moduleResolution configurations

### DIFF
--- a/src/webview/cluster/app/tsconfig.json
+++ b/src/webview/cluster/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "configViewer",
         "lib": [

--- a/src/webview/create-component/app/tsconfig.json
+++ b/src/webview/create-component/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "configViewer",
         "lib": [

--- a/src/webview/create-deployment/app/tsconfig.json
+++ b/src/webview/create-deployment/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "configViewer",
         "lib": [

--- a/src/webview/create-route/app/tsconfig.json
+++ b/src/webview/create-route/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "creatRouteView",
         "lib": [

--- a/src/webview/create-service/app/tsconfig.json
+++ b/src/webview/create-service/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "creatServiceView",
         "lib": [

--- a/src/webview/devfile-registry/app/tsconfig.json
+++ b/src/webview/devfile-registry/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "devFileRegistryViewer",
         "lib": ["es2015", "dom"],

--- a/src/webview/feedback/app/tsconfig.json
+++ b/src/webview/feedback/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "feedbackViewer",
         "lib": ["es2015", "dom"],

--- a/src/webview/helm-chart/app/tsconfig.json
+++ b/src/webview/helm-chart/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "helmChartViewer",
         "lib": ["es2015", "dom"],

--- a/src/webview/helm-manage-repository/app/tsconfig.json
+++ b/src/webview/helm-manage-repository/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "configViewer",
         "lib": [

--- a/src/webview/openshift-terminal/app/tsconfig.json
+++ b/src/webview/openshift-terminal/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "esModuleInterop": true,
         "target": "es2015",
         "outDir": "openshiftTerminal",

--- a/src/webview/serverless-function/app/tsconfig.json
+++ b/src/webview/serverless-function/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "configViewer",
         "lib": [

--- a/src/webview/serverless-manage-repository/app/tsconfig.json
+++ b/src/webview/serverless-manage-repository/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "configViewer",
         "lib": [

--- a/src/webview/tsconfig.json
+++ b/src/webview/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "rootDir": "..",
         "outDir": "../../out",
         "target": "es2015",

--- a/src/webview/welcome/app/tsconfig.json
+++ b/src/webview/welcome/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "target": "es2015",
         "outDir": "configViewer",
         "lib": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": false,
     "noUnusedLocals": false,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "types": ["node", "mocha", "vscode"],
     "experimentalDecorators": true,
     "useDefineForClassFields": false,


### PR DESCRIPTION
This commit corrects the moduleResolution settings for TypeScript 6 compatibility across the extension and webview projects.

Changes:
- Root tsconfig.json: Changed moduleResolution from "bundler" to "node"
  * VSCode extensions require "module": "CommonJS", which is incompatible with "moduleResolution": "bundler" in TypeScript 6
  * "node" resolution is the correct legacy mode for CommonJS modules
- All 13 webview tsconfig.json files: Changed from "node" to "bundler"
  * Webviews are bundled with webpack, so "bundler" is semantically correct for module resolution in TypeScript 6

The previous "bundler" setting in the root tsconfig caused build failures:
  error TS5110: Option 'module' must be set to 'Node16' when option
  'moduleResolution' is set to 'Node16'.

This also fixes runtime errors where lib.dom.d.ts could not be found and Promise type was undefined.