### PR TITLE
[deps] Limit @rjsf/* to v5 to avoid MUI v7+ requirement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,14 @@ updates:
     versions: [">=7.0.0-0"]
   - dependency-name: "@mui/x-tree-view"
     versions: [">=8.0.0-0"]
+  - dependency-name: "@rjsf/core"
+    versions: [">=6.0.0-0"]
+  - dependency-name: "@rjsf/mui"
+    versions: [">=6.0.0-0"]
+  - dependency-name: "@rjsf/utils"
+    versions: [">=6.0.0-0"]
+  - dependency-name: "@rjsf/validator-ajv8"
+    versions: [">=6.0.0-0"]
   groups:
     typescript-eslint:
       patterns:


### PR DESCRIPTION
Prevents Dependabot from upgrading @rjsf/* packages to v6.x, which requires @mui/material v7+ or v9+. We're currently on MUI v6.x, and upgrading MUI would be a separate breaking change effort.