### PR TITLE
[deps] Bump @devfile/api from 2.2.2-1716821574 to 2.3.0-1757407014

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 			"devDependencies": {
 				"@apidevtools/json-schema-ref-parser": "^15.4.0",
 				"@codemirror/lang-yaml": "^6.1.3",
-				"@devfile/api": "^2.2.2-1716821574",
+				"@devfile/api": "^2.3.0-1757407014",
 				"@kubernetes/client-node": "^1.4.0",
 				"@mui/icons-material": "^6.5.0",
 				"@mui/lab": "^6.0.1-beta.36",
@@ -789,10 +789,11 @@
 			}
 		},
 		"node_modules/@devfile/api": {
-			"version": "2.2.2-1716821574",
-			"resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.2.2-1716821574.tgz",
-			"integrity": "sha512-PbtkJualxyD7MiFULCKHOi4rHXONiXMXImMJ0XjjGsPPnbmHt7yUcjm6OzmA+1loYLqR+BrRk+JLUO5zRf062A==",
+			"version": "2.3.0-1757407014",
+			"resolved": "https://registry.npmjs.org/@devfile/api/-/api-2.3.0-1757407014.tgz",
+			"integrity": "sha512-keQ2K2wWNv83tSHN+nflX8W57TQDjqaF9CTFmjWLFTKHEMgwJqTOrQZENR9alq4bO+yC8GAvWiWS3NaMQqazrw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/node": "*",
 				"@types/node-fetch": "^2.5.7",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 	"devDependencies": {
 		"@apidevtools/json-schema-ref-parser": "^15.4.0",
 		"@codemirror/lang-yaml": "^6.1.3",
-		"@devfile/api": "^2.2.2-1716821574",
+		"@devfile/api": "^2.3.0-1757407014",
 		"@kubernetes/client-node": "^1.4.0",
 		"@mui/icons-material": "^6.5.0",
 		"@mui/lab": "^6.0.1-beta.36",

--- a/src/util/devfileConverter.ts
+++ b/src/util/devfileConverter.ts
@@ -3,23 +3,23 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 import {
-    V222Devfile,
-    V222DevfileCommands,
-    V222DevfileComponents,
-    V222DevfileComponentsItemsContainerEndpoints,
-    V222DevfileComponentsItemsContainerEnv,
-    V222DevfileComponentsItemsContainerVolumeMounts,
-    V222DevfileMetadata,
-    V222DevfileProjects
+    V230Devfile,
+    V230DevfileCommands,
+    V230DevfileComponents,
+    V230DevfileComponentsItemsContainerEndpoints,
+    V230DevfileComponentsItemsContainerEnv,
+    V230DevfileComponentsItemsContainerVolumeMounts,
+    V230DevfileMetadata,
+    V230DevfileProjects
 } from '@devfile/api';
 import { Data, Endpoint, Metadata } from '../odo/componentTypeDescription';
 import { ComponentV1, DevfileCommandV1, DevfileV1, DevfileVolumeV1, EndpointV1, EnvV1, MetadataV1, ProjectV1 } from './devfileV1Type';
 
-export type DevfileMetadataLike = V222DevfileMetadata & object;
+export type DevfileMetadataLike = V230DevfileMetadata & object;
 
 export type DevfileMetadata = DevfileMetadataLike & Required<Pick<DevfileMetadataLike, 'name'>>;
 
-export type DevfileLike = V222Devfile & {
+export type DevfileLike = V230Devfile & {
     metadata?: DevfileMetadataLike;
 };
 
@@ -135,7 +135,7 @@ export class DevfileConverter {
         return devfileMetadataV2;
     }
 
-    projectV1toProjectV2(projectV1: ProjectV1): V222DevfileProjects {
+    projectV1toProjectV2(projectV1: ProjectV1): V230DevfileProjects {
         // the name can't have spaces
         // replace space by dash and then remove all special characters
         const projectName = projectV1.name
@@ -191,7 +191,7 @@ export class DevfileConverter {
         return devfileV2Project;
     }
 
-    componentV1toComponentV2(componentV1: ComponentV1): V222DevfileComponents {
+    componentV1toComponentV2(componentV1: ComponentV1): V230DevfileComponents {
         const devfileV2Component: any = {};
 
         if (componentV1.alias) {
@@ -240,7 +240,7 @@ export class DevfileConverter {
         return devfileV2Component;
     }
 
-    commandV1toCommandV2(commandV1: DevfileCommandV1): V222DevfileCommands {
+    commandV1toCommandV2(commandV1: DevfileCommandV1): V230DevfileCommands {
 
         const devfileV2Command: any = {};
 
@@ -285,7 +285,7 @@ export class DevfileConverter {
 
     componentEnvV1toComponentEnvV2(
         componentEnvs?: EnvV1[]
-    ): V222DevfileComponentsItemsContainerEnv[] | undefined {
+    ): V230DevfileComponentsItemsContainerEnv[] | undefined {
         if (componentEnvs) {
             return componentEnvs.map(envV1 => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -304,7 +304,7 @@ export class DevfileConverter {
 
     componentVolumeV1toComponentVolumeV2(
         componentVolumes?: DevfileVolumeV1[]
-    ): V222DevfileComponentsItemsContainerVolumeMounts[] | undefined {
+    ): V230DevfileComponentsItemsContainerVolumeMounts[] | undefined {
         if (componentVolumes) {
             return componentVolumes.map(volumeV1 => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -325,7 +325,7 @@ export class DevfileConverter {
 
     componentEndpointV1toComponentEndpointV2(
         componentEndpoints?: EndpointV1[]
-    ): V222DevfileComponentsItemsContainerEndpoints[] | undefined {
+    ): V230DevfileComponentsItemsContainerEndpoints[] | undefined {
         if (componentEndpoints) {
             return componentEndpoints.map(endpointV1 => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/integration/command.test.ts
+++ b/test/integration/command.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { V222Devfile } from '@devfile/api';
+import { V230Devfile } from '@devfile/api';
 import { fail } from 'assert';
 import { assert, expect } from 'chai';
 import { ChildProcess } from 'child_process';
@@ -313,7 +313,7 @@ suite('odo commands integration', function () {
             //
             // and then save into the same debfile.yaml
             const file = await fs.readFile(devfilePath, 'utf8');
-            const devfile = parse(file.toString()) as V222Devfile;
+            const devfile = parse(file.toString()) as V230Devfile;
             if (!devfile || !devfile.commands) {
                 fail(`DevFile '${devfilePath}' cannot be read`);
             }


### PR DESCRIPTION
Updates @devfile/api to version 2.3.0-1757407014.

BREAKING CHANGES:
- All type names changed from V222* prefix to V230* prefix
- Updated devfileConverter.ts to use new V230Devfile types
- Updated test imports to use new V230Devfile types