### PR TITLE
[deps]  Update dependency overrides to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
 				"git-up": "^8.1.1",
 				"got": "^15.0.6",
 				"istanbul": "^0.4.5",
+				"js-yaml": "^4.2.0",
 				"json-schema": "^0.4.0",
 				"json-to-ast": "^2.1.0",
 				"leasot": "^14.4.0",
@@ -10362,9 +10363,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "17.6.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-			"integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+			"version": "17.7.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+			"integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -11951,14 +11952,11 @@
 			}
 		},
 		"node_modules/js-cookie": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
-			"integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+			"integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			}
+			"license": "MIT"
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -16269,9 +16267,9 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+			"integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -18494,9 +18492,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
 		"git-up": "^8.1.1",
 		"got": "^15.0.6",
 		"istanbul": "^0.4.5",
+		"js-yaml": "^4.2.0",
 		"json-schema": "^0.4.0",
 		"json-to-ast": "^2.1.0",
 		"leasot": "^14.4.0",
@@ -197,14 +198,14 @@
 		"cookie": "^1.1.1",
 		"cross-spawn": "^7.0.6",
 		"diff": "^9.0.0",
-		"globals": "^17.6.0",
-		"js-cookie": "^3.0.7",
+		"globals": "^17.7.0",
+		"js-cookie": "^3.0.8",
 		"js-yaml": "^4.2.0",
-		"serialize-javascript": "^7.0.5",
+		"serialize-javascript": "^7.0.6",
 		"tar-fs": "^3.1.2",
 		"tough-cookie": "^6.0.1",
 		"typescript": "^6.0.3",
-		"uuid": "^14.0.0"
+		"uuid": "^14.0.1"
 	},
 	"activationEvents": [
 		"onView:openshiftProjectExplorer",


### PR DESCRIPTION
Changed overrides:

- globals: ^17.6.0 -> ^17.7.0
- js-cookie: ^3.0.7 -> ^3.0.8
- serialize-javascript: ^7.0.5 -> ^7.0.6
- uuid: ^14.0.0 -> ^14.0.1