### PR TITLE
[deps] Update dependency overrides to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
 				"git-up": "^8.1.1",
 				"got": "^15.0.6",
 				"istanbul": "^0.4.5",
-				"js-yaml": "^4.2.0",
+				"js-yaml": "^4.3.0",
 				"json-schema": "^0.4.0",
 				"json-to-ast": "^2.1.0",
 				"leasot": "^14.4.0",
@@ -7550,13 +7550,13 @@
 			"peer": true
 		},
 		"node_modules/cookie": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-			"integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.0.tgz",
+			"integrity": "sha512-hRSFuKJ6SYHrFVNltQdagQFMk7e0Q/VrORTGqZGyUAmmhA3EwPeldHCTg0HqUaDodQOfQDe7qXuOtpf4lwCsaA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=22"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -11966,9 +11966,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -17420,9 +17420,9 @@
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-			"integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+			"integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
 		"git-up": "^8.1.1",
 		"got": "^15.0.6",
 		"istanbul": "^0.4.5",
-		"js-yaml": "^4.2.0",
+		"js-yaml": "^4.3.0",
 		"json-schema": "^0.4.0",
 		"json-to-ast": "^2.1.0",
 		"leasot": "^14.4.0",
@@ -195,14 +195,14 @@
 		"yaml": "^2.9.0"
 	},
 	"overrides": {
-		"cookie": "^1.1.1",
+		"cookie": "^2.0.0",
 		"cross-spawn": "^7.0.6",
 		"diff": "^9.0.0",
 		"globals": "^17.7.0",
 		"js-cookie": "^3.0.8",
-		"js-yaml": "^4.2.0",
+		"js-yaml": "^4.3.0",
 		"serialize-javascript": "^7.0.6",
-		"tar-fs": "^3.1.2",
+		"tar-fs": "^3.1.3",
 		"tough-cookie": "^6.0.1",
 		"typescript": "^6.0.3",
 		"uuid": "^14.0.1"


### PR DESCRIPTION
Changed overrides:

- cookie: ^1.1.1 -> ^2.0.0
- js-yaml: ^4.2.0 -> ^4.3.0
- tar-fs: ^3.1.2 -> ^3.1.3