### PR TITLE
[build] Add dependency review action to CI workflow

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: read
       actions: write
+      pull-requests: write
 
     strategy:
       fail-fast: false
@@ -43,6 +44,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Dependency Review
+        if: github.event_name == 'pull_request' && runner.os == 'Linux'
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: moderate
+          fail-on-scopes: runtime, development
+          comment-summary-in-pr: on-failure
+          license-check: false
 
       # Run install dependencies
       - name: Install dependencies


### PR DESCRIPTION
Integrates dependency-review-action@v5 into the existing build job to automatically review dependencies on pull requests for:
- Vulnerabilities at moderate severity or higher
- Both runtime and development scopes
- Posts summary comments on PR failures

License checking is disabled to avoid blocking on diverse license types in the dependency tree.


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>