### PR TITLE
[build] Add --ignore-scripts flag to npm install commands

### DIFF
--- a/.github/workflows/circular-dependency-check.yml
+++ b/.github/workflows/circular-dependency-check.yml
@@ -26,7 +26,9 @@ jobs:
 
       # Run install dependencies
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci --ignore-scripts
+          npm rebuild cpu-features ssh2
 
       - name: Check cycles
         run : npm run check-cycles

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -56,7 +56,9 @@ jobs:
 
       # Run install dependencies
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci --ignore-scripts
+          npm rebuild cpu-features ssh2
 
       # Run tests without xvfb, if not running on ubuntu
       - name: Build and Test (non-Linux)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g typescript "vsce" "ovsx"
-          npm install
+          npm install --ignore-scripts
+          npm rebuild cpu-features ssh2
           echo "EXT_VERSION=$(cat package.json | jq -r .version)" >> $GITHUB_ENV
       - name: Build And Run Unit Tests
         run: xvfb-run npm run test

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	"scripts": {
 		"compile": "npm run prebuild-esm && node ./build/esbuild.build.cjs",
 		"build": "npm run prebuild-esm && node ./build/esbuild.build.cjs && npm run bundle-tools",
-		"vscode:prepublish": "npm install && npm run clean && npm run lint && npm run prebuild-esm && node ./build/esbuild.build.cjs --production && npm run bundle-tools && npm prune --omit=dev",
+		"vscode:prepublish": "npm install --ignore-scripts && npm run clean && npm run lint && npm run prebuild-esm && node ./build/esbuild.build.cjs --production && npm run bundle-tools && npm prune --omit=dev",
 		"prebuild-esm": "node ./build/esbuild.transform-esm.cjs",
 		"watch:extension": "tsc -p tsconfig.json --watch",
 		"watch:webviews": "node ./build/esbuild.webviews.cjs --watch",
@@ -61,7 +61,7 @@
 		"check-cycles": "dpdm --no-tree --no-warning --exit-code circular:1 ./src/extension.ts",
 		"todo": "leasot **/*.ts --ignore node_modules -x",
 		"clean": "shx rm -rf out/build out/src out/webview out/test out/tools out/test-resources out/**.tsbuildinfo",
-		"test:prepare": "npm install && npm run test:build-extension && npm run test:build-webviews && shx cp -r test/fixtures out/test/ && npm run bundle-tools",
+		"test:prepare": "npm install --ignore-scripts && npm run test:build-extension && npm run test:build-webviews && shx cp -r test/fixtures out/test/ && npm run bundle-tools",
 		"test:build-extension": "npm run prebuild-esm && tsc -p tsconfig.json",
 		"test:build-webviews": "node ./build/esbuild.webviews.cjs",
 		"test:instrument": "shx rm -rf out/src-orig && shx mv out/src out/src-orig && istanbul instrument --complete-copy --embed-source --output out/src out/src-orig",


### PR DESCRIPTION
The --ignore-scripts flag prevents npm from running lifecycle scripts (preinstall, install, postinstall) during dependency installation. This eliminates npm-allow-scripts warnings and improves build security by skipping potentially untrusted package install scripts.

Modified commands:
- vscode:prepublish: Added --ignore-scripts to npm install
- test:prepare: Added --ignore-scripts to npm install


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>