### PR TITLE
[build] Add --ignore-scripts to secretlint installation in UI tests

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -107,7 +107,7 @@ jobs:
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('package.json'));
-            pkg.scripts['vscode:prepublish'] += ' && npm install @secretlint/node';
+            pkg.scripts['vscode:prepublish'] += ' && npm install --ignore-scripts @secretlint/node';
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
           xvfb-run --server-args="-screen 0 1920x1080x24" npm run public-ui-test


### PR DESCRIPTION
The --ignore-scripts flag prevents npm from running lifecycle scripts during dependency installation. This eliminates npm-allow-scripts warnings during the UI test workflow when @secretlint/node is reinstalled after pruning dev dependencies.

Modified:
- continuous-integration-workflow.yml: Added --ignore-scripts to npm install @secretlint/node in the UI test step


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>