### PR TITLE
Fix git clone error handling and consolidate implementations

### DIFF
--- a/src/util/git.ts
+++ b/src/util/git.ts
@@ -30,7 +30,16 @@ export async function cloneRepository(options: GitCloneOptions): Promise<CloneRe
         };
     }
 
-    const gitApi = gitExtension.exports.getAPI(1);
+    let gitApi;
+    try {
+        gitApi = gitExtension.exports.getAPI(1);
+    } catch (error) {
+        return {
+            status: false,
+            error: `Failed to get Git API: ${error.message}`
+        };
+    }
+
     if (!gitApi?.git?.path) {
         return {
             status: false,
@@ -39,6 +48,13 @@ export async function cloneRepository(options: GitCloneOptions): Promise<CloneRe
     }
 
     const git = gitApi.git.path;
+
+    if (typeof git !== 'string' || git.trim().length === 0) {
+        return {
+            status: false,
+            error: 'Git executable path is invalid'
+        };
+    }
 
     const args = [
         'clone',

--- a/src/webview/create-deployment/createDeploymentLoader.ts
+++ b/src/webview/create-deployment/createDeploymentLoader.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-import * as cp from 'child_process';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as tmp from 'tmp';
@@ -14,17 +13,13 @@ import { Oc } from '../../oc/ocWrapper';
 import { BuilderImage, BuilderImageWrapper, NormalizedBuilderImages } from '../../odo/builderImage';
 import sendTelemetry from '../../telemetry';
 import { ExtensionID } from '../../util/constants';
+import { cloneRepository, CloneResult } from '../../util/git';
 import { vsCommand } from '../../vscommand';
 import {
     validateName,
     validatePortNumber
 } from '../common-ext/createComponentHelpers';
 import { loadWebviewHtml, validateGitURL } from '../common-ext/utils';
-
-interface CloneProcess {
-    status: boolean;
-    error: string | undefined;
-}
 
 type Message = {
     action: string;
@@ -157,7 +152,7 @@ export default class CreateDeploymentLoader implements Disposable {
                 void CreateDeploymentLoader.panel.webview.postMessage({
                     action: 'cloneStart',
                 });
-                const cloneProcess: CloneProcess = await clone(
+                const cloneProcess: CloneResult = await clone(
                     message.data.url,
                     tmpFolder.fsPath,
                     message.data.branch,
@@ -302,21 +297,17 @@ export default class CreateDeploymentLoader implements Disposable {
     }
 }
 
-function clone(url: string, location: string, branch?: string): Promise<CloneProcess> {
-    const gitExtension = extensions.getExtension('vscode.git').exports;
-    const git = gitExtension.getAPI(1).git.path;
-    let command = `${git} clone ${url} ${location}`;
-    command = branch ? `${command} --branch ${branch}` : command;
+async function clone(url: string, location: string, branch?: string): Promise<CloneResult> {
     void CreateDeploymentLoader.panel.webview.postMessage({
         action: 'cloneExecution'
     });
-    // run 'git clone url location' as external process and return location
-    return new Promise((resolve) =>
-        cp.exec(command, (error: cp.ExecException) => {
-            error
-                ? resolve({ status: false, error: error.message })
-                : resolve({ status: true, error: undefined });
-        }),
-    );
+
+    const result = await cloneRepository({
+        url,
+        location,
+        branch
+    });
+
+    return result;
 }
 


### PR DESCRIPTION
- Enhanced cloneRepository() in util/git.ts with comprehensive error handling for missing git executable
- Added try-catch around Git API access to prevent crashes
- Validate git executable path before spawning process
- Consolidated duplicate clone() function in createDeploymentLoader
- Removed duplicate CloneProcess interface, use CloneResult instead
- Changed from cp.exec to using centralized cloneRepository()
- Prevents "spawn git ENOENT" unhandled promise rejections in tests


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>