### PR TITLE
[tests] Fix test failures by disabling incremental TypeScript builds

### DIFF
--- a/src/webview/tsconfig.json
+++ b/src/webview/tsconfig.json
@@ -15,7 +15,7 @@
         "experimentalDecorators": true,
         "skipLibCheck": true,
         "esModuleInterop": true,
-        "incremental": true,
+        "incremental": false,
         "ignoreDeprecations": "6.0",
         "noImplicitAny": false,
         "strict": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "useDefineForClassFields": false,
     "noImplicitOverride": false,
     "skipLibCheck": true,
-    "incremental": true,
+    "incremental": false,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "typeRoots": [ "./src/@types", "./node_modules/@types", "./out/extension" ],


### PR DESCRIPTION
TypeScript incremental builds cache compilation state in .tsbuildinfo files, which can become stale and cause test failures when files are modified by watchers or other build processes. Since tsconfig.json is only used for test builds (not development or production builds which use esbuild), there is no benefit to incremental compilation for tests.

Changes:
- Disable incremental in tsconfig.json (used for test:build-extension)
- Disable incremental in src/webview/tsconfig.json (used for type-checking during test:build-webviews)

This ensures clean, reproducible test builds without stale cache issues.


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>