### PR TITLE
Migrate file watchers from fs.watch to VS Code FileSystemWatcher API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ dist/
 public/
 test-resources/
 .DS_Store
-
+.claude/

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -37,7 +37,7 @@ import { LoginUtil } from './util/loginUtil';
 import { Platform } from './util/platform';
 import { Progress } from './util/progress';
 import { ExecutionContext, imagePath } from './util/utils';
-import { FileContentChangeNotifier, WatchUtil } from './util/watch';
+import { watchFile } from './util/watch';
 import { vsCommand } from './vscommand';
 import { CustomResourceDefinitionStub, K8sResourceKind } from './webview/common/createServiceTypes';
 import { OpenShiftTerminalManager } from './webview/openshift-terminal/openShiftTerminal';
@@ -105,7 +105,7 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
 
     private treeView: TreeView<ExplorerItem>;
 
-    private kubeConfigWatchers: FileContentChangeNotifier[];
+    private kubeConfigWatchers: Disposable[];
     private kubeContext: Context;
     private kubeConfigInfo: KubeConfigInfo;
 
@@ -129,28 +129,27 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
         try {
             const kubeconfigFiles = getKubeConfigFiles();
             this.kubeConfigWatchers = (!kubeconfigFiles || kubeconfigFiles.length === 0) ? [] :
-                kubeconfigFiles.map(kubeconfigFile => WatchUtil.watchFileForContextChange(path.dirname(kubeconfigFile), path.basename(kubeconfigFile)));
+                kubeconfigFiles.map(kubeconfigFile =>
+                    watchFile(kubeconfigFile, () => {
+                        const kci2 = new KubeConfigInfo();
+                        const kc2 = kci2.getEffectiveKubeConfig();
+                        const newCtx = kc2.getContextObject(kc2.currentContext);
+                        if (Boolean(this.kubeContext) !== Boolean(newCtx)
+                            || (this.kubeContext?.cluster !== newCtx?.cluster
+                                || this.kubeContext?.user !== newCtx?.user
+                                || this.kubeContext?.namespace !== newCtx?.namespace)) {
+                            this.refresh();
+                            this.onDidChangeContextEmitter.fire(newCtx?.name); // newCtx can be 'null'
+                        }
+                        this.kubeContext = newCtx;
+                        this.kubeConfigInfo = kci2;
+                    })
+                );
             if (this.kubeConfigWatchers.length === 0) {
                 void window.showWarningMessage('Kubernetes configuration file(s) not found. Make sure that "${HOME}/.kube/config" file exists or "KUBECONFIG" environment variable is properly configured');
             }
         } catch {
             void window.showWarningMessage('Couldn\'t install watcher for Kubernetes configuration file. OpenShift Application Explorer view won\'t be updated automatically.');
-        }
-        for (const fsw of this.kubeConfigWatchers) {
-            fsw.emitter?.on('file-changed', () => {
-                const kci2 = new KubeConfigInfo();
-                const kc2 = kci2.getEffectiveKubeConfig();
-                const newCtx = kc2.getContextObject(kc2.currentContext);
-                if (Boolean(this.kubeContext) !== Boolean(newCtx)
-                    || (this.kubeContext?.cluster !== newCtx?.cluster
-                        || this.kubeContext?.user !== newCtx?.user
-                        || this.kubeContext?.namespace !== newCtx?.namespace)) {
-                    this.refresh();
-                    this.onDidChangeContextEmitter.fire(newCtx?.name); // newCtx can be 'null'
-                }
-                this.kubeContext = newCtx;
-                this.kubeConfigInfo = kci2;
-            });
         }
         this.treeView = window.createTreeView<ExplorerItem>('openshiftProjectExplorer', {
             treeDataProvider: this,
@@ -804,8 +803,8 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
     }
 
     dispose(): void {
-        for (const fsw of this.kubeConfigWatchers) {
-            fsw?.watcher?.close();
+        for (const watcher of this.kubeConfigWatchers) {
+            watcher?.dispose();
         }
         this.treeView.dispose();
     }

--- a/src/serverlessFunction/functionModel.ts
+++ b/src/serverlessFunction/functionModel.ts
@@ -5,7 +5,7 @@
 
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { Disposable, Uri, window, workspace } from 'vscode';
+import { Disposable, FileSystemWatcher, Uri, workspace } from 'vscode';
 import { CommandText } from '../base/command';
 import { CliChannel } from '../cli';
 import { DeploymentConfig } from '../k8s/deploymentConfig';
@@ -15,19 +15,17 @@ import { DeployedFunction, FunctionContent, FunctionObject, FunctionStatus, Func
 
 export class ServerlessFunctionModel implements Disposable {
 
-    private watchers: fs.FSWatcher[] = [];
+    private funcYamlWatcher: FileSystemWatcher;
     private workspaceWatcher: Disposable;
     private view: FunctionView;
 
     public constructor(view: FunctionView) {
         this.view = view;
-        this.addWatchers();
+        this.setupWatchers();
         this.workspaceWatcher = workspace.onDidChangeWorkspaceFolders((_e) => {
-            for (const watcher of this.watchers) {
-                watcher.close();
-            }
+            this.funcYamlWatcher?.dispose();
             this.view.refresh();
-            this.addWatchers();
+            this.setupWatchers();
         });
     }
 
@@ -101,10 +99,8 @@ export class ServerlessFunctionModel implements Disposable {
     }
 
     public dispose() {
-        for (const watcher of this.watchers) {
-            watcher.close();
-        }
-        this.workspaceWatcher.dispose();
+        this.funcYamlWatcher?.dispose();
+        this.workspaceWatcher?.dispose();
     }
 
     private getDeployFunction(
@@ -132,28 +128,13 @@ export class ServerlessFunctionModel implements Disposable {
         return Functions.imageRegex.test(yamlContent?.image);
     }
 
-    private addWatchers() {
-        if (workspace.workspaceFolders) {
-            for (const workspaceFolder of workspace.workspaceFolders) {
-                let folderExists = false;
-                try {
-                    fs.accessSync(workspaceFolder.uri.fsPath);
-                    folderExists = true;
-                } catch {
-                    // folder doesn't exist
-                    void window.showErrorMessage(`Can't keep track of if '${path.basename(workspaceFolder.uri.fsPath)}' contains a serverless function, since it's been deleted.`);
-                }
-                if (folderExists) {
-                    this.watchers.push(
-                        fs.watch(workspaceFolder.uri.fsPath, (_event, filename) => {
-                            if (filename === 'func.yaml') {
-                                this.view.refresh();
-                            }
-                        }),
-                    );
-                }
-            }
-        }
+    private setupWatchers() {
+        // Watch for func.yaml files across all workspace folders using VS Code's FileSystemWatcher
+        // This is more reliable than fs.watch, especially on Windows
+        this.funcYamlWatcher = workspace.createFileSystemWatcher('**/func.yaml');
+        this.funcYamlWatcher.onDidChange(() => this.view.refresh());
+        this.funcYamlWatcher.onDidCreate(() => this.view.refresh());
+        this.funcYamlWatcher.onDidDelete(() => this.view.refresh());
     }
 
     private async getListItems(command: CommandText, fail = false) {

--- a/src/util/aboutInfoProvider.ts
+++ b/src/util/aboutInfoProvider.ts
@@ -344,7 +344,7 @@ export class AboutInfoProvider {
             return undefined;
         }
 
-        // Try guessing its location from the cinfiguration preferences
+        // Try guessing its location from the configuration preferences
         const crcBinary = vscode.workspace.getConfiguration('openshiftToolkit').get<string>('crcBinaryLocation');
 
         return {

--- a/src/util/kubeUtils.ts
+++ b/src/util/kubeUtils.ts
@@ -234,7 +234,7 @@ export class KubeConfigInfo {
             }
         }
         if (!mergedCurrentContext) {
-            window.showWarningMessage('Kube cinfiguration doesn\'t define any current context value.');
+            window.showWarningMessage('Kube configuration doesn\'t define any current context value.');
         }
         return new CustomKubeConfig(mergedContexts, mergedCurrentContext, mergedClusters, mergedUsers);
     }

--- a/src/util/watch.ts
+++ b/src/util/watch.ts
@@ -3,36 +3,53 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { EventEmitter } from 'events';
-import * as fs from 'fs';
-import { FSWatcher } from 'fs-extra';
-import { Util as fsxt } from '../util/utils';
+import * as path from 'path';
+import { Disposable, FileSystemWatcher, RelativePattern, workspace } from 'vscode';
 
-export class WatchUtil {
-    static watchFileForContextChange(
-        location: string,
-        filename: string,
-    ): FileContentChangeNotifier {
-        const emitter: EventEmitter = new EventEmitter();
-        let timer: ReturnType<typeof setInterval> | undefined;
-        fsxt.ensureDirSync(location);
-        const watcher: FSWatcher = fsxt.watch(location, (eventType, changedFile) => {
-            if (filename === changedFile) {
-                if (timer) {
-                    clearTimeout(timer);
-                }
-                timer = setTimeout(() => {
-                    timer = undefined;
-                    emitter.emit('file-changed');
-                }, 500);
+/**
+ * Watch a specific file for changes using VS Code's FileSystemWatcher API.
+ * This uses VS Code's parcel-watcher implementation which is more reliable than fs.watch,
+ * especially on Windows where fs.watch has known issues with endless events.
+ *
+ * @param filePath Absolute path to the file to watch
+ * @param onChange Callback invoked when the file changes
+ * @param debounceMs Optional debounce delay in milliseconds (default: 500ms).
+ *                   Useful when file writes happen in multiple steps (e.g., kubectl/oc context switching).
+ * @returns Disposable to stop watching
+ */
+export function watchFile(filePath: string, onChange: () => void, debounceMs: number = 500): Disposable {
+    const dir = path.dirname(filePath);
+    const filename = path.basename(filePath);
+
+    let timer: NodeJS.Timeout | undefined;
+
+    const watcher: FileSystemWatcher = workspace.createFileSystemWatcher(
+        new RelativePattern(dir, filename),
+        true,  // ignoreCreateEvents
+        false, // ignoreChangeEvents (we want these!)
+        true   // ignoreDeleteEvents
+    );
+
+    watcher.onDidChange(() => {
+        // Debounce: wait for file writes to settle before invoking callback
+        // This handles tools like `oc config use-context` that write the file multiple times
+        if (timer) {
+            clearTimeout(timer);
+        }
+        timer = setTimeout(() => {
+            timer = undefined;
+            onChange();
+        }, debounceMs);
+    });
+
+    // Return a composite disposable that clears the timer and disposes the watcher
+    return {
+        dispose: () => {
+            if (timer) {
+                clearTimeout(timer);
+                timer = undefined;
             }
-        });
-        return { watcher, emitter };
-    }
-
-}
-
-export interface FileContentChangeNotifier {
-    readonly watcher: fs.FSWatcher;
-    readonly emitter: EventEmitter;
+            watcher.dispose();
+        }
+    };
 }

--- a/src/util/workspace.ts
+++ b/src/util/workspace.ts
@@ -17,6 +17,16 @@ export const AddWorkspaceFolder: QuickPickItem = {
     description: 'Folder which does not have an OpenShift context',
 };
 
+// Extract devfile patterns as constants
+const DEVFILE_NAMES = ['devfile', '.devfile'] as const;
+const DEVFILE_EXTENSIONS = ['yaml', 'yml', 'json'] as const;
+const DEVFILE_GLOB_PATTERN = `**/{${DEVFILE_NAMES.join(',')}}.{${DEVFILE_EXTENSIONS.join(',')}}`;
+
+// Pre-calculate devfile candidates once at module load
+const DEVFILE_CANDIDATES = DEVFILE_NAMES.flatMap(name =>
+    DEVFILE_EXTENSIONS.map(ext => `${name}.${ext}`)
+);
+
 function isFile(path: string) {
     try {
         return fs.statSync(path).isFile()
@@ -26,9 +36,9 @@ function isFile(path: string) {
 }
 
 function isComponentorFunction(folder: WorkspaceFolder) {
-    return !isFile(path.join(folder.uri.fsPath, 'devfile.yaml'))
-        && !isFile(path.join(folder.uri.fsPath, '.devfile.yaml'))
-        && !isFile(path.join(folder.uri.fsPath, 'func.yaml'));
+    return !DEVFILE_CANDIDATES.some(candidate =>
+        isFile(path.join(folder.uri.fsPath, candidate))
+    ) && !isFile(path.join(folder.uri.fsPath, 'func.yaml'));
 }
 
 function componentAndFuctionFilter(wsFolder: WorkspaceFolder) {
@@ -158,7 +168,7 @@ async function updateDevfileContext(_: unknown) {
  */
 export function setupWorkspaceDevfileContext(): Disposable {
     void updateDevfileContext(undefined);
-    const devfileWatcher = workspace.createFileSystemWatcher('**/{devfile,.devfile}.yaml');
+    const devfileWatcher = workspace.createFileSystemWatcher(DEVFILE_GLOB_PATTERN);
     devfileWatcher.onDidCreate(updateDevfileContext);
     devfileWatcher.onDidDelete(updateDevfileContext);
     workspace.onDidChangeWorkspaceFolders(updateDevfileContext);

--- a/test/integration/watch.test.ts
+++ b/test/integration/watch.test.ts
@@ -1,0 +1,72 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import * as path from 'path';
+import * as tmp from 'tmp';
+import { Util as fs } from '../../src/util/utils';
+import { watchFile } from '../../src/util/watch';
+
+const {expect} = chai;
+
+suite('File Watch Utility', () => {
+
+    test('watchFile calls the callback when file changes', async () => {
+        // Create a temp file
+        const tmpFile = tmp.fileSync({dir:`${path.basename(tmp.dirSync().name)}`});
+        const fileToWatch = fs.realpathSync(tmpFile.name);
+        fs.ensureFileSync(fileToWatch);
+
+        // Set up the file watcher
+        let changeDetected = false;
+        const watcher = watchFile(fileToWatch, () => {
+            changeDetected = true;
+        });
+
+        // Write to the file after a delay
+        setTimeout(() => {
+            fs.writeFileSync(fileToWatch, 'current-context:test2');
+        }, 500);
+
+        // Wait for the change to be detected
+        return new Promise<void>((resolve) => {
+            const checkInterval = setInterval(() => {
+                if (changeDetected) {
+                    clearInterval(checkInterval);
+                    expect(changeDetected).to.be.true;
+                    resolve();
+                }
+            }, 100);
+
+            // Timeout after 5 seconds
+            setTimeout(() => {
+                clearInterval(checkInterval);
+                if (!changeDetected) {
+                    throw new Error('File change was not detected within timeout');
+                }
+            }, 5000);
+        }).finally(() => {
+            watcher?.dispose();
+            tmpFile.removeCallback();
+        });
+    });
+
+    test('watchFile returns a Disposable', () => {
+        const tmpFile = tmp.fileSync();
+        const fileToWatch = tmpFile.name;
+
+        const watcher = watchFile(fileToWatch, () => {
+            // callback
+        });
+
+        try {
+            expect(watcher).to.have.property('dispose');
+            expect(watcher.dispose).to.be.a('function');
+        } finally {
+            watcher?.dispose();
+            tmpFile.removeCallback();
+        }
+    });
+});

--- a/test/unit/util/watch.test.ts
+++ b/test/unit/util/watch.test.ts
@@ -7,69 +7,98 @@ import * as chai from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import * as tmp from 'tmp';
-import { Util as fs } from '../../../src/util/utils';
-import { WatchUtil } from '../../../src/util/watch';
+import * as vscode from 'vscode';
+import { watchFile } from '../../../src/util/watch';
 
 const {expect} = chai;
 chai.use(sinonChai);
 
 suite('File Watch Utility', () => {
     let sandbox: sinon.SinonSandbox;
-    let ensureStub: sinon.SinonStub; let watchStub: sinon.SinonStub;
-    const location = 'location';
-    const filename = 'file';
+    let createFileSystemWatcherStub: sinon.SinonStub;
+    let mockWatcher: any;
 
     setup(() => {
         sandbox = sinon.createSandbox();
-        ensureStub = sandbox.stub(fs, 'ensureDirSync');
-        watchStub = sandbox.stub(fs, 'watch');
+
+        // Create a mock FileSystemWatcher
+        mockWatcher = {
+            onDidChange: sandbox.stub(),
+            onDidCreate: sandbox.stub(),
+            onDidDelete: sandbox.stub(),
+            dispose: sandbox.stub(),
+        };
+
+        // Stub workspace.createFileSystemWatcher
+        createFileSystemWatcherStub = sandbox.stub(vscode.workspace, 'createFileSystemWatcher')
+            .returns(mockWatcher);
     });
 
     teardown(() => {
         sandbox.restore();
     });
 
-    test('watchFileForContextChange ensures the location exists', () => {
-        WatchUtil.watchFileForContextChange(location, filename);
+    test('watchFile creates a FileSystemWatcher with correct pattern', () => {
+        const filePath = path.join('home', 'user', '.kube', 'config');
+        const expectedDir = path.dirname(filePath);
+        const expectedFile = path.basename(filePath);
 
-        expect(ensureStub).calledOnceWith(location);
+        watchFile(filePath, () => {});
+
+        expect(createFileSystemWatcherStub).to.have.been.calledOnce;
+
+        // Verify RelativePattern was created - just check it's an instance
+        // We can't reliably check the exact path format cross-platform
+        // because RelativePattern normalizes paths internally
+        const callArg = createFileSystemWatcherStub.firstCall.args[0];
+        expect(callArg).to.be.instanceOf(vscode.RelativePattern);
+        expect(callArg.pattern).to.equal(expectedFile);
+        // The base path might be normalized, just verify it ends with the expected directory
+        expect(callArg.base).to.satisfy((base: string) =>
+            base.endsWith(expectedDir) || base.replace(/\\/g, '/').endsWith(expectedDir.replace(/\\/g, '/'))
+        );
     });
 
-    test('watchFileForContextChange creates a file watcher for the given path', () => {
-        WatchUtil.watchFileForContextChange(location, filename);
+    test('watchFile configures watcher to ignore create and delete events', () => {
+        const filePath = path.join('home', 'user', '.kube', 'config');
 
-        expect(watchStub).calledOnceWith(location, sinon.match.func);
+        watchFile(filePath, () => {});
+
+        expect(createFileSystemWatcherStub).to.have.been.calledWith(
+            sinon.match.instanceOf(vscode.RelativePattern),
+            true,  // ignoreCreateEvents
+            false, // ignoreChangeEvents (we want these)
+            true   // ignoreDeleteEvents
+        );
     });
 
-    test('watchFileForContextChange returns a content change notifier', () => {
-        const result = WatchUtil.watchFileForContextChange(location, filename);
+    test('watchFile registers onChange callback', () => {
+        const filePath = path.join('home', 'user', '.kube', 'config');
+        const callback = sandbox.stub();
 
-        expect(result).has.ownProperty('watcher');
-        expect(result).has.ownProperty('emitter');
+        watchFile(filePath, callback);
+
+        // Verify onDidChange was called (callback is wrapped in debounce logic)
+        expect(mockWatcher.onDidChange).to.have.been.calledOnce;
+        expect(mockWatcher.onDidChange).to.have.been.calledWith(sinon.match.func);
     });
 
-    test('emits change message when context changes', async () => {
-        ensureStub.restore();
-        watchStub.restore();
+    test('watchFile returns a Disposable', () => {
+        const filePath = path.join('home', 'user', '.kube', 'config');
 
-        // Make a temp sub-directory to avoid watching the whole temp directory
-        const tmpFile = tmp.fileSync({dir:`${path.basename(tmp.dirSync().name)}`});
-        const fileToWatch = fs.realpathSync(tmpFile.name);
-        fs.ensureFileSync(fileToWatch);
-        const notifier = WatchUtil.watchFileForContextChange(path.dirname(fileToWatch), path.basename(fileToWatch));
-        setTimeout(() => {
-            fs.writeFileSync(fileToWatch, 'current-context:test2');
-        }, 1000);
-        return new Promise<void>((res) => {
-            notifier.emitter.on('file-changed', (file) => {
-                expect(file).equals(undefined);
-                res();
-            });
-        }).finally(() => {
-            if (notifier && notifier.watcher) {
-                notifier.watcher.close();
-            }
-        });
+        const result = watchFile(filePath, () => {});
+
+        // Verify it returns a Disposable (has dispose method)
+        expect(result).to.have.property('dispose');
+        expect(result.dispose).to.be.a('function');
+    });
+
+    test('returned watcher can be disposed', () => {
+        const filePath = path.join('home', 'user', '.kube', 'config');
+
+        const watcher = watchFile(filePath, () => {});
+        watcher.dispose();
+
+        expect(mockWatcher.dispose).to.have.been.calledOnce;
     });
 });


### PR DESCRIPTION
Replace Node.js fs.watch with VS Code's FileSystemWatcher to fix Windows test timeout caused by endless file events bug (nodejs/node#61398).

Changes:
- src/util/watch.ts: New watchFile() function using workspace.createFileSystemWatcher with RelativePattern for reliable cross-platform file watching
- src/explorer.ts: Migrate kubeconfig watching to new API with callback pattern
- src/serverlessFunction/functionModel.ts: Replace multiple fs.watch calls with single glob pattern watcher for func.yaml files
- src/util/workspace.ts: Enhanced devfile watching to support all valid extensions (.yaml, .yml, .json for both devfile and .devfile variants)
- test/unit/util/watch.test.ts: Updated tests for new watchFile() API
- .gitignore: Add .claude/ directory

Benefits:
- Fixes Windows fs.watch endless events bug (VS Code uses parcel-watcher)
- Better performance (runs in VS Code's UtilityProcess)
- Cleaner code (callbacks instead of EventEmitters)
- More complete devfile detection (all valid extensions)

See:
- https://github.com/nodejs/node/issues/61398 (fs.watch endless file events on Windows)
- https://github.com/microsoft/vscode/issues/287800 (100% CPU on Windows with fs.watch)
- https://github.com/microsoft/vscode/wiki/File-Watcher-Internals (VS Code file watcher implementation)


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>