### PR TITLE
Fix: Use proper URL hostname parsing for registry validation

### DIFF
--- a/src/devfile-registry/devfileRegistryWrapper.ts
+++ b/src/devfile-registry/devfileRegistryWrapper.ts
@@ -361,8 +361,14 @@ export class RegistryResourceResolver {
      * Check if this registry is backed by the official GitHub devfile/registry repo.
      */
     private isGitHubBackedRegistry(registryUrl: string): boolean {
-        return registryUrl.includes('registry.devfile.io') ||
-               registryUrl.includes('registry.stage.devfile.io');
+        try {
+            const url = new URL(registryUrl);
+            return url.hostname === 'registry.devfile.io' ||
+                   url.hostname === 'registry.stage.devfile.io';
+        } catch {
+            // Invalid URL, not a GitHub-backed registry
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Security fix for CodeQL warnings about incomplete URL substring sanitization.

**Issue:**
Using `registryUrl.includes('registry.devfile.io')` could match malicious URLs like `https://evil.com?redirect=registry.devfile.io`.

**Fix:**
Parse URL and check hostname exactly using `new URL(registryUrl).hostname`. Only matches exact hostnames:
- registry.devfile.io
- registry.stage.devfile.io


Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>