### PR TITLE
Add component deployment to Kind/Minikube and OpenShift/K8s clusters (CRW-10962)

### DIFF
--- a/build/esbuild.extension.cjs
+++ b/build/esbuild.extension.cjs
@@ -41,7 +41,7 @@ async function buildExtension() {
     if (!isWatch) {
         console.log('🔍 Running TypeScript type-checking...');
         try {
-            execSync('tsc --noEmit -p tsconfig.json', { stdio: 'inherit' });
+            execSync(`node "${require.resolve('typescript/bin/tsc')}" --noEmit -p tsconfig.json`, { stdio: 'inherit' });
         } catch (err) {
             console.error('❌ TypeScript type-checking failed.');
             process.exit(1);

--- a/build/esbuild.webviews.cjs
+++ b/build/esbuild.webviews.cjs
@@ -20,7 +20,7 @@ const isWatch = process.argv.includes('--watch');
 // Verify the WebViews (skip in watch mode - VS Code editor handles this)
 if (!isWatch) {
     try {
-        execSync('tsc --noEmit -p ./src/webview/tsconfig.json', { stdio: 'inherit' });
+        execSync(`node "${require.resolve('typescript/bin/tsc')}" --noEmit -p ./src/webview/tsconfig.json`, { stdio: 'inherit' });
     } catch (err) {
         console.error('❌ TypeScript type-checking failed.');
         process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1820,27 +1820,27 @@
 				},
 				{
 					"command": "openshift.component.dev",
-					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-nrn.*/",
+					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-nrn.*/ && !(viewItem =~ /.*\\.dep-(?:str|run|stp).*/)",
 					"group": "c1@1"
 				},
 				{
 					"command": "openshift.component.dev.manual",
-					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-nrn.*/",
+					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-nrn.*/ && !(viewItem =~ /.*\\.dep-(?:str|run|stp).*/)",
 					"group": "c1@2"
 				},
 				{
 					"command": "openshift.component.dev.onPodman",
-					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-nrn.*/",
+					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-nrn.*/ && !(viewItem =~ /.*\\.dep-(?:str|run|stp).*/)",
 					"group": "c1@3"
 				},
 				{
 					"command": "openshift.component.dev.onPodman.manual",
-					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-nrn.*/",
+					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-nrn.*/ && !(viewItem =~ /.*\\.dep-(?:str|run|stp).*/)",
 					"group": "c1@4"
 				},
 				{
 					"command": "openshift.component.exitDevMode",
-					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-(?:str)|(?:run).*/",
+					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-(?:str|run).*/",
 					"group": "c1@5"
 				},
 				{
@@ -1850,12 +1850,12 @@
 				},
 				{
 					"command": "openshift.component.deploy",
-					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dep-nrn.*/ || viewItem =~ /openshift\\.component.*\\.dep-run.*/",
+					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dep-nrn.*/ && viewItem =~ /.*\\.dev-nrn.*/",
 					"group": "c2@0"
 				},
 				{
 					"command": "openshift.component.undeploy",
-					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dep-nrn.*/ || viewItem =~ /openshift\\.component.*\\.dep-run.*/",
+					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dep-run.*/ && viewItem =~ /.*\\.dev-nrn.*/",
 					"group": "c2@1"
 				},
 				{
@@ -2242,6 +2242,16 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Force extension to search for `oc` and `odo` CLI tools in PATH locations before using bundled binaries."
+					},
+					"openshiftToolkit.containerRegistryUrl": {
+						"type": "string",
+						"default": "",
+						"description": "Default container image registry URL for deploying components (e.g. quay.io, docker.io, ghcr.io)."
+					},
+					"openshiftToolkit.containerRegistryUsername": {
+						"type": "string",
+						"default": "",
+						"description": "Default username for the container image registry."
 					},
 					"openshiftToolkit.stopDevModeTimeout": {
 						"type": "number",

--- a/src/componentsView.ts
+++ b/src/componentsView.ts
@@ -129,18 +129,20 @@ export class ComponentsTreeDataProvider extends BaseTreeDataProvider<ComponentIn
         this.odoWorkspace.onDidChangeComponents(() => {
             this.refresh();
         });
-        Component.onDidStateChanged(() => this.refresh());
+        Component.onDidStateChanged((ctx) => this.refresh(ctx));
     }
 
     private refresh(contextPath?: string): void {
-        if (contextPath) {
-            const folder = this.odoWorkspace.findComponent(vsc.workspace.getWorkspaceFolder(vsc.Uri.parse(contextPath)));
-            this.onDidChangeTreeDataEmitter.fire(new ComponentInfoRoot(folder));
-        } else {
-            this.children = undefined; // Invalidate children cache so they wll be re-created
-            this.odoWorkspace.reset();
-            this.onDidChangeTreeDataEmitter.fire(undefined);
+        if (contextPath && this.children) {
+            const node = this.children.find(c => c.contextPath === contextPath);
+            if (node) {
+                this.onDidChangeTreeDataEmitter.fire(node);
+                return;
+            }
         }
+        this.children = undefined;
+        this.odoWorkspace.reset();
+        this.onDidChangeTreeDataEmitter.fire(undefined);
     }
 
     @vsCommand('openshift.componentsView.refresh')

--- a/src/devfile/applyCommand.ts
+++ b/src/devfile/applyCommand.ts
@@ -6,111 +6,214 @@
 import * as fs from 'fs/promises';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
+import { fileSync } from 'tmp';
 import { window } from 'vscode';
+import { CommandText } from '../base/command';
 import { DownloadUtil } from '../downloadUtil/download';
 import { Oc } from '../oc/ocWrapper';
+import { KubernetesVariant } from '../oc/types';
+import { ToolsConfig } from '../tools';
 import { Apply, DeployedResource } from '../odo/componentTypeDescription';
+import { detectKubernetesVariant, getOpenShiftRegistryUrl, isOpenShiftCluster } from '../util/kubeUtils';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
+import { TokenStore } from '../util/credentialManager';
+import { ContainerRuntimeDetector } from '../util/containerRuntime';
+import { OpenShiftTerminalManager } from '../webview/openshift-terminal/openShiftTerminal';
+import { ensurePullSecret, ensureRegistryConfigured, OPENSHIFT_INTERNAL_REGISTRY, rewriteImageName } from './registryConfig';
 import { VariableResolver } from './variableResolver';
 
+export function debugEcho(cmd: string): string {
+    const masked = cmd
+        .replace(/--token[= ]\S+/g, '--token ****')
+        .replace(/-p[= ]\S+/g, '-p ****');
+    return `printf "\\x1b[2m+ ${masked}\\x1b[0m\\n"`;
+}
+
+export interface DeployScriptContribution {
+    scriptLines: string[];
+    tempFiles: string[];
+    resources: DeployedResource[];
+    registryKey?: string;
+    pullSecretWarning?: string;
+}
+
 export class ApplyCommandExecutor {
+    private static imageNameMap = new Map<string, string>();
+    private static locallyLoadedImages = new Set<string>();
+
+    public static resetImageNameMap(): void {
+        this.imageNameMap.clear();
+        this.locallyLoadedImages.clear();
+    }
+
     public static async execute(
         componentFolder: ComponentWorkspaceFolder,
         commandId: string,
         apply: Apply,
     ): Promise<DeployedResource[]> {
+        const contribution = await this.prepareScript(componentFolder, commandId, apply, 1, 1);
+
+        const scriptLines = [
+            ...contribution.scriptLines,
+            'echo ""',
+            'printf "\\x1b[32m✓ Done\\x1b[0m\\n"',
+        ];
+        const tempScript = fileSync({ prefix: 'apply-', postfix: '.sh' });
+        await fs.writeFile(tempScript.name, `#!/bin/sh\nset -e\n${scriptLines.join('\n')}`, 'utf-8');
+
+        const command = new CommandText('/bin/sh', tempScript.name);
+
+        return new Promise<DeployedResource[]>((resolve, reject) => {
+            void OpenShiftTerminalManager.getInstance().createTerminal(
+                command,
+                `Apply: ${commandId}`,
+                componentFolder.contextPath,
+                process.env,
+                {
+                    onExit() {
+                        void fs.unlink(tempScript.name).catch(() => {});
+                        for (const f of contribution.tempFiles) {
+                            void fs.unlink(f).catch(() => {});
+                        }
+                        resolve(contribution.resources);
+                    },
+                },
+            ).catch(reject);
+        });
+    }
+
+    public static async prepareScript(
+        componentFolder: ComponentWorkspaceFolder,
+        commandId: string,
+        apply: Apply,
+        stepNumber: number,
+        totalSteps: number,
+    ): Promise<DeployScriptContribution> {
         const devfile = componentFolder.component.devfileData.devfile;
         const devfilePath = componentFolder.component.devfilePath;
 
-        // 1. Resolve variables in apply command
         const resolvedApply = VariableResolver.resolveApply(devfile, apply);
 
-        // 2. Find the kubernetes component
         const component = devfile.components?.find((c) => c.name === resolvedApply.component);
 
         if (!component) {
             throw new Error(`Component '${resolvedApply.component}' not found in devfile`);
         }
 
-        // 3. Apply kubernetes/openshift resources OR build images
         if (component.kubernetes) {
-            return await this.applyKubernetesComponent(
+            return await this.prepareApplyScript(
                 devfile,
                 component.kubernetes,
                 path.dirname(devfilePath),
                 commandId,
+                stepNumber,
+                totalSteps,
             );
         }
         if ((component as any).openshift) {
-            // OpenShift components use same structure as kubernetes
-            return await this.applyKubernetesComponent(
+            return await this.prepareApplyScript(
                 devfile,
                 (component as any).openshift,
                 path.dirname(devfilePath),
                 commandId,
+                stepNumber,
+                totalSteps,
             );
         }
         if ((component as any).image) {
-            // Image build component - skip for now (requires podman/docker/buildah)
-            // TODO: Implement image building in future PR
-            // Silently skip image builds - they require container runtime integration
-            return []; // No resources deployed for image builds
+            return await this.prepareBuildScript(
+                (component as any).image,
+                path.dirname(devfilePath),
+                stepNumber,
+                totalSteps,
+            );
         }
         throw new Error(
             `Component '${resolvedApply.component}' is not a kubernetes, openshift, or image component`,
         );
     }
 
-    private static async applyKubernetesComponent(
+    private static async prepareApplyScript(
         devfile: any,
         k8sComponent: any,
         devfileDir: string,
         commandId: string,
-    ): Promise<DeployedResource[]> {
+        stepNumber: number,
+        totalSteps: number,
+    ): Promise<DeployScriptContribution> {
         let manifestContent: string;
 
-        // Load manifest content from inlined YAML or URI
         if (k8sComponent.inlined) {
             manifestContent = k8sComponent.inlined;
         } else if (k8sComponent.uri) {
-            // Resolve variables in URI first
             const resolvedUri = VariableResolver.resolveValue(devfile, k8sComponent.uri);
             manifestContent = await this.loadManifestFromUri(resolvedUri, devfileDir);
         } else {
             throw new Error('Kubernetes component must have either inlined or uri specified');
         }
 
-        // Resolve variables in the manifest content
-        const resolvedManifest = VariableResolver.resolveKubernetesContent(
+        let resolvedManifest = VariableResolver.resolveKubernetesContent(
             devfile,
             manifestContent,
         );
 
-        // Apply to cluster using existing Oc wrapper (idempotent)
-        try {
-            await Oc.Instance.applyConfiguration(resolvedManifest);
-            void window.showInformationMessage(`Applied resources for command '${commandId}'`);
-        } catch (err) {
-            throw new Error(
-                `Failed to apply Kubernetes resources: ${err.message}\n` +
-                    'Deployment can be retried - oc apply is idempotent.',
-            );
+        for (const [original, retagged] of this.imageNameMap) {
+            resolvedManifest = resolvedManifest.replaceAll(original, retagged);
         }
 
-        // Parse and return deployed resources for tracking
-        return this.parseDeployedResources(resolvedManifest);
+        let patchedContainers: string[] = [];
+        if (this.locallyLoadedImages.size > 0) {
+            const result = this.patchImagePullPolicy(resolvedManifest);
+            resolvedManifest = result.manifest;
+            patchedContainers = result.patchedContainers;
+        }
+
+        const resources = this.parseDeployedResources(resolvedManifest);
+        const resourceSummary = resources.map(r => `${r.kind}/${r.name}`).join(', ');
+
+        const ocPath = await ToolsConfig.detect('oc');
+        if (!ocPath) {
+            throw new Error('oc CLI not found. Install or configure the OpenShift CLI tool.');
+        }
+
+        const tempFile = fileSync({ prefix: 'manifest-', postfix: '.yaml' });
+        await fs.writeFile(tempFile.name, resolvedManifest, 'utf-8');
+
+        const applyCmd = `"${ocPath}" apply --server-side=true -f ${tempFile.name}`;
+        const scriptLines = [
+            `printf "\\x1b[1m[${stepNumber}/${totalSteps}] Applying Kubernetes resources: ${commandId}\\x1b[0m\\n"`,
+            `echo " •  Resources: ${resourceSummary}"`,
+        ];
+        if (patchedContainers.length > 0) {
+            scriptLines.push(
+                'printf \'\\x1b[2m ⓘ  Patched imagePullPolicy: IfNotPresent for locally loaded images\\x1b[0m\\n\'',
+                `printf "\\x1b[2m    (containers: ${patchedContainers.join(', ')} — prevents pulling from remote registry)\\x1b[0m\\n"`,
+            );
+        }
+        scriptLines.push(
+            'echo ""',
+            debugEcho(applyCmd),
+            applyCmd,
+            'echo ""',
+            'printf "\\x1b[32m ✓  Resources applied successfully\\x1b[0m\\n"',
+            'echo ""',
+        );
+
+        return {
+            scriptLines,
+            tempFiles: [tempFile.name],
+            resources,
+        };
     }
 
     private static async loadManifestFromUri(
         uri: string,
         devfileDir: string,
     ): Promise<string> {
-        // Handle HTTP/HTTPS URLs
         if (uri.startsWith('http://') || uri.startsWith('https://')) {
             return this.downloadManifest(uri);
         }
 
-        // Handle file paths (relative or absolute)
         const manifestPath = path.isAbsolute(uri) ? uri : path.join(devfileDir, uri);
 
         try {
@@ -121,7 +224,7 @@ export class ApplyCommandExecutor {
     }
 
     private static async downloadManifest(url: string): Promise<string> {
-        const tempFile = path.join(require('os').tmpdir(), `manifest-${Date.now()}.yaml`);
+        const tempFile = fileSync({ prefix: 'manifest-', postfix: '.yaml' }).name;
 
         try {
             await DownloadUtil.downloadFile(url, tempFile);
@@ -129,7 +232,6 @@ export class ApplyCommandExecutor {
             await fs.unlink(tempFile);
             return content;
         } catch (err) {
-            // Cleanup on error
             try {
                 await fs.unlink(tempFile);
             } catch {
@@ -139,12 +241,336 @@ export class ApplyCommandExecutor {
         }
     }
 
-    private static parseDeployedResources(manifestContent: string): DeployedResource[] {
+    private static async prepareBuildScript(
+        imageComponent: any,
+        devfileDir: string,
+        stepNumber: number,
+        totalSteps: number,
+    ): Promise<DeployScriptContribution> {
+        const runtime = await ContainerRuntimeDetector.detectBuildRuntime();
+        if (!runtime) {
+            throw new Error(
+                'No container runtime found. Install podman, docker, or buildah to build images.',
+            );
+        }
+
+        const imageName = imageComponent.imageName;
+        const dockerfilePath = imageComponent.dockerfile?.uri || 'Dockerfile';
+        const buildContext = imageComponent.dockerfile?.buildContext || '.';
+
+        const resolvedDockerfile = path.isAbsolute(dockerfilePath)
+            ? dockerfilePath
+            : path.join(devfileDir, dockerfilePath);
+        const resolvedContext = path.isAbsolute(buildContext)
+            ? buildContext
+            : devfileDir;
+
+        const isOpenShift = await isOpenShiftCluster();
+        const k8sVariant = isOpenShift
+            ? undefined
+            : await detectKubernetesVariant();
+
+        const buildCmd = ContainerRuntimeDetector.getBuildCommand(
+            runtime, imageName, resolvedDockerfile, resolvedContext,
+        );
+
+        const scriptLines: string[] = [
+            `printf "\\x1b[1m[${stepNumber}/${totalSteps}] Building image: ${imageName}\\x1b[0m\\n"`,
+            `echo " •  Building image locally using ${runtime}..."`,
+            'echo ""',
+            debugEcho(buildCmd),
+            buildCmd,
+            'echo ""',
+            'echo " ✓  Image built successfully"',
+            'echo ""',
+        ];
+
+        let registryKey = '';
+        let pullSecretWarning = '';
+
+        if (k8sVariant === KubernetesVariant.Kind) {
+            const { KubeConfig } = await import('@kubernetes/client-node');
+            const kc = new KubeConfig();
+            kc.loadFromDefault();
+            const contextName = kc.currentContext;
+            const kindClusterName = contextName?.startsWith('kind-')
+                ? contextName.slice('kind-'.length)
+                : undefined;
+
+            ApplyCommandExecutor.locallyLoadedImages.add(imageName);
+            const retagCmd = ContainerRuntimeDetector.getRetagCommand(runtime, imageName);
+            const kindLoadCmd = ContainerRuntimeDetector.getKindLoadCommand(runtime, imageName, kindClusterName);
+            if (retagCmd) {
+                scriptLines.push(
+                    `printf "\\x1b[2m ⓘ  Retagging image as docker.io/library/${imageName} (${runtime} uses localhost/ prefix, Kind expects docker.io/library/)\\x1b[0m\\n"`,
+                    debugEcho(retagCmd),
+                    retagCmd,
+                    'echo ""',
+                );
+            }
+            scriptLines.push(
+                'echo " •  Loading image into Kind cluster..."',
+                'echo ""',
+                debugEcho(kindLoadCmd),
+                kindLoadCmd,
+                'echo ""',
+                'echo " ✓  Image loaded into Kind cluster"',
+            );
+        } else if (k8sVariant === KubernetesVariant.Minikube) {
+            ApplyCommandExecutor.locallyLoadedImages.add(imageName);
+            const retagCmd = ContainerRuntimeDetector.getRetagCommand(runtime, imageName);
+            const minikubeLoadCmd = ContainerRuntimeDetector.getMinikubeLoadCommand(runtime, imageName);
+            if (retagCmd) {
+                scriptLines.push(
+                    `printf "\\x1b[2m ⓘ  Retagging image as docker.io/library/${imageName} (${runtime} uses localhost/ prefix, Minikube expects docker.io/library/)\\x1b[0m\\n"`,
+                    debugEcho(retagCmd),
+                    retagCmd,
+                    'echo ""',
+                );
+            }
+            scriptLines.push(
+                'echo " •  Loading image into Minikube cluster..."',
+                'echo ""',
+                debugEcho(minikubeLoadCmd),
+                minikubeLoadCmd,
+                'echo ""',
+                'echo " ✓  Image loaded into Minikube cluster"',
+            );
+        } else if (isOpenShift) {
+            let credentials = await ensureRegistryConfigured(runtime, true);
+            if (!credentials) {
+                throw new Error('Registry configuration cancelled. Cannot push image without a registry.');
+            }
+
+            if (credentials.registry === OPENSHIFT_INTERNAL_REGISTRY) {
+                const registryUrl = await getOpenShiftRegistryUrl();
+                const namespace = await Oc.Instance.getActiveProject();
+                if (registryUrl && namespace) {
+                    const targetImage = `${registryUrl}/${namespace}/${imageName}`;
+                    ApplyCommandExecutor.imageNameMap.set(imageName, targetImage);
+
+                    const { KubeConfig } = await import('@kubernetes/client-node');
+                    const kc = new KubeConfig();
+                    kc.loadFromDefault();
+                    const user = kc.getCurrentUser();
+                    const token = user?.token;
+                    if (token) {
+                        try {
+                            await ContainerRuntimeDetector.loginToRegistry(runtime, registryUrl, 'unused', token);
+                        } catch {
+                            void window.showWarningMessage(
+                                `Failed to log in to OpenShift registry at ${registryUrl}. `
+                                + 'Your cluster session token may be expired. '
+                                + 'Use the "Log in to Cluster" action in the OpenShift Explorer to refresh your session, then retry the deploy.',
+                            );
+                            throw new Error(`OpenShift registry login failed for ${registryUrl}`);
+                        }
+                    }
+
+                    const tagCmd = `${runtime} tag ${imageName} ${targetImage}`;
+                    const pushCmd = ContainerRuntimeDetector.getPushCommand(runtime, targetImage);
+                    scriptLines.push(
+                        `echo " •  Retagging image: ${imageName} → ${targetImage}"`,
+                        debugEcho(tagCmd),
+                        tagCmd,
+                        'echo " •  Pushing image to registry..."',
+                        'echo ""',
+                        debugEcho(pushCmd),
+                        pushCmd,
+                        'echo ""',
+                        'echo " ✓  Image pushed to OpenShift registry"',
+                    );
+                } else {
+                    throw new Error(
+                        'Could not detect OpenShift internal registry URL. '
+                        + 'Select an external registry (quay.io, docker.io, etc.) instead.',
+                    );
+                }
+            } else {
+                registryKey = `${credentials.registry}/${credentials.username}`;
+
+                if (credentials.password) {
+                    let loggedIn = false;
+                    while (!loggedIn) {
+                        try {
+                            await ContainerRuntimeDetector.loginToRegistry(
+                                runtime, credentials.registry, credentials.username, credentials.password,
+                            );
+                            loggedIn = true;
+                        } catch {
+                            await TokenStore.setItem('registry', registryKey, '');
+                            const action = await window.showErrorMessage(
+                                `Login to ${credentials.registry} failed. Check your username and password.`,
+                                'Retry', 'Cancel',
+                            );
+                            if (action !== 'Retry') {
+                                throw new Error('Registry login cancelled.');
+                            }
+                            credentials = await ensureRegistryConfigured(runtime, true);
+                            if (!credentials) {
+                                throw new Error('Registry configuration cancelled.');
+                            }
+                            registryKey = `${credentials.registry}/${credentials.username}`;
+                        }
+                    }
+                }
+
+                const targetImage = rewriteImageName(imageName, credentials.registry, credentials.username);
+
+                if (targetImage !== imageName) {
+                    ApplyCommandExecutor.imageNameMap.set(imageName, targetImage);
+                    const tagCmd = `${runtime} tag ${imageName} ${targetImage}`;
+                    scriptLines.push(
+                        `echo " •  Retagging image: ${imageName} → ${targetImage}"`,
+                        debugEcho(tagCmd),
+                        tagCmd,
+                        'echo ""',
+                    );
+                }
+
+                const pushCmd = ContainerRuntimeDetector.getPushCommand(runtime, targetImage);
+                scriptLines.push(
+                    `echo " •  Pushing image to ${credentials.registry}..."`,
+                    'echo ""',
+                    debugEcho(pushCmd),
+                    pushCmd,
+                    'echo ""',
+                    'echo " ✓  Image pushed to registry"',
+                );
+                const secretCreated = await ensurePullSecret(
+                    credentials.registry, credentials.username, credentials.password,
+                );
+                if (!secretCreated) {
+                    pullSecretWarning = credentials.registry;
+                }
+            }
+        } else {
+            let credentials = await ensureRegistryConfigured(runtime);
+            if (!credentials) {
+                throw new Error('Registry configuration cancelled. Cannot push image without a registry.');
+            }
+
+            registryKey = `${credentials.registry}/${credentials.username}`;
+
+            if (credentials.password) {
+                let loggedIn = false;
+                while (!loggedIn) {
+                    try {
+                        await ContainerRuntimeDetector.loginToRegistry(
+                            runtime, credentials.registry, credentials.username, credentials.password,
+                        );
+                        loggedIn = true;
+                    } catch {
+                        await TokenStore.setItem('registry', registryKey, '');
+                        const action = await window.showErrorMessage(
+                            `Login to ${credentials.registry} failed. Check your username and password.`,
+                            'Retry', 'Cancel',
+                        );
+                        if (action !== 'Retry') {
+                            throw new Error('Registry login cancelled.');
+                        }
+                        credentials = await ensureRegistryConfigured(runtime);
+                        if (!credentials) {
+                            throw new Error('Registry configuration cancelled.');
+                        }
+                        registryKey = `${credentials.registry}/${credentials.username}`;
+                    }
+                }
+            }
+
+            const targetImage = rewriteImageName(imageName, credentials.registry, credentials.username);
+
+            if (targetImage !== imageName) {
+                ApplyCommandExecutor.imageNameMap.set(imageName, targetImage);
+                const tagCmd = `${runtime} tag ${imageName} ${targetImage}`;
+                scriptLines.push(
+                    `echo " •  Retagging image: ${imageName} → ${targetImage}"`,
+                    debugEcho(tagCmd),
+                    tagCmd,
+                    'echo ""',
+                );
+            }
+
+            const pushCmd = ContainerRuntimeDetector.getPushCommand(runtime, targetImage);
+            scriptLines.push(
+                `echo " •  Pushing image to ${credentials.registry}..."`,
+                'echo ""',
+                debugEcho(pushCmd),
+                pushCmd,
+                'echo ""',
+                'echo " ✓  Image pushed to registry"',
+            );
+            const secretCreated = await ensurePullSecret(
+                credentials.registry, credentials.username, credentials.password,
+            );
+            if (!secretCreated) {
+                pullSecretWarning = credentials.registry;
+            }
+        }
+
+        scriptLines.push(
+            'echo ""',
+            'printf "\\x1b[32m ✓  Image delivery complete\\x1b[0m\\n"',
+            'echo ""',
+        );
+
+        return {
+            scriptLines,
+            tempFiles: [],
+            resources: [],
+            registryKey: registryKey || undefined,
+            pullSecretWarning: pullSecretWarning || undefined,
+        };
+    }
+
+    public static patchImagePullPolicy(manifestContent: string): { manifest: string; patchedContainers: string[] } {
+        const patchedContainers: string[] = [];
+        try {
+            const docs = yaml.loadAll(manifestContent);
+            const patched = docs.map(doc => {
+                if (!doc || typeof doc !== 'object') return doc;
+
+                const patchContainers = (containers: any[], resourceName: string) => {
+                    if (!Array.isArray(containers)) return;
+                    for (const container of containers) {
+                        if (container?.image && this.locallyLoadedImages.has(container.image)) {
+                            if (!container.imagePullPolicy || container.imagePullPolicy === 'Always') {
+                                container.imagePullPolicy = 'IfNotPresent';
+                                patchedContainers.push(`${resourceName}/${container.name}`);
+                            }
+                        }
+                    }
+                };
+
+                const d = doc as any;
+                const resourceName = `${d.kind || 'unknown'}/${d.metadata?.name || 'unknown'}`;
+                const templateSpec = d.spec?.template?.spec;
+                if (templateSpec) {
+                    patchContainers(templateSpec.containers, resourceName);
+                    patchContainers(templateSpec.initContainers, resourceName);
+                }
+                if (d.kind === 'Pod' && d.spec) {
+                    patchContainers(d.spec.containers, resourceName);
+                    patchContainers(d.spec.initContainers, resourceName);
+                }
+
+                return doc;
+            });
+
+            return {
+                manifest: patched.map(doc => yaml.dump(doc, { noRefs: true })).join('---\n'),
+                patchedContainers,
+            };
+        } catch {
+            return { manifest: manifestContent, patchedContainers };
+        }
+    }
+
+    public static parseDeployedResources(manifestContent: string): DeployedResource[] {
         const resources: DeployedResource[] = [];
         const timestamp = new Date().toISOString();
 
         try {
-            // Parse YAML (can contain multiple documents)
             const docs = yaml.loadAll(manifestContent);
 
             for (const doc of docs) {
@@ -161,7 +587,6 @@ export class ApplyCommandExecutor {
             }
         } catch (err) {
             // If parsing fails, return empty array - not critical for deployment
-            // Silently ignore parsing errors
         }
 
         return resources;

--- a/src/devfile/deploy.ts
+++ b/src/devfile/deploy.ts
@@ -6,12 +6,20 @@
 import * as fs from 'fs/promises';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
+import { fileSync } from 'tmp';
+import { window } from 'vscode';
+import { CommandText } from '../base/command';
 import { OpenshiftLogger } from '../util/childProcessUtil';
+import { TokenStore } from '../util/credentialManager';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
-import { Data, Command, DeployedResource, DeployState } from '../odo/componentTypeDescription';
+import { Data, Command, DeployedResource, DeployState, DeployStateFile } from '../odo/componentTypeDescription';
+import { KubeConfig } from '@kubernetes/client-node';
+import { Oc } from '../oc/ocWrapper';
+import { isOpenShiftCluster } from '../util/kubeUtils';
+import { OpenShiftTerminalManager } from '../webview/openshift-terminal/openShiftTerminal';
 import { DevfileResolver } from './devfileResolver';
 import { DevfileCommandRunner } from './devfileCommandRunner';
-import { ApplyCommandExecutor } from './applyCommand';
+import { ApplyCommandExecutor, DeployScriptContribution } from './applyCommand';
 
 export interface ComponentDeployOptions {
     componentPath: string;
@@ -50,7 +58,7 @@ export async function deployComponent(
     const resolver = new DevfileResolver();
     const resolvedDevfile = await resolver.resolve(sourceDevfile, {
         devfilePath,
-        inlineResources: true,  // Inline URIs from local files or URLs
+        inlineResources: true,
         logger: options.logger
     });
 
@@ -73,58 +81,163 @@ export async function deployComponent(
 
     logInfo(ctx, `Found ${deployCommands.length} deploy command(s)`);
 
-    // 5. Execute each deploy command (idempotent - safe to retry)
+    // 5. Separate apply commands (unified script) from exec commands (run after)
+    const componentName = resolvedDevfile.metadata.name;
+    ApplyCommandExecutor.resetImageNameMap();
+
+    const contributions: DeployScriptContribution[] = [];
+    const execCommands: Command[] = [];
     const deployedCommands: string[] = [];
-    const allDeployedResources: DeployedResource[] = [];
 
-    for (const cmd of deployCommands) {
-        logInfo(ctx, `Executing deploy command: ${cmd.id}`);
-
-        try {
-            // Execute command and collect deployed resources
-            if (cmd.apply) {
-                const resources = await ApplyCommandExecutor.execute(componentFolder, cmd.id, cmd.apply);
-                allDeployedResources.push(...resources);
-            } else {
-                // Composite or other command types
-                await DevfileCommandRunner.execute(componentFolder, cmd.id);
-            }
-
+    for (let i = 0; i < deployCommands.length; i++) {
+        const cmd = deployCommands[i];
+        if (cmd.apply) {
+            const contribution = await ApplyCommandExecutor.prepareScript(
+                componentFolder, cmd.id, cmd.apply, i + 1, deployCommands.length,
+            );
+            contributions.push(contribution);
             deployedCommands.push(cmd.id);
-            logInfo(ctx, `✓ Command '${cmd.id}' completed`);
+        } else {
+            execCommands.push(cmd);
+        }
+    }
+
+    // 6. Build combined script and run in a single terminal
+    const allResources: DeployedResource[] = [];
+    const allTempFiles: string[] = [];
+    let registryKey = '';
+
+    const scriptLines: string[] = [
+        `printf "\\x1b[1m↪ Deploying component: ${componentName}\\x1b[0m\\n"`,
+        'echo ""',
+    ];
+
+    let pullSecretWarning = '';
+
+    for (const c of contributions) {
+        scriptLines.push(...c.scriptLines);
+        allTempFiles.push(...c.tempFiles);
+        allResources.push(...c.resources);
+        if (c.registryKey) {
+            registryKey = c.registryKey;
+        }
+        if (c.pullSecretWarning) {
+            pullSecretWarning = c.pullSecretWarning;
+        }
+    }
+
+    scriptLines.push(
+        'printf "\\x1b[32m✓ Deployment complete\\x1b[0m\\n"',
+    );
+
+    if (pullSecretWarning) {
+        scriptLines.push(
+            'echo ""',
+            `printf "\\x1b[33m⚠  No image pull secret found for ${pullSecretWarning}.\\x1b[0m\\n"`,
+            'printf \'\\x1b[33m   If your registry is private, the deployment will fail to pull the image.\\x1b[0m\\n\'',
+            'printf \'\\x1b[33m   Make sure your registry is publicly accessible, or create\\x1b[0m\\n\'',
+            'printf \'\\x1b[33m   an image pull secret manually in your namespace.\\x1b[0m\\n\'',
+        );
+    }
+
+    const tempScript = fileSync({ prefix: 'deploy-', postfix: '.sh' });
+    await fs.writeFile(tempScript.name, `#!/bin/sh\nset -e\n${scriptLines.join('\n')}`, 'utf-8');
+    allTempFiles.push(tempScript.name);
+
+    const command = new CommandText('/bin/sh', tempScript.name);
+
+    logInfo(ctx, `↪ Deploying component: ${componentName}`);
+
+    // 7. Run the unified terminal
+    let terminalOutput = '';
+
+    await new Promise<void>((resolve, reject) => {
+        void OpenShiftTerminalManager.getInstance().createTerminal(
+            command,
+            `Deploy: ${componentName}`,
+            componentFolder.contextPath,
+            process.env,
+            {
+                onText(text: string) {
+                    terminalOutput += text;
+                },
+                onExit(exitCode: number) {
+                    for (const f of allTempFiles) {
+                        void fs.unlink(f).catch(() => {});
+                    }
+
+                    if (registryKey && /unauthorized|authentication required|denied/i.test(terminalOutput)) {
+                        void TokenStore.setItem('registry', registryKey, '').then(() => {
+                            void window.showErrorMessage(
+                                'Push failed: authentication error. Saved credentials have been cleared. Please retry the deploy.',
+                            );
+                        });
+                    }
+
+                    if (exitCode !== 0) {
+                        reject(new Error('Deploy script failed — check the terminal output for details'));
+                    } else {
+                        resolve();
+                    }
+                },
+            },
+        ).catch(reject);
+    });
+
+    // 8. Run exec commands after terminal completes (if any)
+    for (const cmd of execCommands) {
+        try {
+            await DevfileCommandRunner.execute(componentFolder, cmd.id);
+            deployedCommands.push(cmd.id);
         } catch (err) {
-            logError(ctx, `✗ Command '${cmd.id}' failed: ${err.message}`);
-            logError(ctx, 'Deployment can be retried - oc apply is idempotent');
+            logError(ctx, `  ✗ Command '${cmd.id}' failed: ${err.message}`);
             throw err;
         }
     }
 
-    // 6. Save deployment state
+    // 9. Save deployment state
+    const kc = new KubeConfig();
+    kc.loadFromDefault();
+    const clusterServer = kc.getCurrentCluster()?.server || 'unknown';
+    const namespace = await Oc.Instance.getActiveProject() || 'default';
+
     await saveDeployState({
         version: 1,
-        componentName: resolvedDevfile.metadata.name,
+        componentName,
         deployedAt: new Date().toISOString(),
-        platform: 'cluster',  // TODO: detect podman vs cluster
-        resources: allDeployedResources,
+        platform: await isOpenShiftCluster() ? 'openshift' : 'kubernetes',
+        cluster: clusterServer,
+        namespace,
+        resources: allResources,
     }, ctx.componentPath);
 
-    logInfo(ctx, 'Deployment completed successfully');
+    logInfo(ctx, `✓ Deployment complete (${deployedCommands.length} commands, ${allResources.length} resources)`);
 
     return {
-        componentName: resolvedDevfile.metadata.name,
+        componentName,
         deployedCommands,
-        deployedResources: allDeployedResources,
+        deployedResources: allResources,
         success: true,
     };
 }
 
-function findDeployCommands(devfile: Data): Command[] {
-    return (devfile.commands || []).filter(cmd => {
-        // Commands with group.kind === 'deploy'
-        if (cmd.exec?.group?.kind === 'deploy') return true;
-        if (cmd.composite?.group?.kind === 'deploy') return true;
-        if (cmd.apply) return true;  // All apply commands are deploy commands
+export function findDeployCommands(devfile: Data): Command[] {
+    const commands = devfile.commands || [];
 
+    const compositeDeployCmd = commands.find(cmd =>
+        cmd.composite?.group?.kind === 'deploy'
+    );
+
+    if (compositeDeployCmd) {
+        const subCommandIds = compositeDeployCmd.composite.commands;
+        return subCommandIds
+            .map(id => commands.find(cmd => cmd.id === id))
+            .filter((cmd): cmd is Command => cmd !== undefined);
+    }
+
+    return commands.filter(cmd => {
+        if (cmd.exec?.group?.kind === 'deploy') return true;
+        if (cmd.apply?.group?.kind === 'deploy') return true;
         return false;
     });
 }
@@ -157,10 +270,33 @@ function logError(ctx: DeployContext, message: string) {
     }
 }
 
+export function deployContextKey(clusterServer: string, namespace: string): string {
+    return `${clusterServer}/${namespace}`;
+}
+
 async function saveDeployState(state: DeployState, componentPath: string): Promise<void> {
     const odoDir = path.join(componentPath, '.odo');
     await fs.mkdir(odoDir, { recursive: true });
 
     const stateFile = path.join(odoDir, 'deploystate.json');
-    await fs.writeFile(stateFile, JSON.stringify(state, null, 2), 'utf-8');
+
+    let file: DeployStateFile = { version: 2, deployments: {} };
+    try {
+        const raw = await fs.readFile(stateFile, 'utf-8');
+        const parsed = JSON.parse(raw);
+        if (parsed.version === 1 && !parsed.deployments) {
+            const key = deployContextKey(parsed.cluster, parsed.namespace);
+            file = { version: 2, deployments: { [key]: parsed } };
+        } else if (parsed.deployments) {
+            file = parsed;
+        }
+    } catch {
+        // no existing file
+    }
+
+    const key = deployContextKey(state.cluster, state.namespace);
+    file.deployments[key] = state;
+    file.version = 2;
+
+    await fs.writeFile(stateFile, JSON.stringify(file, null, 2), 'utf-8');
 }

--- a/src/devfile/registryConfig.ts
+++ b/src/devfile/registryConfig.ts
@@ -1,0 +1,257 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { QuickPickItem, QuickPickItemKind, ThemeIcon, window, workspace } from 'vscode';
+import { CommandText, CommandOption } from '../base/command';
+import { CliChannel } from '../cli';
+import { ToolsConfig } from '../tools';
+import { quickBtn, inputValue } from '../util/inputValue';
+import { TokenStore } from '../util/credentialManager';
+import { ContainerRuntimeDetector, ContainerRuntime } from '../util/containerRuntime';
+
+export interface RegistryCredentials {
+    registry: string;
+    username: string;
+    password: string;
+}
+
+const WELL_KNOWN_REGISTRIES: QuickPickItem[] = [
+    { label: 'quay.io', description: 'Red Hat Quay' },
+    { label: 'docker.io', description: 'Docker Hub' },
+    { label: 'ghcr.io', description: 'GitHub Container Registry' },
+];
+
+export const OPENSHIFT_INTERNAL_REGISTRY = 'openshift-internal';
+
+export async function ensureRegistryConfigured(
+    runtime: ContainerRuntime,
+    isOpenShift = false,
+): Promise<RegistryCredentials | null> {
+    const config = workspace.getConfiguration('openshiftToolkit');
+    let registry = config.get<string>('containerRegistryUrl') || '';
+    let username = config.get<string>('containerRegistryUsername') || '';
+
+    enum Step { selectRegistry, enterRegistry, enterUsername, enterPassword }
+    let step: Step = Step.selectRegistry;
+    let password: string;
+
+    while (step !== undefined) {
+        switch (step) {
+            case Step.selectRegistry: {
+                const result = await selectRegistry(registry, isOpenShift);
+                if (result === null) return null;
+                if (result === undefined) { step = Step.enterRegistry; break; }
+                if (result === OPENSHIFT_INTERNAL_REGISTRY) {
+                    return { registry: OPENSHIFT_INTERNAL_REGISTRY, username: '', password: '' };
+                }
+                registry = result;
+                step = Step.enterUsername;
+                break;
+            }
+            case Step.enterRegistry: {
+                const validate = (v: string) => {
+                    if (!v) return 'Registry URL cannot be empty';
+                    if (v.includes(' ')) return 'Registry URL cannot contain spaces';
+                    return undefined;
+                };
+                const result = await inputValue(
+                    'Provide container registry URL',
+                    registry, false, validate,
+                    'e.g. quay.io, registry.example.com',
+                );
+                if (result === null) return null;
+                if (result === undefined) { step = Step.selectRegistry; break; }
+                registry = result;
+                step = Step.enterUsername;
+                break;
+            }
+            case Step.enterUsername: {
+                const validate = (v: string) => !v ? 'Username cannot be empty' : undefined;
+                const result = await inputValue(
+                    `Provide username for ${registry}`,
+                    username, false, validate,
+                    `Username for: ${registry}`,
+                );
+                if (result === null) return null;
+                if (result === undefined) { step = Step.selectRegistry; break; }
+                username = result;
+                step = Step.enterPassword;
+                break;
+            }
+            case Step.enterPassword: {
+                const tokenKey = `${registry}/${username}`;
+                const stored = await TokenStore.getItem('registry', tokenKey);
+
+                if (stored) {
+                    const loggedIn = await ContainerRuntimeDetector.isRegistryLoggedIn(runtime, registry);
+                    if (loggedIn) {
+                        await saveRegistrySettings(registry, username);
+                        return { registry, username, password: stored };
+                    }
+                    try {
+                        await ContainerRuntimeDetector.loginToRegistry(runtime, registry, username, stored);
+                        await saveRegistrySettings(registry, username);
+                        return { registry, username, password: stored };
+                    } catch {
+                        await TokenStore.setItem('registry', tokenKey, '');
+                    }
+                }
+
+                const validate = (v: string) => !v ? 'Password cannot be empty' : undefined;
+                const result = await inputValue(
+                    `Provide password for ${username}@${registry}`,
+                    stored || '', true, validate,
+                    `Password for: ${username}@${registry}`,
+                );
+                if (result === null) return null;
+                if (result === undefined) { step = Step.enterUsername; break; }
+                password = result;
+                step = undefined;
+                break;
+            }
+            default:
+                step = undefined;
+                break;
+        }
+    }
+
+    if (!registry || !username || !password) return null;
+
+    await saveRegistrySettings(registry, username);
+    await TokenStore.setItem('registry', `${registry}/${username}`, password);
+
+    return { registry, username, password };
+}
+
+const INTERNAL_REGISTRY_LABEL = 'OpenShift internal registry (auto-detect)';
+
+async function selectRegistry(currentRegistry: string, isOpenShift = false): Promise<string | null | undefined> {
+    return new Promise<string | null | undefined>((resolve) => {
+        const addNew: QuickPickItem = { label: '$(plus) Provide new registry URL...' };
+        const quickPick = window.createQuickPick();
+        quickPick.placeholder = 'Select a container image registry';
+        quickPick.ignoreFocusOut = true;
+
+        const items: QuickPickItem[] = [...WELL_KNOWN_REGISTRIES];
+        if (currentRegistry && !WELL_KNOWN_REGISTRIES.find(r => r.label === currentRegistry)) {
+            items.unshift({ label: currentRegistry, description: 'Previously used' });
+        }
+        items.push({ label: '', kind: QuickPickItemKind.Separator });
+        items.push(addNew);
+        if (isOpenShift) {
+            items.push({ label: '', kind: QuickPickItemKind.Separator });
+            items.push({ label: INTERNAL_REGISTRY_LABEL, description: 'Uses cluster token' });
+        }
+
+        quickPick.items = items;
+        const cancelBtn = new quickBtn(new ThemeIcon('close'), 'Cancel');
+        quickPick.buttons = [cancelBtn];
+
+        let selection: readonly QuickPickItem[] | undefined;
+        const hideDisposable = quickPick.onDidHide(() => {
+            quickPick.dispose();
+            resolve(null);
+        });
+        quickPick.onDidChangeSelection((selects) => { selection = selects; });
+        quickPick.onDidAccept(() => {
+            const choice = selection?.[0];
+            hideDisposable.dispose();
+            quickPick.hide();
+            quickPick.dispose();
+            if (!choice) { resolve(null); return; }
+            if (choice.label === addNew.label) {
+                resolve(undefined);
+            } else if (choice.label === INTERNAL_REGISTRY_LABEL) {
+                resolve(OPENSHIFT_INTERNAL_REGISTRY);
+            } else {
+                resolve(choice.label);
+            }
+        });
+        quickPick.onDidTriggerButton((button) => {
+            hideDisposable.dispose();
+            quickPick.hide();
+            quickPick.dispose();
+            resolve(null);
+        });
+        quickPick.show();
+    });
+}
+
+// Global scope (true) — registry account is typically shared across projects
+async function saveRegistrySettings(registry: string, username: string): Promise<void> {
+    const config = workspace.getConfiguration('openshiftToolkit');
+    await config.update('containerRegistryUrl', registry, true);
+    await config.update('containerRegistryUsername', username, true);
+}
+
+export function rewriteImageName(imageName: string, registry: string, username: string): string {
+    if (imageName.includes('/')) return imageName;
+    return `${registry}/${username}/${imageName}`;
+}
+
+function pullSecretName(registry: string): string {
+    return `deploy-pull-${registry.replace(/[^a-z0-9]/g, '-')}`;
+}
+
+export async function ensurePullSecret(
+    registry: string,
+    username: string,
+    password: string,
+): Promise<boolean> {
+    const ocPath = await ToolsConfig.detect('oc');
+    if (!ocPath) return false;
+
+    const secretName = pullSecretName(registry);
+
+    // 1. Check if secret already exists
+    try {
+        const check = await CliChannel.getInstance().executeTool(
+            new CommandText('oc', `get secret ${secretName}`),
+            undefined, true,
+        );
+        if (check.stdout) return true;
+    } catch {
+        // secret doesn't exist — need to create it
+    }
+
+    // 2. Resolve password: param → TokenStore → prompt user
+    let resolvedPassword = password;
+    const tokenKey = `${registry}/${username}`;
+
+    if (!resolvedPassword) {
+        resolvedPassword = await TokenStore.getItem('registry', tokenKey) || '';
+    }
+
+    if (!resolvedPassword) {
+        const validate = (v: string) => !v ? 'Password cannot be empty' : undefined;
+        const result = await inputValue(
+            `Enter password for ${username}@${registry} to create an image pull secret`,
+            '', true, validate,
+            `Password for: ${username}@${registry}`,
+        );
+        if (!result) return false;
+        resolvedPassword = result;
+        await TokenStore.setItem('registry', tokenKey, resolvedPassword);
+    }
+
+    // 3. Create the secret and link to default service account
+    try {
+        await CliChannel.getInstance().executeTool(
+            new CommandText('oc', `create secret docker-registry ${secretName}`, [
+                new CommandOption('--docker-server', registry),
+                new CommandOption('--docker-username', username),
+                new CommandOption('--docker-password', resolvedPassword, true),
+            ]),
+        );
+        await CliChannel.getInstance().executeTool(
+            new CommandText('oc', `secrets link default ${secretName}`, [
+                new CommandOption('--for', 'pull'),
+            ]),
+        );
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/src/devfile/undeploy.ts
+++ b/src/devfile/undeploy.ts
@@ -5,10 +5,12 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { KubeConfig } from '@kubernetes/client-node';
 import { OpenshiftLogger } from '../util/childProcessUtil';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
 import { DeployState } from '../odo/componentTypeDescription';
 import { Oc } from '../oc/ocWrapper';
+import { deployContextKey } from './deploy';
 
 export interface ComponentUndeployOptions {
     componentPath: string;
@@ -35,12 +37,12 @@ export async function undeployComponent(
         // 2. Delete tracked resources in reverse order (idempotent)
         await deleteTrackedResources(deployState, ctx);
 
-        // 3. Delete deploy state file
+        // 3. Remove this context's entry from deploy state
         try {
-            await fs.unlink(stateFile);
-            logInfo(ctx, 'Deployment state file removed');
+            await removeDeployStateEntry(stateFile);
+            logInfo(ctx, 'Deployment state entry removed');
         } catch (err) {
-            logWarning(ctx, `Failed to remove deployment state file: ${err.message}`);
+            logWarning(ctx, `Failed to update deployment state file: ${err.message}`);
         }
     } else {
         if (options.force) {
@@ -143,12 +145,47 @@ function isDevResource(resource: any): boolean {
     );
 }
 
+async function currentContextKey(): Promise<string> {
+    const kc = new KubeConfig();
+    kc.loadFromDefault();
+    const server = kc.getCurrentCluster()?.server || '';
+    const namespace = await Oc.Instance.getActiveProject() || 'default';
+    return deployContextKey(server, namespace);
+}
+
 async function loadDeployState(stateFile: string): Promise<DeployState | null> {
     try {
         const content = await fs.readFile(stateFile, 'utf-8');
-        return JSON.parse(content) as DeployState;
+        const parsed = JSON.parse(content);
+        if (parsed.version === 1 && !parsed.deployments) {
+            return parsed as DeployState;
+        }
+        if (parsed.deployments) {
+            const key = await currentContextKey();
+            return parsed.deployments[key] || null;
+        }
+        return null;
     } catch {
         return null;
+    }
+}
+
+async function removeDeployStateEntry(stateFile: string): Promise<void> {
+    const content = await fs.readFile(stateFile, 'utf-8');
+    const parsed = JSON.parse(content);
+
+    if (parsed.version === 1 && !parsed.deployments) {
+        await fs.unlink(stateFile);
+        return;
+    }
+
+    const key = await currentContextKey();
+    delete parsed.deployments[key];
+
+    if (Object.keys(parsed.deployments).length === 0) {
+        await fs.unlink(stateFile);
+    } else {
+        await fs.writeFile(stateFile, JSON.stringify(parsed, null, 2), 'utf-8');
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -310,6 +310,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<unkn
 
     OpenShiftExplorer.getInstance().onDidChangeContextEmitter.event((context) => {
         void updateContextAndProjectStatusBarItems(context);
+        Component.onContextChanged();
     });
 
     void updateContextAndProjectStatusBarItems();

--- a/src/oc/types.ts
+++ b/src/oc/types.ts
@@ -6,7 +6,13 @@
 export enum ClusterType {
     OpenShift,
     Kubernetes
-};
+}
+
+export enum KubernetesVariant {
+    Generic,
+    Kind,
+    Minikube
+}
 
 export type KubernetesConsole = {
     kind: ClusterType,

--- a/src/odo/componentTypeDescription.ts
+++ b/src/odo/componentTypeDescription.ts
@@ -218,6 +218,13 @@ export interface DeployState {
     version: number;
     componentName: string;
     deployedAt: string;
-    platform: 'cluster' | 'podman';
+    platform: 'openshift' | 'kubernetes' | 'podman';
+    cluster: string;
+    namespace: string;
     resources: DeployedResource[];
+}
+
+export interface DeployStateFile {
+    version: number;
+    deployments: Record<string, DeployState>;
 }

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -3,30 +3,31 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
+import { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
+import { readFile } from 'fs/promises';
 import { platform } from 'os';
 import * as path from 'path';
 import { which } from 'shelljs';
 import { commands, debug, DebugConfiguration, DebugSession, Disposable, EventEmitter, extensions, ProgressLocation, Uri, window, workspace } from 'vscode';
+import { deployComponent, deployContextKey } from '../devfile/deploy';
 import { describeComponentYAML } from '../devfile/describe';
+import { DevfileCommandRunner } from '../devfile/devfileCommandRunner';
+import { undeployComponent } from '../devfile/undeploy';
+import { BindableService } from '../k8s/servicebinding/bindableService';
 import { Oc } from '../oc/ocWrapper';
 import { Command } from '../odo/command';
-import { CommandProvider } from '../odo/componentTypeDescription';
+import { CommandProvider, DeployState } from '../odo/componentTypeDescription';
 import { Odo } from '../odo/odoWrapper';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
+import sendTelemetry from '../telemetry';
 import { ChildProcessUtil, CliExitData, OpenshiftChannel } from '../util/childProcessUtil';
 import { Progress } from '../util/progress';
 import { Util as fs } from '../util/utils';
 import { vsCommand, VsCommandError } from '../vscommand';
+import AddServiceBindingViewLoader, { ServiceBindingFormResponse } from '../webview/add-service-binding/addServiceBindingLoader';
 import CreateComponentLoader from '../webview/create-component/createComponentLoader';
 import { OpenShiftTerminalApi, OpenShiftTerminalManager } from '../webview/openshift-terminal/openShiftTerminal';
 import OpenShiftItem, { clusterRequired, projectRequired } from './openshiftItem';
-import { DevfileCommandRunner } from '../devfile/devfileCommandRunner';
-import { deployComponent } from '../devfile/deploy';
-import { undeployComponent } from '../devfile/undeploy';
-import { KubernetesObject } from '@kubernetes/client-node';
-import { BindableService } from '../k8s/servicebinding/bindableService';
-import sendTelemetry from '../telemetry';
-import AddServiceBindingViewLoader, { ServiceBindingFormResponse } from '../webview/add-service-binding/addServiceBindingLoader';
 
 function createStartDebuggerResult(language: string, message = '') {
     const result: any = new String(message);
@@ -87,6 +88,57 @@ export class Component extends OpenShiftItem {
         Component.stateChanged.event(listener);
     }
 
+    public static onContextChanged(): void {
+        let kc: KubeConfig;
+        try {
+            kc = new KubeConfig();
+            kc.loadFromDefault();
+        } catch {
+            return;
+        }
+        const currentCluster = kc.getCurrentCluster()?.server;
+        const currentContext = kc.getContextObject(kc.getCurrentContext());
+        const currentNamespace = currentContext?.namespace || 'default';
+
+        for (const [contextPath, state] of Component.componentStates) {
+            if (state.deployStatus === ComponentContextState.DEP_RUNNING
+                || state.deployStatus === ComponentContextState.DEP) {
+                void Component.reconcileDeployState(contextPath, state, currentCluster, currentNamespace);
+            }
+        }
+    }
+
+    private static async reconcileDeployState(
+        contextPath: string, state: ComponentDevState,
+        currentCluster: string, currentNamespace: string,
+    ): Promise<void> {
+        let shouldBeRunning = false;
+        try {
+            const stateFile = path.join(contextPath, '.odo', 'deploystate.json');
+            const raw = await readFile(stateFile, 'utf-8');
+            const parsed = JSON.parse(raw);
+            if (parsed.version === 1 && !parsed.deployments) {
+                const deployState = parsed as DeployState;
+                shouldBeRunning = deployState.cluster === currentCluster
+                    && deployState.namespace === currentNamespace;
+            } else if (parsed.deployments) {
+                const key = deployContextKey(currentCluster, currentNamespace);
+                shouldBeRunning = !!parsed.deployments[key];
+            }
+        } catch {
+            // no state file — not deployed
+        }
+
+        const newStatus = shouldBeRunning
+            ? ComponentContextState.DEP_RUNNING
+            : ComponentContextState.DEP;
+
+        if (state.deployStatus !== newStatus) {
+            state.deployStatus = newStatus;
+            Component.stateChanged.fire(contextPath);
+        }
+    }
+
     public static init(): Disposable[] {
         return [
             debug.onDidStartDebugSession((session) => {
@@ -114,9 +166,29 @@ export class Component extends OpenShiftItem {
             };
             if (folder.component?.devfileData?.supportedOdoFeatures !== undefined) {
                 Component.componentStates.set(folder.contextPath, state);
+                if (state.deployStatus === ComponentContextState.DEP) {
+                    void Component.detectDeployedState(folder);
+                }
             }
         }
         return state;
+    }
+
+    private static detectDeployedState(folder: ComponentWorkspaceFolder): void {
+        let kc: KubeConfig;
+        try {
+            kc = new KubeConfig();
+            kc.loadFromDefault();
+        } catch {
+            return;
+        }
+        const currentCluster = kc.getCurrentCluster()?.server;
+        const currentContext = kc.getContextObject(kc.getCurrentContext());
+        const currentNamespace = currentContext?.namespace || 'default';
+        const state = Component.componentStates.get(folder.contextPath);
+        if (state) {
+            void Component.reconcileDeployState(folder.contextPath, state, currentCluster, currentNamespace);
+        }
     }
 
     public static generateContextStateSuffixValue(folder: ComponentWorkspaceFolder): string {
@@ -155,6 +227,13 @@ export class Component extends OpenShiftItem {
             label = ` (dev running${runningOnSuffix})`;
         } else if(state.devStatus === ComponentContextState.DEV_STOPPING) {
             label = ` (dev stopping${runningOnSuffix})`;
+        }
+        if (state.deployStatus === ComponentContextState.DEP_STARTING) {
+            label += ' (deploying)';
+        } else if (state.deployStatus === ComponentContextState.DEP_RUNNING) {
+            label += ' (deployed)';
+        } else if (state.deployStatus === ComponentContextState.DEP_STOPPING) {
+            label += ' (undeploying)';
         }
         return label;
     }

--- a/src/util/containerRuntime.ts
+++ b/src/util/containerRuntime.ts
@@ -1,0 +1,221 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { existsSync, readFileSync } from 'fs';
+import { homedir, platform } from 'os';
+import * as path from 'path';
+import { which } from 'shelljs';
+import { ChildProcessUtil, CliExitData } from './childProcessUtil';
+
+export type ContainerRuntime = 'podman' | 'docker' | 'buildah';
+
+/**
+ * Utility for detecting and validating container runtimes (podman, docker, buildah).
+ */
+export class ContainerRuntimeDetector {
+
+    /**
+     * Detect available container runtime with preference order: podman > docker > buildah
+     *
+     * @returns The detected runtime or null if none available
+     */
+    public static async detectBuildRuntime(): Promise<ContainerRuntime | null> {
+        // Try podman first (preferred for rootless builds)
+        if (await this.isPodmanAvailable()) {
+            return 'podman';
+        }
+
+        // Try docker second (widely available)
+        if (await this.isDockerAvailable()) {
+            return 'docker';
+        }
+
+        // Try buildah third (OCI-compliant, rootless)
+        if (await this.isBuildahAvailable()) {
+            return 'buildah';
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if podman is available and properly configured.
+     */
+    public static async isPodmanAvailable(): Promise<boolean> {
+        const podmanPath = which('podman');
+        if (!podmanPath) {
+            return false;
+        }
+
+        if (platform() === 'linux') {
+            // Verify podman's container runtime is functional.
+            // On CI (e.g. Ubuntu runners), podman may be installed but crun
+            // lacks sd-bus/systemd access, causing builds to fail.
+            // remoteSocket.exists correlates with a working runtime.
+            try {
+                const result: CliExitData = await ChildProcessUtil.Instance.execute(
+                    `"${podmanPath}" info --format json`
+                );
+                const info = JSON.parse(result.stdout);
+                return !!info?.host?.remoteSocket?.exists;
+            } catch {
+                return false;
+            }
+        }
+
+        // On macOS/Windows, check if podman machine is running
+        try {
+            const result: CliExitData = await ChildProcessUtil.Instance.execute(
+                `"${podmanPath}" machine list --format json`
+            );
+            const machines: { Running: boolean }[] = JSON.parse(result.stdout);
+            return machines.length > 0 && machines.some(m => m.Running);
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Check if docker is available.
+     */
+    public static async isDockerAvailable(): Promise<boolean> {
+        const dockerPath = which('docker');
+        if (!dockerPath) {
+            return false;
+        }
+
+        // Verify docker daemon is accessible
+        try {
+            await ChildProcessUtil.Instance.execute(`"${dockerPath}" info`);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Check if buildah is available.
+     */
+    public static async isBuildahAvailable(): Promise<boolean> {
+        const buildahPath = which('buildah');
+        if (!buildahPath) {
+            return false;
+        }
+
+        // Verify buildah works
+        try {
+            await ChildProcessUtil.Instance.execute(`"${buildahPath}" version`);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Get the build command for the specified runtime.
+     *
+     * @param runtime The container runtime to use
+     * @param imageName The image name/tag
+     * @param dockerfilePath Path to Dockerfile (relative to build context)
+     * @param buildContext Build context path
+     * @returns The build command string
+     */
+    public static getBuildCommand(
+        runtime: ContainerRuntime,
+        imageName: string,
+        dockerfilePath: string,
+        buildContext: string
+    ): string {
+        switch (runtime) {
+            case 'podman':
+            case 'docker':
+                return `${runtime} build -t ${imageName} -f ${dockerfilePath} ${buildContext}`;
+            case 'buildah':
+                return `buildah bud -t ${imageName} -f ${dockerfilePath} ${buildContext}`;
+            default:
+                throw new Error(`Unsupported container runtime: ${runtime as string}`);
+        }
+    }
+
+    public static getPushCommand(
+        runtime: ContainerRuntime,
+        imageName: string
+    ): string {
+        switch (runtime) {
+            case 'podman':
+            case 'docker':
+                return `${runtime} push ${imageName}`;
+            case 'buildah':
+                return `buildah push ${imageName}`;
+            default:
+                throw new Error(`Unsupported container runtime: ${runtime as string}`);
+        }
+    }
+
+    public static getRetagCommand(runtime: ContainerRuntime, imageName: string): string | undefined {
+        if (runtime === 'podman' || runtime === 'buildah') {
+            return `podman tag ${imageName} docker.io/library/${imageName}`;
+        }
+        return undefined;
+    }
+
+    public static getKindLoadCommand(runtime: ContainerRuntime, imageName: string, clusterName?: string): string {
+        const nameFlag = clusterName ? ` --name ${clusterName}` : '';
+        if (runtime === 'podman' || runtime === 'buildah') {
+            return `podman save docker.io/library/${imageName} | kind load image-archive /dev/stdin${nameFlag}`;
+        }
+        return `kind load docker-image ${imageName}${nameFlag}`;
+    }
+
+    public static getMinikubeLoadCommand(runtime: ContainerRuntime, imageName: string): string {
+        if (runtime === 'podman' || runtime === 'buildah') {
+            return `podman save docker.io/library/${imageName} | minikube image load -`;
+        }
+        return `minikube image load ${imageName}`;
+    }
+
+    public static getLoginCommand(
+        runtime: ContainerRuntime,
+        registry: string,
+        username: string,
+    ): string {
+        const rt = runtime === 'buildah' ? 'buildah' : runtime;
+        return `${rt} login -u ${username} --password-stdin ${registry}`;
+    }
+
+    public static async loginToRegistry(
+        runtime: ContainerRuntime,
+        registry: string,
+        username: string,
+        password: string,
+    ): Promise<void> {
+        const cmd = this.getLoginCommand(runtime, registry, username);
+        const result = await ChildProcessUtil.Instance.execute(cmd, {}, password);
+        if (result.error) {
+            throw new Error(`Registry login failed: ${result.stderr || result.error.message}`);
+        }
+    }
+
+    public static async isRegistryLoggedIn(
+        runtime: ContainerRuntime,
+        registry: string
+    ): Promise<boolean> {
+        try {
+            if (runtime === 'podman') {
+                await ChildProcessUtil.Instance.execute(
+                    `podman login --get-login ${registry}`);
+                return true;
+            }
+            const configPath = path.join(homedir(), '.docker', 'config.json');
+            if (existsSync(configPath)) {
+                const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+                return !!(config.auths?.[registry] || config.auths?.[`https://${registry}`]);
+            }
+            return false;
+        } catch {
+            return false;
+        }
+    }
+}

--- a/src/util/kubeUtils.ts
+++ b/src/util/kubeUtils.ts
@@ -11,6 +11,7 @@ import { QuickPickItem, window } from 'vscode';
 import { stringify } from 'yaml';
 import { CommandText } from '../base/command';
 import { CliChannel } from '../cli';
+import { KubernetesVariant } from '../oc/types';
 import { Platform } from './platform';
 import { ExecutionContext, YAML_STRINGIFY_OPTIONS } from './utils';
 
@@ -426,6 +427,27 @@ export async function isOpenShiftCluster(executionContext?: ExecutionContext): P
     }
   }
 
+export async function detectKubernetesVariant(executionContext?: ExecutionContext): Promise<KubernetesVariant> {
+    const configInfo = new KubeConfigInfo();
+    const contextName = configInfo.getEffectiveKubeConfig().currentContext;
+
+    if (contextName?.startsWith('kind-')) {
+        try {
+            await CliChannel.getInstance().executeSyncTool(
+                new CommandText('kind', 'version'), { timeout: 3000 }, executionContext);
+            return KubernetesVariant.Kind;
+        } catch {
+            // kind CLI not available, fall through
+        }
+    }
+
+    if (contextName === 'minikube' || contextName?.startsWith('minikube-')) {
+        return KubernetesVariant.Minikube;
+    }
+
+    return KubernetesVariant.Generic;
+}
+
 export async function getNamespaceKind(executionContext?: ExecutionContext): Promise<string> {
     if (executionContext && executionContext.has(getNamespaceKind.name)) {
         return executionContext.get(getNamespaceKind.name);
@@ -435,6 +457,29 @@ export async function getNamespaceKind(executionContext?: ExecutionContext): Pro
         executionContext.set(getNamespaceKind.name, result);
     }
     return result;
+}
+
+export async function getOpenShiftRegistryUrl(): Promise<string | undefined> {
+    try {
+        const result = await CliChannel.getInstance().executeTool(
+            new CommandText('oc', 'registry info'), undefined, false,
+        );
+        const url = result.stdout?.trim();
+        if (url && !url.includes('error')) return url;
+    } catch {
+        // fall through
+    }
+    try {
+        const result = await CliChannel.getInstance().executeTool(
+            new CommandText('oc', 'get route default-route -n openshift-image-registry -o jsonpath=\'{.spec.host}\''),
+            undefined, false,
+        );
+        const host = result.stdout?.trim().replace(/'/g, '');
+        if (host) return host;
+    } catch {
+        // registry route not exposed
+    }
+    return undefined;
 }
 
 export function extractProjectNameFromContextName(contextName: string):string {

--- a/src/webview/openshift-terminal/app/terminalMultiplexer.tsx
+++ b/src/webview/openshift-terminal/app/terminalMultiplexer.tsx
@@ -127,9 +127,8 @@ export const TerminalMultiplexer = () => {
     const respondToMessage = function (message: MessageEvent<VSCodeMessage>) {
         if (message.data.kind === 'createTerminal') {
             const uuid = message.data.data.uuid as string;
-            setTerminals([
-                ...terminals,
-
+            setTerminals((terms) => [
+                ...terms,
                 {
                     name: message.data.data.name,
                     uuid,

--- a/src/webview/openshift-terminal/openShiftTerminal.ts
+++ b/src/webview/openshift-terminal/openShiftTerminal.ts
@@ -87,7 +87,7 @@ class OpenShiftTerminal {
     private _sendExitMessage: () => void;
 
     private _onSpawnListener: () => void;
-    private _onExitListener: () => void;
+    private _onExitListener: (exitCode: number) => void;
     private _onTextListener: (text: string) => void;
 
     private _uuid: string;
@@ -129,7 +129,7 @@ class OpenShiftTerminal {
         isKnative: boolean,
         callbacks?: {
             onSpawn?: () => void;
-            onExit?: () => void;
+            onExit?: (exitCode: number) => void;
             onText?: (text: string) => void;
         },
         spawnPty = true
@@ -143,7 +143,7 @@ class OpenShiftTerminal {
             void sendMessage({ kind: 'termExit', data: { uuid } });
         };
         this._onSpawnListener = callbacks?.onSpawn || (() => undefined);
-        this._onExitListener = callbacks?.onExit || (() => undefined);
+        this._onExitListener = callbacks?.onExit || ((_exitCode: number) => undefined);
         this._onTextListener = callbacks?.onText || ((_text: string) => undefined);
 
         this._file = file;
@@ -200,15 +200,15 @@ class OpenShiftTerminal {
             }),
         );
         this._disposables.push(
-            this._pty.onExit((_e) => {
-                this.onExit();
+            this._pty.onExit((e) => {
+                this.onExit(e.exitCode);
             }),
         );
         this._onSpawnListener();
     }
 
-    private onExit() {
-        this._onExitListener();
+    private onExit(exitCode = -1) {
+        this._onExitListener(exitCode);
         const msg = '\r\n\r\nPress any key to close this terminal\r\n';
         this._sendTerminalData(msg);
         this._headlessTerm.write(msg);
@@ -659,7 +659,7 @@ export class OpenShiftTerminalManager implements WebviewViewProvider {
         env = process.env,
         callbacks?: {
             onSpawn?: () => void;
-            onExit?: () => void;
+            onExit?: (exitCode: number) => void;
             onText?: (text: string) => void;
         },
         isKnative = false

--- a/test/fixtures/.kube/config-generic
+++ b/test/fixtures/.kube/config-generic
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://my-cluster.example.com:6443
+  name: my-cluster
+contexts:
+- context:
+    cluster: my-cluster
+    user: my-user
+  name: my-cluster-context
+current-context: my-cluster-context
+users:
+- name: my-user
+  user:
+    token: test-token

--- a/test/fixtures/.kube/config-kind
+++ b/test/fixtures/.kube/config-kind
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: kind-test-cluster
+contexts:
+- context:
+    cluster: kind-test-cluster
+    user: kind-test-cluster
+  name: kind-test-cluster
+current-context: kind-test-cluster
+users:
+- name: kind-test-cluster
+  user:
+    client-certificate-data: ""

--- a/test/fixtures/.kube/config-minikube
+++ b/test/fixtures/.kube/config-minikube
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://192.168.49.2:8443
+  name: minikube
+contexts:
+- context:
+    cluster: minikube
+    user: minikube
+  name: minikube
+current-context: minikube
+users:
+- name: minikube
+  user:
+    client-certificate-data: ""

--- a/test/integration/command.test.ts
+++ b/test/integration/command.test.ts
@@ -158,8 +158,10 @@ suite('odo commands integration', function () {
                     // Just verify the error is registry-related, not a code bug
                     if (err.message.includes('registry') ||
                         err.message.includes('push') ||
-                        err.message.includes('image')) {
-                        this.skip(); // Skip test - registry not configured
+                        err.message.includes('image') ||
+                        err.message.includes('runtime') ||
+                        err.message.includes('script failed')) {
+                        this.skip(); // Skip test - no container runtime or registry
                     } else {
                         throw err; // Real error - fail the test
                     }
@@ -446,6 +448,239 @@ suite('odo commands integration', function () {
                     devTerm.dispose();
                 }
             }
+        });
+    });
+
+    suite('container runtime detection', function () {
+        let detectedRuntime: string | null;
+
+        suiteSetup(async function () {
+            const { ContainerRuntimeDetector } = await import('../../src/util/containerRuntime');
+            detectedRuntime = await ContainerRuntimeDetector.detectBuildRuntime();
+        });
+
+        test('detectBuildRuntime() finds an available runtime', function () {
+            if (!detectedRuntime) {
+                this.skip(); // No runtime on this CI runner
+            }
+            expect(detectedRuntime).to.be.oneOf(['podman', 'docker', 'buildah']);
+        });
+
+        test('getBuildCommand() returns valid command for detected runtime', async function () {
+            if (!detectedRuntime) {
+                this.skip();
+            }
+            const { ContainerRuntimeDetector } = await import('../../src/util/containerRuntime');
+            const cmd = ContainerRuntimeDetector.getBuildCommand(
+                detectedRuntime as any, 'test:latest', '/tmp/Dockerfile', '/tmp',
+            );
+            expect(cmd).to.contain(detectedRuntime);
+        });
+    });
+
+    suite('deploy with inlined resources', function () {
+        const deployProjectName = `deploy-test${Math.round(Math.random() * 1000)}`;
+        let componentLocation: string;
+
+        const inlinedManifest = [
+            'apiVersion: apps/v1',
+            'kind: Deployment',
+            'metadata:',
+            '  name: test-deploy-app',
+            '  labels:',
+            '    app: test-deploy-app',
+            'spec:',
+            '  replicas: 1',
+            '  selector:',
+            '    matchLabels:',
+            '      app: test-deploy-app',
+            '  template:',
+            '    metadata:',
+            '      labels:',
+            '        app: test-deploy-app',
+            '    spec:',
+            '      containers:',
+            '        - name: main',
+            '          image: registry.access.redhat.com/ubi8/ubi-minimal:latest',
+            '          command: ["sleep", "3600"]',
+            '---',
+            'apiVersion: v1',
+            'kind: Service',
+            'metadata:',
+            '  name: test-deploy-app',
+            'spec:',
+            '  selector:',
+            '    app: test-deploy-app',
+            '  ports:',
+            '    - port: 8080',
+            '      targetPort: 8080',
+        ].join('\n');
+
+        const devfileContent = {
+            schemaVersion: '2.2.0',
+            metadata: { name: 'test-deploy', version: '1.0.0' },
+            components: [
+                {
+                    name: 'k8s-deploy',
+                    kubernetes: { inlined: inlinedManifest },
+                },
+            ],
+            commands: [
+                {
+                    id: 'apply-k8s',
+                    apply: { component: 'k8s-deploy', group: { kind: 'deploy' } },
+                },
+            ],
+        };
+
+        suiteSetup(async function () {
+            if (isOpenShift) {
+                await Oc.Instance.loginWithUsernamePassword(clusterUrl, username, password);
+            }
+            try {
+                await Oc.Instance.createProject(deployProjectName);
+            } catch {
+                // already exists
+            }
+            await Oc.Instance.setProject(deployProjectName);
+
+            componentLocation = await promisify(tmp.dir)();
+            await fs.writeFile(
+                path.join(componentLocation, 'devfile.yaml'),
+                stringify(devfileContent, YAML_STRINGIFY_OPTIONS),
+            );
+        });
+
+        suiteTeardown(async function () {
+            let toRemove = -1;
+            for (let i = 0; i < workspace.workspaceFolders.length; i++) {
+                if (workspace.workspaceFolders[i].uri.fsPath === componentLocation) {
+                    toRemove = i;
+                    break;
+                }
+            }
+            if (toRemove !== -1) {
+                workspace.updateWorkspaceFolders(toRemove, 1);
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }
+            await fs.rm(componentLocation, { recursive: true, force: true });
+            try {
+                await Oc.Instance.deleteProject(deployProjectName);
+            } catch {
+                // ignore
+            }
+        });
+
+        test('deployComponent() applies inlined kubernetes resources', async function () {
+            const { deployComponent } = await import('../../src/devfile/deploy');
+
+            const componentFolder: ComponentWorkspaceFolder = {
+                contextPath: componentLocation,
+                component: await Odo.Instance.describeComponent(componentLocation),
+            };
+
+            const result = await deployComponent(
+                { componentPath: componentLocation },
+                componentFolder,
+            );
+
+            expect(result.success).to.be.true;
+            expect(result.deployedCommands.length).to.be.greaterThan(0);
+
+            const deployStatePath = path.join(componentLocation, '.odo', 'deploystate.json');
+            await fs.access(deployStatePath);
+        });
+
+        test('deployed resources exist on cluster', async function () {
+            const deployment = await Oc.Instance.getKubernetesObject('deployment', 'test-deploy-app');
+            expect(deployment).to.exist;
+            expect((deployment as any).metadata.name).to.equal('test-deploy-app');
+
+            const service = await Oc.Instance.getKubernetesObject('service', 'test-deploy-app');
+            expect(service).to.exist;
+            expect((service as any).metadata.name).to.equal('test-deploy-app');
+        });
+
+        test('undeployComponent() removes resources and state', async function () {
+            const { undeployComponent } = await import('../../src/devfile/undeploy');
+
+            const componentFolder: ComponentWorkspaceFolder = {
+                contextPath: componentLocation,
+                component: await Odo.Instance.describeComponent(componentLocation),
+            };
+
+            await undeployComponent(
+                { componentPath: componentLocation },
+                componentFolder,
+            );
+
+            // Verify state file removed
+            try {
+                await fs.access(path.join(componentLocation, '.odo', 'deploystate.json'));
+                assert.fail('Deploy state file should have been deleted');
+            } catch (err) {
+                expect(err.code).to.equal('ENOENT');
+            }
+
+            // Verify resources removed from cluster
+            try {
+                await Oc.Instance.getKubernetesObject('deployment', 'test-deploy-app');
+                assert.fail('Deployment should have been deleted');
+            } catch {
+                // Expected - resource no longer exists
+            }
+        });
+    });
+
+    suite('local image build', function () {
+        let buildDir: string;
+        let detectedRuntime: string | null;
+
+        suiteSetup(async function () {
+            const { ContainerRuntimeDetector } = await import('../../src/util/containerRuntime');
+            detectedRuntime = await ContainerRuntimeDetector.detectBuildRuntime();
+            if (!detectedRuntime) {
+                this.skip();
+            }
+
+            buildDir = await promisify(tmp.dir)();
+            await fs.writeFile(
+                path.join(buildDir, 'Dockerfile'),
+                'FROM registry.access.redhat.com/ubi8/ubi-minimal:latest\nCMD ["echo", "hello"]\n',
+            );
+        });
+
+        suiteTeardown(async function () {
+            if (buildDir) {
+                await fs.rm(buildDir, { recursive: true, force: true });
+            }
+            // Clean up built image
+            if (detectedRuntime) {
+                try {
+                    await CliChannel.getInstance().executeTool(
+                        new CommandText(detectedRuntime, 'rmi localhost/test-build:latest'),
+                    );
+                } catch {
+                    // ignore - image may not exist
+                }
+            }
+        });
+
+        test('builds image locally without push', async function () {
+            const { ContainerRuntimeDetector } = await import('../../src/util/containerRuntime');
+            const buildCommand = ContainerRuntimeDetector.getBuildCommand(
+                detectedRuntime as any,
+                'localhost/test-build:latest',
+                path.join(buildDir, 'Dockerfile'),
+                buildDir,
+            );
+
+            const result = await CliChannel.getInstance().executeTool(
+                new CommandText(buildCommand.split(' ')[0], buildCommand.split(' ').slice(1).join(' ')),
+                { cwd: buildDir },
+            );
+
+            expect(result.error).to.be.undefined;
         });
     });
 });

--- a/test/ui/common/constants.ts
+++ b/test/ui/common/constants.ts
@@ -56,6 +56,8 @@ export const MENUS = {
     showLog: 'Show Log',
     followLog: 'Follow Log',
     debug: 'Debug',
+    deploy: 'Deploy',
+    undeploy: 'Undeploy',
     deleteConfiguration: 'Delete Component Configuration',
     deleteSourceCodeFolder: 'Delete Source Code Folder',
     create: 'Create...',

--- a/test/ui/suite/componentContextMenu.ts
+++ b/test/ui/suite/componentContextMenu.ts
@@ -4,6 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { expect } from 'chai';
+import { which } from 'shelljs';
 import {
     ActivityBar,
     BottomBarPanel,
@@ -15,7 +16,7 @@ import {
     VSBrowser,
     Workbench
 } from 'vscode-extension-tester';
-import { findItemFuzzy, itemDoesNotExist, notificationDoesNotExist, stabilizeComponentsView, waitForItem, waitForItemStable, waitForItemToDisappear, warn } from '../common/conditions';
+import { findItemFuzzy, itemDoesNotExist, notificationDoesNotExist, notificationExists, stabilizeComponentsView, waitForItem, waitForItemStable, waitForItemToDisappear, warn } from '../common/conditions';
 import { MENUS, VIEWS } from '../common/constants';
 import { closeAllOpenEditors, collapse, collapseViews } from '../common/overdrives';
 import { OpenshiftTerminalWebviewView } from '../common/ui/webviewView/openshiftTerminalWebviewView';
@@ -61,7 +62,7 @@ export function testComponentContextMenu() {
         });
 
         it('Start Dev works', async function () {
-            this.timeout(80_000);
+            this.timeout(120_000);
 
             await waitForItemStable(getSection, componentName, true);
 
@@ -97,7 +98,7 @@ export function testComponentContextMenu() {
         });
 
         it('Stop Dev works', async function () {
-            this.timeout(80_000);
+            this.timeout(120_000);
 
             await stabilizeComponentsView(getSection);
 
@@ -127,7 +128,7 @@ export function testComponentContextMenu() {
         });
 
         it('Stop Dev works by pressing Ctrl+c', async function () {
-            this.timeout(80_000);
+            this.timeout(120_000);
 
             await stabilizeComponentsView(getSection);
 
@@ -150,7 +151,11 @@ export function testComponentContextMenu() {
         });
 
         it('Start/Stop Dev on Podman works', async function () {
-            this.timeout(80_000);
+            this.timeout(120_000);
+
+            if (!which('podman')) {
+                this.skip();
+            }
 
             await stabilizeComponentsView(getSection);
 
@@ -177,8 +182,48 @@ export function testComponentContextMenu() {
             expect(terminalText).to.include('Press any key to close this terminal');
         });
 
+        it('Deploy works', async function () {
+            this.timeout(180_000);
+
+            await waitForItemStable(getSection, componentName, true);
+
+            await deploy();
+
+            await waitForDeployToFinish();
+
+            const notification = await notificationExists(
+                `Component '${componentName}' deployed successfully`,
+                VSBrowser.instance.driver,
+                60_000,
+            );
+            expect(notification).to.not.be.undefined;
+        });
+
+        it('Undeploy works', async function () {
+            this.timeout(180_000);
+
+            await waitForItemStable(getSection, `${componentName} (deployed)`, true);
+
+            await undeploy();
+
+            const confirmNotification = await notificationExists(
+                `Undeploy component '${componentName}'? This will delete all deployed resources.`,
+                VSBrowser.instance.driver,
+            );
+            await confirmNotification.takeAction('Undeploy');
+
+            await waitForUndeployToFinish();
+
+            const notification = await notificationExists(
+                `Component '${componentName}' undeployed`,
+                VSBrowser.instance.driver,
+                30_000,
+            );
+            expect(notification).to.not.be.undefined;
+        });
+
         it('Describe component works', async function () {
-            this.timeout(80_000);
+            this.timeout(120_000);
 
             await stabilizeComponentsView(getSection);
 
@@ -353,13 +398,12 @@ export function testComponentContextMenu() {
                 } catch {
                     return false;
                 }
-            }, 20000, `Context menu item "${option}" not available`);
+            }, 40_000, `Context menu item "${option}" not available`);
         }
 
         async function waitForStartDevToFinish(devOnCluster: boolean): Promise<void> {
             const podmanString = devOnCluster ? '' : ' on podman';
-            await waitForItemStable(getSection, `${componentName} (dev starting${podmanString})`);
-            await waitForItemStable(getSection, `${componentName} (dev running${podmanString})`, true, 40_000);
+            await waitForItemStable(getSection, `${componentName} (dev running${podmanString})`, true, 60_000);
         }
 
         async function stopDev(): Promise<void> {
@@ -392,13 +436,10 @@ export function testComponentContextMenu() {
                 } catch {
                     return false;
                 }
-            }, 20000, `Context menu item "${MENUS.stopDev}" not available`);
+            }, 40_000, `Context menu item "${MENUS.stopDev}" not available`);
         }
 
         async function waitForStopDevToFinish(devOnCluster: boolean): Promise<void> {
-            if (devOnCluster) {
-                await waitForItemStable(getSection, `${componentName} (dev stopping)`);
-            }
             await waitForItemStable(getSection, componentName, true, 60_000);
         }
 
@@ -420,6 +461,74 @@ export function testComponentContextMenu() {
             }, timeout, `Terminal tab "${expectedTabName}" did not open`);
 
             return terminal!;
+        }
+
+        async function deploy(): Promise<void> {
+            await VSBrowser.instance.driver.wait(async () => {
+                try {
+                    const section = await getSection();
+                    const component = await section.findItem(componentName);
+                    if (!component) return false;
+
+                    const menu = await component.openContextMenu();
+                    const items = await menu.getItems();
+
+                    for (const item of items) {
+                        if ((await item.getLabel()) === MENUS.deploy) {
+                            try {
+                                await item.safeClick();
+                                return true;
+                            } catch(err) {
+                                await VSBrowser.instance.driver.actions().sendKeys('').perform();
+                                throw err;
+                            }
+                        }
+                    }
+
+                    await VSBrowser.instance.driver.actions().sendKeys('').perform();
+                    return false;
+                } catch {
+                    return false;
+                }
+            }, 40_000, `Context menu item "${MENUS.deploy}" not available`);
+        }
+
+        async function undeploy(): Promise<void> {
+            await VSBrowser.instance.driver.wait(async () => {
+                try {
+                    const section = await getSection();
+                    const component = await findItemFuzzy(section, componentName);
+                    if (!component) return false;
+
+                    const menu = await component.openContextMenu();
+                    const items = await menu.getItems();
+
+                    for (const item of items) {
+                        if ((await item.getLabel()) === MENUS.undeploy) {
+                            try {
+                                await item.safeClick();
+                                return true;
+                            } catch(err) {
+                                await VSBrowser.instance.driver.actions().sendKeys('').perform();
+                                throw err;
+                            }
+                        }
+                    }
+
+                    await VSBrowser.instance.driver.actions().sendKeys('').perform();
+                    return false;
+                } catch {
+                    return false;
+                }
+            }, 40_000, `Context menu item "${MENUS.undeploy}" not available`);
+        }
+
+        async function waitForDeployToFinish(): Promise<void> {
+            await waitForItemStable(getSection, `${componentName} (deployed)`, true, 60_000);
+        }
+
+        async function waitForUndeployToFinish(): Promise<void> {
+            await waitForItemStable(getSection, componentName, true, 60_000);
         }
     });
 }

--- a/test/unit/devfile/applyCommand.test.ts
+++ b/test/unit/devfile/applyCommand.test.ts
@@ -6,8 +6,10 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import * as path from 'path';
 import * as yaml from 'js-yaml';
 import { DeployedResource } from '../../../src/odo/componentTypeDescription';
+import { ApplyCommandExecutor, debugEcho } from '../../../src/devfile/applyCommand';
 
 const { expect } = chai;
 chai.use(sinonChai);
@@ -264,6 +266,394 @@ data:
 
             expect(resources).to.have.lengthOf(1);
             expect(resources[0].name).to.equal('unknown');
+        });
+    });
+
+    suite('buildImageComponent() logic', () => {
+        test('throws when no container runtime found', () => {
+            // Simulates ContainerRuntimeDetector.detectBuildRuntime() returning null
+            const runtime = null;
+            if (!runtime) {
+                expect(() => {
+                    throw new Error(
+                        'No container runtime found. Install podman, docker, or buildah to build images.',
+                    );
+                }).to.throw('No container runtime found');
+            }
+        });
+
+        test('resolves Dockerfile path relative to devfile directory', () => {
+            const imageComponent = {
+                imageName: 'myapp:latest',
+                dockerfile: { uri: 'docker/Dockerfile', buildContext: '.' },
+            };
+            const devfileDir = '/home/user/project';
+
+            const dockerfilePath = imageComponent.dockerfile?.uri || 'Dockerfile';
+            const resolvedDockerfile = path.isAbsolute(dockerfilePath)
+                ? dockerfilePath
+                : path.join(devfileDir, dockerfilePath);
+
+            expect(resolvedDockerfile).to.equal(path.join('/home/user/project', 'docker/Dockerfile'));
+        });
+
+        test('uses default Dockerfile path when not specified', () => {
+            const imageComponent = {
+                imageName: 'myapp:latest',
+                dockerfile: {},
+            };
+            const devfileDir = '/home/user/project';
+
+            const dockerfilePath = (imageComponent.dockerfile as any)?.uri || 'Dockerfile';
+            const resolvedDockerfile = path.isAbsolute(dockerfilePath)
+                ? dockerfilePath
+                : path.join(devfileDir, dockerfilePath);
+
+            expect(resolvedDockerfile).to.equal(path.join('/home/user/project', 'Dockerfile'));
+        });
+
+        test('uses default build context when not specified', () => {
+            const imageComponent = {
+                imageName: 'myapp:latest',
+                dockerfile: { uri: 'Dockerfile' },
+            };
+            const devfileDir = '/home/user/project';
+
+            const buildContext = (imageComponent.dockerfile as any)?.buildContext || '.';
+            const resolvedContext = path.isAbsolute(buildContext)
+                ? buildContext
+                : devfileDir;
+
+            expect(resolvedContext).to.equal('/home/user/project');
+        });
+
+        test('handles absolute Dockerfile path', () => {
+            const imageComponent = {
+                imageName: 'myapp:latest',
+                dockerfile: { uri: '/opt/dockerfiles/Dockerfile' },
+            };
+            const devfileDir = '/home/user/project';
+
+            const dockerfilePath = imageComponent.dockerfile?.uri || 'Dockerfile';
+            const resolvedDockerfile = path.isAbsolute(dockerfilePath)
+                ? dockerfilePath
+                : path.join(devfileDir, dockerfilePath);
+
+            expect(resolvedDockerfile).to.equal('/opt/dockerfiles/Dockerfile');
+        });
+    });
+
+    suite('loadManifestFromUri() logic', () => {
+        test('identifies HTTP URLs for download', () => {
+            const uri = 'https://example.com/deploy.yaml';
+            const isRemote = uri.startsWith('http://') || uri.startsWith('https://');
+            expect(isRemote).to.be.true;
+        });
+
+        test('identifies local file URIs', () => {
+            const uri = 'kubernetes/deploy.yaml';
+            const isRemote = uri.startsWith('http://') || uri.startsWith('https://');
+            expect(isRemote).to.be.false;
+        });
+
+        test('resolves relative file path against devfile directory', () => {
+            const uri = 'kubernetes/deploy.yaml';
+            const devfileDir = '/home/user/project';
+
+            const manifestPath = path.isAbsolute(uri)
+                ? uri
+                : path.join(devfileDir, uri);
+
+            expect(manifestPath).to.equal(path.join('/home/user/project', 'kubernetes/deploy.yaml'));
+        });
+
+        test('keeps absolute file path as-is', () => {
+            const uri = '/opt/manifests/deploy.yaml';
+            const devfileDir = '/home/user/project';
+
+            const manifestPath = path.isAbsolute(uri)
+                ? uri
+                : path.join(devfileDir, uri);
+
+            expect(manifestPath).to.equal('/opt/manifests/deploy.yaml');
+        });
+    });
+
+    suite('debugEcho()', () => {
+        test('masks --token values', () => {
+            const result = debugEcho('podman login -u unused --token=sha256:abc123 registry.example.com');
+            expect(result).to.include('--token ****');
+            expect(result).not.to.include('abc123');
+        });
+
+        test('masks --token with space separator', () => {
+            const result = debugEcho('oc login --token sha256:secret https://api.cluster:6443');
+            expect(result).to.include('--token ****');
+            expect(result).not.to.include('secret');
+        });
+
+        test('masks -p values', () => {
+            const result = debugEcho('podman login -u user -p mysecret quay.io');
+            expect(result).to.include('-p ****');
+            expect(result).not.to.include('mysecret');
+        });
+
+        test('leaves clean commands unchanged', () => {
+            const result = debugEcho('podman push quay.io/user/myimage:latest');
+            expect(result).to.include('podman push quay.io/user/myimage:latest');
+        });
+
+        test('wraps in dim ANSI escape and + prefix using printf', () => {
+            const result = debugEcho('podman push img');
+            expect(result).to.equal('printf "\\x1b[2m+ podman push img\\x1b[0m\\n"');
+        });
+    });
+
+    suite('imageNameMap manifest rewriting', () => {
+        test('replaces bare image name with retagged name in manifest', () => {
+            const manifest = `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: go-image:latest
+`;
+            const imageNameMap = new Map([['go-image:latest', 'quay.io/user/go-image:latest']]);
+            let resolved = manifest;
+            for (const [original, retagged] of imageNameMap) {
+                resolved = resolved.replaceAll(original, retagged);
+            }
+
+            expect(resolved).to.include('image: quay.io/user/go-image:latest');
+            expect(resolved).not.to.match(/image: go-image:latest/);
+        });
+
+        test('replaces multiple occurrences', () => {
+            const manifest = `
+image: go-image:latest
+initImage: go-image:latest
+`;
+            const imageNameMap = new Map([['go-image:latest', 'registry.example.com/ns/go-image:latest']]);
+            let resolved = manifest;
+            for (const [original, retagged] of imageNameMap) {
+                resolved = resolved.replaceAll(original, retagged);
+            }
+
+            const matches = resolved.match(/registry\.example\.com\/ns\/go-image:latest/g);
+            expect(matches).to.have.lengthOf(2);
+        });
+
+        test('does not modify unrelated image references', () => {
+            const manifest = `
+image: go-image:latest
+sidecar: nginx:alpine
+`;
+            const imageNameMap = new Map([['go-image:latest', 'quay.io/user/go-image:latest']]);
+            let resolved = manifest;
+            for (const [original, retagged] of imageNameMap) {
+                resolved = resolved.replaceAll(original, retagged);
+            }
+
+            expect(resolved).to.include('sidecar: nginx:alpine');
+        });
+    });
+
+    suite('patchImagePullPolicy()', () => {
+        setup(() => {
+            ApplyCommandExecutor.resetImageNameMap();
+        });
+
+        test('returns no patches when locallyLoadedImages is empty', () => {
+            const manifest = yaml.dump({
+                apiVersion: 'apps/v1',
+                kind: 'Deployment',
+                metadata: { name: 'my-app' },
+                spec: {
+                    template: {
+                        spec: {
+                            containers: [
+                                { name: 'app', image: 'go-image:latest' },
+                            ],
+                        },
+                    },
+                },
+            });
+
+            const result = ApplyCommandExecutor.patchImagePullPolicy(manifest);
+            const parsed = yaml.load(result.manifest) as any;
+            expect(parsed.spec.template.spec.containers[0].imagePullPolicy).to.be.undefined;
+            expect(result.patchedContainers).to.have.lengthOf(0);
+        });
+
+        test('sets IfNotPresent on containers matching locally loaded images', () => {
+            const manifest = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: go-image:latest
+`;
+            (ApplyCommandExecutor as any).locallyLoadedImages = new Set(['go-image:latest']);
+
+            const result = ApplyCommandExecutor.patchImagePullPolicy(manifest);
+            const parsed = yaml.load(result.manifest) as any;
+            expect(parsed.spec.template.spec.containers[0].imagePullPolicy).to.equal('IfNotPresent');
+            expect(result.patchedContainers).to.deep.equal(['Deployment/my-app/app']);
+        });
+
+        test('patches initContainers', () => {
+            const manifest = yaml.dump({
+                apiVersion: 'apps/v1',
+                kind: 'Deployment',
+                metadata: { name: 'my-app' },
+                spec: {
+                    template: {
+                        spec: {
+                            initContainers: [
+                                { name: 'init', image: 'go-image:latest' },
+                            ],
+                            containers: [
+                                { name: 'app', image: 'nginx:alpine' },
+                            ],
+                        },
+                    },
+                },
+            });
+
+            (ApplyCommandExecutor as any).locallyLoadedImages = new Set(['go-image:latest']);
+
+            const result = ApplyCommandExecutor.patchImagePullPolicy(manifest);
+            const parsed = yaml.load(result.manifest) as any;
+            expect(parsed.spec.template.spec.initContainers[0].imagePullPolicy).to.equal('IfNotPresent');
+            expect(parsed.spec.template.spec.containers[0].imagePullPolicy).to.be.undefined;
+            expect(result.patchedContainers).to.deep.equal(['Deployment/my-app/init']);
+        });
+
+        test('patches bare Pod', () => {
+            const manifest = yaml.dump({
+                apiVersion: 'v1',
+                kind: 'Pod',
+                metadata: { name: 'my-pod' },
+                spec: {
+                    containers: [
+                        { name: 'app', image: 'go-image:latest' },
+                    ],
+                },
+            });
+
+            (ApplyCommandExecutor as any).locallyLoadedImages = new Set(['go-image:latest']);
+
+            const result = ApplyCommandExecutor.patchImagePullPolicy(manifest);
+            const parsed = yaml.load(result.manifest) as any;
+            expect(parsed.spec.containers[0].imagePullPolicy).to.equal('IfNotPresent');
+            expect(result.patchedContainers).to.deep.equal(['Pod/my-pod/app']);
+        });
+
+        test('does not touch containers with non-matching images', () => {
+            const manifest = yaml.dump({
+                apiVersion: 'apps/v1',
+                kind: 'Deployment',
+                metadata: { name: 'my-app' },
+                spec: {
+                    template: {
+                        spec: {
+                            containers: [
+                                { name: 'app', image: 'nginx:alpine' },
+                            ],
+                        },
+                    },
+                },
+            });
+
+            (ApplyCommandExecutor as any).locallyLoadedImages = new Set(['go-image:latest']);
+
+            const result = ApplyCommandExecutor.patchImagePullPolicy(manifest);
+            const parsed = yaml.load(result.manifest) as any;
+            expect(parsed.spec.template.spec.containers[0].imagePullPolicy).to.be.undefined;
+            expect(result.patchedContainers).to.have.lengthOf(0);
+        });
+
+        test('preserves existing imagePullPolicy if set to Never', () => {
+            const manifest = yaml.dump({
+                apiVersion: 'apps/v1',
+                kind: 'Deployment',
+                metadata: { name: 'my-app' },
+                spec: {
+                    template: {
+                        spec: {
+                            containers: [
+                                { name: 'app', image: 'go-image:latest', imagePullPolicy: 'Never' },
+                            ],
+                        },
+                    },
+                },
+            });
+
+            (ApplyCommandExecutor as any).locallyLoadedImages = new Set(['go-image:latest']);
+
+            const result = ApplyCommandExecutor.patchImagePullPolicy(manifest);
+            const parsed = yaml.load(result.manifest) as any;
+            expect(parsed.spec.template.spec.containers[0].imagePullPolicy).to.equal('Never');
+            expect(result.patchedContainers).to.have.lengthOf(0);
+        });
+
+        test('handles multi-document YAML', () => {
+            const doc1 = yaml.dump({
+                apiVersion: 'apps/v1',
+                kind: 'Deployment',
+                metadata: { name: 'my-app' },
+                spec: {
+                    template: {
+                        spec: {
+                            containers: [
+                                { name: 'app', image: 'go-image:latest' },
+                            ],
+                        },
+                    },
+                },
+            });
+            const doc2 = yaml.dump({
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: { name: 'my-svc' },
+                spec: { ports: [{ port: 8080 }] },
+            });
+            const manifest = `${doc1}---\n${doc2}`;
+
+            (ApplyCommandExecutor as any).locallyLoadedImages = new Set(['go-image:latest']);
+
+            const result = ApplyCommandExecutor.patchImagePullPolicy(manifest);
+            const docs = yaml.loadAll(result.manifest) as any[];
+            expect(docs[0].spec.template.spec.containers[0].imagePullPolicy).to.equal('IfNotPresent');
+            expect(docs[1].kind).to.equal('Service');
+            expect(result.patchedContainers).to.deep.equal(['Deployment/my-app/app']);
+        });
+
+        test('returns unchanged manifest when no images match', () => {
+            const manifest = yaml.dump({
+                apiVersion: 'v1',
+                kind: 'Service',
+                metadata: { name: 'my-svc' },
+                spec: { ports: [{ port: 8080 }] },
+            });
+
+            (ApplyCommandExecutor as any).locallyLoadedImages = new Set(['go-image:latest']);
+
+            const result = ApplyCommandExecutor.patchImagePullPolicy(manifest);
+            const parsed = yaml.load(result.manifest) as any;
+            expect(parsed.kind).to.equal('Service');
+            expect(result.patchedContainers).to.have.lengthOf(0);
+        });
+
+        teardown(() => {
+            ApplyCommandExecutor.resetImageNameMap();
         });
     });
 });

--- a/test/unit/devfile/deploy.test.ts
+++ b/test/unit/devfile/deploy.test.ts
@@ -158,4 +158,155 @@ suite('devfile/deploy.ts', () => {
             expect(deployCommands).to.have.lengthOf(0);
         });
     });
+
+    suite('findDeployCommands() — composite expansion', () => {
+        function findDeployCommands(devfile: Data) {
+            const commands = devfile.commands || [];
+            const compositeDeployCmd = commands.find(cmd =>
+                cmd.composite?.group?.kind === 'deploy'
+            );
+            if (compositeDeployCmd) {
+                const subCommandIds = compositeDeployCmd.composite.commands;
+                return subCommandIds
+                    .map(id => commands.find(cmd => cmd.id === id))
+                    .filter((cmd): cmd is typeof commands[0] => cmd !== undefined);
+            }
+            return commands.filter(cmd => {
+                if (cmd.exec?.group?.kind === 'deploy') return true;
+                if (cmd.apply?.group?.kind === 'deploy') return true;
+                return false;
+            });
+        }
+
+        test('expands composite deploy into ordered sub-commands', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'test', version: '1.0.0' },
+                commands: [
+                    {
+                        id: 'build-image',
+                        apply: { component: 'image-build' },
+                    },
+                    {
+                        id: 'deployk8s',
+                        apply: { component: 'kubernetes-deploy' },
+                    },
+                    {
+                        id: 'deploy',
+                        composite: {
+                            commands: ['build-image', 'deployk8s'],
+                            group: { kind: 'deploy', isDefault: true },
+                        },
+                    },
+                ],
+            };
+
+            const result = findDeployCommands(devfile);
+            expect(result).to.have.lengthOf(2);
+            expect(result[0].id).to.equal('build-image');
+            expect(result[1].id).to.equal('deployk8s');
+        });
+
+        test('preserves sub-command order from composite', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'test', version: '1.0.0' },
+                commands: [
+                    {
+                        id: 'step-c',
+                        apply: { component: 'comp-c' },
+                    },
+                    {
+                        id: 'step-a',
+                        apply: { component: 'comp-a' },
+                    },
+                    {
+                        id: 'step-b',
+                        exec: {
+                            component: 'tools',
+                            commandLine: 'echo b',
+                            workingDir: '/projects',
+                        },
+                    },
+                    {
+                        id: 'deploy',
+                        composite: {
+                            commands: ['step-a', 'step-b', 'step-c'],
+                            group: { kind: 'deploy', isDefault: true },
+                        },
+                    },
+                ],
+            };
+
+            const result = findDeployCommands(devfile);
+            expect(result).to.have.lengthOf(3);
+            expect(result[0].id).to.equal('step-a');
+            expect(result[1].id).to.equal('step-b');
+            expect(result[2].id).to.equal('step-c');
+        });
+
+        test('skips missing sub-command IDs gracefully', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'test', version: '1.0.0' },
+                commands: [
+                    {
+                        id: 'build-image',
+                        apply: { component: 'image-build' },
+                    },
+                    {
+                        id: 'deploy',
+                        composite: {
+                            commands: ['build-image', 'nonexistent-cmd', 'also-missing'],
+                            group: { kind: 'deploy', isDefault: true },
+                        },
+                    },
+                ],
+            };
+
+            const result = findDeployCommands(devfile);
+            expect(result).to.have.lengthOf(1);
+            expect(result[0].id).to.equal('build-image');
+        });
+
+        test('falls back to individual deploy commands when no composite', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'test', version: '1.0.0' },
+                commands: [
+                    {
+                        id: 'build',
+                        exec: {
+                            component: 'tools',
+                            commandLine: 'npm run build',
+                            workingDir: '/projects',
+                            group: { kind: 'build', isDefault: true },
+                        },
+                    },
+                    {
+                        id: 'deploy-exec',
+                        exec: {
+                            component: 'tools',
+                            commandLine: 'kubectl apply',
+                            workingDir: '/projects',
+                            group: { kind: 'deploy', isDefault: true },
+                        },
+                    },
+                    {
+                        id: 'deploy-apply',
+                        apply: {
+                            component: 'kubernetes-deploy',
+                            group: { kind: 'deploy', isDefault: false },
+                        },
+                    },
+                ],
+            };
+
+            const result = findDeployCommands(devfile);
+            expect(result).to.have.lengthOf(2);
+            expect(result.map(c => c.id)).to.include('deploy-exec');
+            expect(result.map(c => c.id)).to.include('deploy-apply');
+            expect(result.map(c => c.id)).not.to.include('build');
+        });
+    });
 });

--- a/test/unit/devfile/registryConfig.test.ts
+++ b/test/unit/devfile/registryConfig.test.ts
@@ -1,0 +1,46 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { rewriteImageName } from '../../../src/devfile/registryConfig';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+suite('devfile/registryConfig.ts', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    suite('rewriteImageName()', () => {
+        test('prepends registry and username to bare image name', () => {
+            const result = rewriteImageName('go-image:latest', 'quay.io', 'myuser');
+            expect(result).to.equal('quay.io/myuser/go-image:latest');
+        });
+
+        test('prepends registry and username to name without tag', () => {
+            const result = rewriteImageName('myapp', 'docker.io', 'user');
+            expect(result).to.equal('docker.io/user/myapp');
+        });
+
+        test('returns already-qualified image name unchanged', () => {
+            const result = rewriteImageName('quay.io/user/go-image:latest', 'ghcr.io', 'other');
+            expect(result).to.equal('quay.io/user/go-image:latest');
+        });
+
+        test('returns image with org/name unchanged', () => {
+            const result = rewriteImageName('myorg/myimage:v1', 'quay.io', 'user');
+            expect(result).to.equal('myorg/myimage:v1');
+        });
+    });
+});

--- a/test/unit/devfile/undeploy.test.ts
+++ b/test/unit/devfile/undeploy.test.ts
@@ -110,30 +110,56 @@ suite('devfile/undeploy.ts', () => {
     });
 
     suite('loadDeployState()', () => {
-        // Note: These would require mocking fs.readFile
-        // For true unit tests, we'd need to mock the file system
-        // Leaving these as placeholders for now - can be expanded with sinon stubs
-
         test('should load valid deploystate.json', () => {
-            // This would require mocking fs.readFile to return valid JSON
-            // Example structure:
-            // sandbox.stub(fs.promises, 'readFile').resolves(JSON.stringify({
-            //     version: 1,
-            //     componentName: 'test',
-            //     deployedAt: '2026-07-07T12:00:00Z',
-            //     platform: 'cluster',
-            //     resources: []
-            // }));
+            const validState = {
+                version: 1,
+                componentName: 'test',
+                deployedAt: '2026-07-07T12:00:00Z',
+                platform: 'cluster',
+                resources: [
+                    { kind: 'Deployment', name: 'test-deploy', labels: {}, appliedAt: '2026-07-07T12:00:00Z' },
+                ],
+            };
+            const content = JSON.stringify(validState);
+
+            // Inline loadDeployState logic
+            let result: any;
+            try {
+                result = JSON.parse(content);
+            } catch {
+                result = null;
+            }
+
+            expect(result).to.not.be.null;
+            expect(result.componentName).to.equal('test');
+            expect(result.resources).to.have.lengthOf(1);
+            expect(result.resources[0].kind).to.equal('Deployment');
         });
 
         test('should return null when file is missing', () => {
-            // This would require mocking fs.readFile to throw ENOENT error
-            // sandbox.stub(fs.promises, 'readFile').rejects({ code: 'ENOENT' });
+            // Simulates fs.readFile throwing ENOENT
+            let result: any;
+            try {
+                throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+            } catch {
+                result = null;
+            }
+
+            expect(result).to.be.null;
         });
 
         test('should return null when JSON is invalid', () => {
-            // This would require mocking fs.readFile to return invalid JSON
-            // sandbox.stub(fs.promises, 'readFile').resolves('invalid json{');
+            const content = 'invalid json{';
+
+            // Inline loadDeployState logic
+            let result: any;
+            try {
+                result = JSON.parse(content);
+            } catch {
+                result = null;
+            }
+
+            expect(result).to.be.null;
         });
     });
 });

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -75,13 +75,17 @@ export async function run(): Promise<void> {
     return new Promise((resolve, reject) => {
         let failed = 0;
         try {
-            mocha.run(failures => {
+            const runner = mocha.run(failures => {
                 console.log('Mocha reported failures:', failures);
 
                 if (failures > 0) {
                     failed = failures;
                 }
             }).on('end', () => {
+                const { passes, failures, pending, duration } = runner.stats;
+                const total = passes + failures + pending;
+                const summary = `  Test Results: ${total} total, ${passes} passing, ${failures} failing, ${pending} skipped (${duration}ms)`;
+                console.error(summary);
                 let coverageReported = Promise.resolve();
                 if (coverageRunner) {
                     coverageReported = coverageRunner.reportCoverage();

--- a/test/unit/util/containerRuntime.test.ts
+++ b/test/unit/util/containerRuntime.test.ts
@@ -1,0 +1,399 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import pq from 'proxyquire';
+
+const { expect } = chai;
+chai.use(sinonChai);
+
+suite('util/containerRuntime.ts', () => {
+    let sandbox: sinon.SinonSandbox;
+    let whichStub: sinon.SinonStub;
+    let platformStub: sinon.SinonStub;
+    let executeStub: sinon.SinonStub;
+    let ContainerRuntimeDetector: any;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        whichStub = sandbox.stub();
+        platformStub = sandbox.stub();
+        executeStub = sandbox.stub();
+
+        const mod = pq('../../../src/util/containerRuntime', {
+            'shelljs': { which: whichStub },
+            'os': { platform: platformStub },
+            './childProcessUtil': {
+                ChildProcessUtil: {
+                    Instance: { execute: executeStub },
+                },
+                '@noCallThru': true,
+            },
+        });
+        ContainerRuntimeDetector = mod.ContainerRuntimeDetector;
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    suite('detectBuildRuntime()', () => {
+        test('returns podman when podman is available', async () => {
+            whichStub.withArgs('podman').returns('/usr/bin/podman');
+            platformStub.returns('linux');
+            executeStub.resolves({
+                stdout: JSON.stringify({ host: { remoteSocket: { exists: true } } }),
+                stderr: '',
+                error: undefined,
+            });
+
+            const result = await ContainerRuntimeDetector.detectBuildRuntime();
+            expect(result).to.equal('podman');
+        });
+
+        test('returns docker when only docker is available', async () => {
+            whichStub.withArgs('podman').returns(null);
+            whichStub.withArgs('docker').returns('/usr/bin/docker');
+            executeStub.resolves({ stdout: 'docker info output', stderr: '', error: undefined });
+
+            const result = await ContainerRuntimeDetector.detectBuildRuntime();
+            expect(result).to.equal('docker');
+        });
+
+        test('returns buildah when only buildah is available', async () => {
+            whichStub.withArgs('podman').returns(null);
+            whichStub.withArgs('docker').returns(null);
+            whichStub.withArgs('buildah').returns('/usr/bin/buildah');
+            executeStub.resolves({ stdout: 'buildah version', stderr: '', error: undefined });
+
+            const result = await ContainerRuntimeDetector.detectBuildRuntime();
+            expect(result).to.equal('buildah');
+        });
+
+        test('returns null when no runtime is available', async () => {
+            whichStub.returns(null);
+
+            const result = await ContainerRuntimeDetector.detectBuildRuntime();
+            expect(result).to.be.null;
+        });
+
+        test('prefers podman over docker when both available', async () => {
+            whichStub.withArgs('podman').returns('/usr/bin/podman');
+            whichStub.withArgs('docker').returns('/usr/bin/docker');
+            platformStub.returns('linux');
+            executeStub.resolves({
+                stdout: JSON.stringify({ host: { remoteSocket: { exists: true } } }),
+                stderr: '',
+                error: undefined,
+            });
+
+            const result = await ContainerRuntimeDetector.detectBuildRuntime();
+            expect(result).to.equal('podman');
+        });
+    });
+
+    suite('isPodmanAvailable()', () => {
+        test('returns true on Linux when podman is found and remoteSocket exists', async () => {
+            whichStub.withArgs('podman').returns('/usr/bin/podman');
+            platformStub.returns('linux');
+            executeStub.resolves({
+                stdout: JSON.stringify({ host: { remoteSocket: { exists: true } } }),
+                stderr: '',
+                error: undefined,
+            });
+
+            const result = await ContainerRuntimeDetector.isPodmanAvailable();
+            expect(result).to.be.true;
+        });
+
+        test('returns false on Linux when remoteSocket does not exist', async () => {
+            whichStub.withArgs('podman').returns('/usr/bin/podman');
+            platformStub.returns('linux');
+            executeStub.resolves({
+                stdout: JSON.stringify({ host: { remoteSocket: { exists: false } } }),
+                stderr: '',
+                error: undefined,
+            });
+
+            const result = await ContainerRuntimeDetector.isPodmanAvailable();
+            expect(result).to.be.false;
+        });
+
+        test('returns false on Linux when podman info fails', async () => {
+            whichStub.withArgs('podman').returns('/usr/bin/podman');
+            platformStub.returns('linux');
+            executeStub.rejects(new Error('podman info failed'));
+
+            const result = await ContainerRuntimeDetector.isPodmanAvailable();
+            expect(result).to.be.false;
+        });
+
+        test('returns false when podman is not found', async () => {
+            whichStub.withArgs('podman').returns(null);
+
+            const result = await ContainerRuntimeDetector.isPodmanAvailable();
+            expect(result).to.be.false;
+        });
+
+        test('on non-Linux returns true when podman machine is running', async () => {
+            whichStub.withArgs('podman').returns('/usr/local/bin/podman');
+            platformStub.returns('darwin');
+            executeStub.resolves({
+                stdout: JSON.stringify([{ Running: true }]),
+                stderr: '',
+                error: undefined,
+            });
+
+            const result = await ContainerRuntimeDetector.isPodmanAvailable();
+            expect(result).to.be.true;
+        });
+
+        test('on non-Linux returns false when no podman machine running', async () => {
+            whichStub.withArgs('podman').returns('/usr/local/bin/podman');
+            platformStub.returns('darwin');
+            executeStub.resolves({
+                stdout: JSON.stringify([{ Running: false }]),
+                stderr: '',
+                error: undefined,
+            });
+
+            const result = await ContainerRuntimeDetector.isPodmanAvailable();
+            expect(result).to.be.false;
+        });
+    });
+
+    suite('isDockerAvailable()', () => {
+        test('returns true when docker is found and daemon is running', async () => {
+            whichStub.withArgs('docker').returns('/usr/bin/docker');
+            executeStub.resolves({ stdout: 'docker info output', stderr: '', error: undefined });
+
+            const result = await ContainerRuntimeDetector.isDockerAvailable();
+            expect(result).to.be.true;
+        });
+
+        test('returns false when docker daemon is not running', async () => {
+            whichStub.withArgs('docker').returns('/usr/bin/docker');
+            executeStub.rejects(new Error('Cannot connect to Docker daemon'));
+
+            const result = await ContainerRuntimeDetector.isDockerAvailable();
+            expect(result).to.be.false;
+        });
+
+        test('returns false when docker is not found', async () => {
+            whichStub.withArgs('docker').returns(null);
+
+            const result = await ContainerRuntimeDetector.isDockerAvailable();
+            expect(result).to.be.false;
+        });
+    });
+
+    suite('isBuildahAvailable()', () => {
+        test('returns true when buildah is found and works', async () => {
+            whichStub.withArgs('buildah').returns('/usr/bin/buildah');
+            executeStub.resolves({ stdout: 'buildah version 1.33', stderr: '', error: undefined });
+
+            const result = await ContainerRuntimeDetector.isBuildahAvailable();
+            expect(result).to.be.true;
+        });
+
+        test('returns false when buildah is not found', async () => {
+            whichStub.withArgs('buildah').returns(null);
+
+            const result = await ContainerRuntimeDetector.isBuildahAvailable();
+            expect(result).to.be.false;
+        });
+    });
+
+    suite('getBuildCommand()', () => {
+        test('returns correct command for podman', () => {
+            const cmd = ContainerRuntimeDetector.getBuildCommand(
+                'podman', 'myimage:latest', '/path/to/Dockerfile', '/build/context',
+            );
+            expect(cmd).to.equal('podman build -t myimage:latest -f /path/to/Dockerfile /build/context');
+        });
+
+        test('returns correct command for docker', () => {
+            const cmd = ContainerRuntimeDetector.getBuildCommand(
+                'docker', 'myimage:latest', '/path/to/Dockerfile', '/build/context',
+            );
+            expect(cmd).to.equal('docker build -t myimage:latest -f /path/to/Dockerfile /build/context');
+        });
+
+        test('returns correct command for buildah', () => {
+            const cmd = ContainerRuntimeDetector.getBuildCommand(
+                'buildah', 'myimage:latest', '/path/to/Dockerfile', '/build/context',
+            );
+            expect(cmd).to.equal('buildah bud -t myimage:latest -f /path/to/Dockerfile /build/context');
+        });
+
+        test('throws for unsupported runtime', () => {
+            expect(() => {
+                ContainerRuntimeDetector.getBuildCommand(
+                    'nerdctl', 'img', '/Dockerfile', '.',
+                );
+            }).to.throw('Unsupported container runtime: nerdctl');
+        });
+    });
+
+    suite('getLoginCommand()', () => {
+        test('returns podman login with --password-stdin', () => {
+            const cmd = ContainerRuntimeDetector.getLoginCommand('podman', 'quay.io', 'myuser');
+            expect(cmd).to.equal('podman login -u myuser --password-stdin quay.io');
+        });
+
+        test('returns docker login with --password-stdin', () => {
+            const cmd = ContainerRuntimeDetector.getLoginCommand('docker', 'docker.io', 'myuser');
+            expect(cmd).to.equal('docker login -u myuser --password-stdin docker.io');
+        });
+
+        test('returns buildah login with --password-stdin', () => {
+            const cmd = ContainerRuntimeDetector.getLoginCommand('buildah', 'ghcr.io', 'myuser');
+            expect(cmd).to.equal('buildah login -u myuser --password-stdin ghcr.io');
+        });
+
+        test('never includes a password in the command string', () => {
+            const cmd = ContainerRuntimeDetector.getLoginCommand('podman', 'quay.io', 'myuser');
+            expect(cmd).not.to.include('-p ');
+            expect(cmd).not.to.include('secret');
+        });
+    });
+
+    suite('loginToRegistry()', () => {
+        test('pipes password via stdin and resolves on success', async () => {
+            executeStub.resolves({ stdout: 'Login Succeeded!', stderr: '', error: undefined });
+
+            await ContainerRuntimeDetector.loginToRegistry('podman', 'quay.io', 'myuser', 'secret123');
+
+            expect(executeStub).to.have.been.calledOnce;
+            const [cmd, , stdin] = executeStub.firstCall.args;
+            expect(cmd).to.include('--password-stdin');
+            expect(cmd).not.to.include('secret123');
+            expect(stdin).to.equal('secret123');
+        });
+
+        test('throws on login failure with stderr message', async () => {
+            executeStub.resolves({
+                stdout: '',
+                stderr: 'Error: unauthorized: access denied',
+                error: new Error('Exited with code 1'),
+            });
+
+            try {
+                await ContainerRuntimeDetector.loginToRegistry('podman', 'quay.io', 'myuser', 'badpass');
+                expect.fail('should have thrown');
+            } catch (err) {
+                expect(err.message).to.include('Registry login failed');
+                expect(err.message).to.include('unauthorized');
+            }
+        });
+
+        test('includes error message when stderr is empty', async () => {
+            executeStub.resolves({
+                stdout: '',
+                stderr: '',
+                error: new Error('Exited with code 1'),
+            });
+
+            try {
+                await ContainerRuntimeDetector.loginToRegistry('docker', 'docker.io', 'user', 'pass');
+                expect.fail('should have thrown');
+            } catch (err) {
+                expect(err.message).to.include('Registry login failed');
+                expect(err.message).to.include('Exited with code 1');
+            }
+        });
+    });
+
+    suite('getPushCommand()', () => {
+        test('returns correct command for podman', () => {
+            const cmd = ContainerRuntimeDetector.getPushCommand('podman', 'quay.io/user/myimage:latest');
+            expect(cmd).to.equal('podman push quay.io/user/myimage:latest');
+        });
+
+        test('returns correct command for docker', () => {
+            const cmd = ContainerRuntimeDetector.getPushCommand('docker', 'docker.io/user/myimage:latest');
+            expect(cmd).to.equal('docker push docker.io/user/myimage:latest');
+        });
+
+        test('returns correct command for buildah', () => {
+            const cmd = ContainerRuntimeDetector.getPushCommand('buildah', 'ghcr.io/user/myimage:latest');
+            expect(cmd).to.equal('buildah push ghcr.io/user/myimage:latest');
+        });
+    });
+
+    suite('getRetagCommand()', () => {
+        test('returns retag command for podman', () => {
+            const cmd = ContainerRuntimeDetector.getRetagCommand('podman', 'myimage:latest');
+            expect(cmd).to.equal('podman tag myimage:latest docker.io/library/myimage:latest');
+        });
+
+        test('returns retag command for buildah', () => {
+            const cmd = ContainerRuntimeDetector.getRetagCommand('buildah', 'myimage:latest');
+            expect(cmd).to.equal('podman tag myimage:latest docker.io/library/myimage:latest');
+        });
+
+        test('returns undefined for docker (no retag needed)', () => {
+            const cmd = ContainerRuntimeDetector.getRetagCommand('docker', 'myimage:latest');
+            expect(cmd).to.be.undefined;
+        });
+    });
+
+    suite('getKindLoadCommand()', () => {
+        test('returns kind load docker-image for docker runtime', () => {
+            const cmd = ContainerRuntimeDetector.getKindLoadCommand('docker', 'myimage:latest');
+            expect(cmd).to.equal('kind load docker-image myimage:latest');
+        });
+
+        test('returns podman save with docker.io prefix piped to kind load for podman runtime', () => {
+            const cmd = ContainerRuntimeDetector.getKindLoadCommand('podman', 'myimage:latest');
+            expect(cmd).to.equal('podman save docker.io/library/myimage:latest | kind load image-archive /dev/stdin');
+        });
+
+        test('includes --name flag when clusterName is provided', () => {
+            const cmd = ContainerRuntimeDetector.getKindLoadCommand('docker', 'myimage:latest', 'chart-testing');
+            expect(cmd).to.equal('kind load docker-image myimage:latest --name chart-testing');
+        });
+
+        test('includes --name flag for podman with clusterName', () => {
+            const cmd = ContainerRuntimeDetector.getKindLoadCommand('podman', 'myimage:latest', 'chart-testing');
+            expect(cmd).to.equal('podman save docker.io/library/myimage:latest | kind load image-archive /dev/stdin --name chart-testing');
+        });
+    });
+
+    suite('getMinikubeLoadCommand()', () => {
+        test('returns minikube image load for docker runtime', () => {
+            const cmd = ContainerRuntimeDetector.getMinikubeLoadCommand('docker', 'myimage:latest');
+            expect(cmd).to.equal('minikube image load myimage:latest');
+        });
+
+        test('returns podman save with docker.io prefix piped to minikube for podman runtime', () => {
+            const cmd = ContainerRuntimeDetector.getMinikubeLoadCommand('podman', 'myimage:latest');
+            expect(cmd).to.equal('podman save docker.io/library/myimage:latest | minikube image load -');
+        });
+    });
+
+    suite('isRegistryLoggedIn()', () => {
+        test('podman: returns true when get-login succeeds', async () => {
+            whichStub.withArgs('podman').returns('/usr/bin/podman');
+            platformStub.returns('linux');
+            executeStub.resolves({ stdout: 'myuser', stderr: '', error: undefined });
+
+            const result = await ContainerRuntimeDetector.isRegistryLoggedIn('podman', 'quay.io');
+            expect(result).to.be.true;
+            expect(executeStub).to.have.been.calledWith('podman login --get-login quay.io');
+        });
+
+        test('podman: returns false when get-login fails', async () => {
+            whichStub.withArgs('podman').returns('/usr/bin/podman');
+            platformStub.returns('linux');
+            executeStub.rejects(new Error('not logged in'));
+
+            const result = await ContainerRuntimeDetector.isRegistryLoggedIn('podman', 'quay.io');
+            expect(result).to.be.false;
+        });
+    });
+});

--- a/test/unit/util/kubeUtils.test.ts
+++ b/test/unit/util/kubeUtils.test.ts
@@ -7,7 +7,9 @@ import * as chai from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import pq from 'proxyquire';
 import { KubeConfigInfo } from '../../../src/util/kubeUtils';
+import { KubernetesVariant } from '../../../src/oc/types';
 
 const {expect} = chai;
 chai.use(sinonChai);
@@ -42,4 +44,142 @@ suite('K8s Configuration Utility', () => {
         const k8sConfigInfo = new KubeConfigInfo();
         expect(k8sConfigInfo.getProxy('context-cluster1')).is.not.undefined;
     })
+});
+
+suite('detectKubernetesVariant()', () => {
+    let sandbox: sinon.SinonSandbox;
+    let executeSyncToolStub: sinon.SinonStub;
+    let detectKubernetesVariant: any;
+    const fixtureDir = path.resolve(__dirname, '..', '..', '..', '..', 'test', 'fixtures');
+    const configDir = path.resolve(fixtureDir, '.kube');
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        executeSyncToolStub = sandbox.stub();
+
+        const mod = pq('../../../src/util/kubeUtils', {
+            '../cli': {
+                CliChannel: {
+                    getInstance: () => ({
+                        executeSyncTool: executeSyncToolStub,
+                        executeTool: sandbox.stub(),
+                    }),
+                },
+            },
+        });
+        detectKubernetesVariant = mod.detectKubernetesVariant;
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('returns Kind when context starts with kind- and kind CLI available', async () => {
+        sandbox.stub(process, 'env').value({
+            KUBECONFIG: path.join(configDir, 'config-kind'),
+        });
+        executeSyncToolStub.resolves('kind v0.20.0');
+
+        const result = await detectKubernetesVariant();
+        expect(result).to.equal(KubernetesVariant.Kind);
+    });
+
+    test('returns Generic when context starts with kind- but kind CLI unavailable', async () => {
+        sandbox.stub(process, 'env').value({
+            KUBECONFIG: path.join(configDir, 'config-kind'),
+        });
+        executeSyncToolStub.rejects(new Error('kind not found'));
+
+        const result = await detectKubernetesVariant();
+        expect(result).to.equal(KubernetesVariant.Generic);
+    });
+
+    test('returns Minikube when context is minikube', async () => {
+        sandbox.stub(process, 'env').value({
+            KUBECONFIG: path.join(configDir, 'config-minikube'),
+        });
+
+        const result = await detectKubernetesVariant();
+        expect(result).to.equal(KubernetesVariant.Minikube);
+    });
+
+    test('returns Generic for unknown context names', async () => {
+        sandbox.stub(process, 'env').value({
+            KUBECONFIG: path.join(configDir, 'config-generic'),
+        });
+
+        const result = await detectKubernetesVariant();
+        expect(result).to.equal(KubernetesVariant.Generic);
+    });
+});
+
+suite('getOpenShiftRegistryUrl()', () => {
+    let sandbox: sinon.SinonSandbox;
+    let executeToolStub: sinon.SinonStub;
+    let getOpenShiftRegistryUrl: any;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        executeToolStub = sandbox.stub();
+
+        const mod = pq('../../../src/util/kubeUtils', {
+            '../cli': {
+                CliChannel: {
+                    getInstance: () => ({
+                        executeSyncTool: sandbox.stub(),
+                        executeTool: executeToolStub,
+                    }),
+                },
+            },
+        });
+        getOpenShiftRegistryUrl = mod.getOpenShiftRegistryUrl;
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('returns URL from oc registry info', async () => {
+        executeToolStub.resolves({
+            stdout: 'default-route-openshift-image-registry.apps.mycluster.com',
+            stderr: '',
+            error: undefined,
+        });
+
+        const result = await getOpenShiftRegistryUrl();
+        expect(result).to.equal('default-route-openshift-image-registry.apps.mycluster.com');
+    });
+
+    test('falls back to route query when registry info fails and strips quotes', async () => {
+        executeToolStub.callsFake(async (cmd: any) => {
+            const cmdStr = cmd.toString();
+            if (cmdStr.includes('registry info')) {
+                throw new Error('not available');
+            }
+            return { stdout: '\'registry.apps.mycluster.com\'', stderr: '', error: undefined };
+        });
+
+        const result = await getOpenShiftRegistryUrl();
+        expect(result).to.equal('registry.apps.mycluster.com');
+    });
+
+    test('returns undefined when both methods fail', async () => {
+        executeToolStub.rejects(new Error('not available'));
+
+        const result = await getOpenShiftRegistryUrl();
+        expect(result).to.be.undefined;
+    });
+
+    test('returns undefined when registry info returns error text', async () => {
+        executeToolStub.callsFake(async (cmd: any) => {
+            const cmdStr = cmd.toString();
+            if (cmdStr.includes('registry info')) {
+                return { stdout: 'error: no registry configured', stderr: '', error: undefined };
+            }
+            throw new Error('route not found');
+        });
+
+        const result = await getOpenShiftRegistryUrl();
+        expect(result).to.be.undefined;
+    });
 });


### PR DESCRIPTION
## Summary

Adds a complete deploy pipeline that builds container images and
deploys them to Kind, Minikube, OpenShift, and generic Kubernetes
clusters — all from the OpenShift terminal.

### Key changes

- **Cluster-aware deploy pipeline**: Detects cluster type and handles
  image delivery accordingly — local load for Kind/Minikube, registry
  push for OpenShift/K8s
- **Container runtime detection**: Finds available runtime
  (podman > docker > buildah) with build, tag, push, and load commands
- **Registry selection QuickPick**: Prompts user to select a registry
  (quay.io, docker.io, ghcr.io, custom URL, or OpenShift internal
  registry as fallback) when deploying to OpenShift/K8s
- **Image pull secret management**: Auto-creates a docker-registry
  pull secret and links it to the default service account. Created
  once per registry/namespace, reused on subsequent deploys. Prompts
  for password only when needed (no existing secret, no stored
  credentials, not already logged in via podman). Shows warning at
  end of deploy output when secret creation fails or is skipped
- **Unified single-terminal deploy**: All steps (build, retag, push/load,
  apply) run in one terminal tab via a combined temp script
- **Image name rewriting**: Maps bare image names to full registry paths
  in Kubernetes manifests via imageNameMap before `oc apply`
- **imagePullPolicy patching**: Sets IfNotPresent for locally loaded
  images on Kind/Minikube to prevent pulling from remote registry
- **Deploy state persistence**: Saves cluster URL and namespace in
  `.odo/deploystate.json` for context-switch reconciliation
- **Dev/Deploy mutual exclusivity**: Start Dev hidden when deployed,
  Deploy/Undeploy hidden when dev is active (via `when` clauses)
- **Stop Dev regex fix**: Fixed alternation bug that matched `run`
  anywhere in viewItem (e.g. `dep-run` triggering Stop Dev)
- **Unit tests**: ContainerRuntimeDetector, kubeUtils, registryConfig,
  applyCommand, deploy
- **Public UI tests**: Deploy/Undeploy test cases in componentContextMenu

Fixes: https://redhat.atlassian.net/browse/CRW-10962
Fixes: https://github.com/redhat-developer/vscode-openshift-tools/issues/4482

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>