### PR TITLE
[deps] Update dependency overrides to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7550,9 +7550,9 @@
 			"peer": true
 		},
 		"node_modules/cookie": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.0.tgz",
-			"integrity": "sha512-hRSFuKJ6SYHrFVNltQdagQFMk7e0Q/VrORTGqZGyUAmmhA3EwPeldHCTg0HqUaDodQOfQDe7qXuOtpf4lwCsaA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+			"integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -16267,9 +16267,9 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
-			"integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+			"integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -195,15 +195,15 @@
 		"yaml": "^2.9.0"
 	},
 	"overrides": {
-		"cookie": "^2.0.0",
+		"cookie": "^2.0.1",
 		"cross-spawn": "^7.0.6",
 		"diff": "^9.0.0",
 		"globals": "^17.7.0",
 		"js-cookie": "^3.0.8",
 		"js-yaml": "^4.3.0",
-		"serialize-javascript": "^7.0.6",
+		"serialize-javascript": "^7.0.7",
 		"tar-fs": "^3.1.3",
-		"tough-cookie": "^6.0.1",
+		"tough-cookie": "^6.0.2",
 		"typescript": "^6.0.3",
 		"uuid": "^14.0.1"
 	},


### PR DESCRIPTION
Changed overrides:

- cookie: ^2.0.0 -> ^2.0.1
- serialize-javascript: ^7.0.6 -> ^7.0.7
- tough-cookie: ^6.0.1 -> ^6.0.2