### PR TITLE
[deps] Fix vulnerability in protobufjs >=7.5.0, <=7.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14645,9 +14645,9 @@
 			"license": "MIT"
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",


### PR DESCRIPTION
protobufjs  >=7.5.0, <=7.6.4
Severity: medium
protobufjs: Denial of Service via infinite loop in .proto option parsing - https://github.com/advisories/GHSA-j3f2-48v5-ccww fix available via `npm audit fix`
node_modules/protobufjs

Fixes: https://github.com/redhat-developer/vscode-openshift-tools/security/dependabot/188


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>