### PR TITLE
[build] Fix native module bundling and webview JSON leak in productio…

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,4 @@
+.claude/**
 azure-pipelines.yml
 build/**
 build/**

--- a/build/esbuild.extension.cjs
+++ b/build/esbuild.extension.cjs
@@ -28,7 +28,7 @@ const baseConfig = {
 };
 
 async function copyJsonFiles() {
-    const jsonFiles = sync('src/**/*.json', { absolute: false });
+    const jsonFiles = sync('src/**/*.json', { absolute: false, ignore: ['src/webview/**'] });
     for (const file of jsonFiles) {
         const dest = path.join('out', file);
         await cp(file, dest, { recursive: false, force: true });

--- a/build/esbuild.plugins.cjs
+++ b/build/esbuild.plugins.cjs
@@ -63,11 +63,15 @@ function nativeNodeModulesPlugin() {
                 // If a ".node" file is imported within a module in the "file" namespace, resolve
                 // it to an absolute path and put it into the "node-file" virtual namespace.
                 build.onResolve({ filter: /\.node$/, namespace: 'file' }, args => {
-                    const resolvedId = require.resolve(args.path, { paths: [args.resolveDir] });
-                    if (resolvedId.endsWith('.node')) {
-                        return { path: resolvedId, namespace: 'node-file' };
+                    try {
+                        const resolvedId = require.resolve(args.path, { paths: [args.resolveDir] });
+                        if (resolvedId.endsWith('.node')) {
+                            return { path: resolvedId, namespace: 'node-file' };
+                        }
+                        return { path: resolvedId };
+                    } catch {
+                        return { path: args.path, external: true };
                     }
-                    return { path: resolvedId };
                 });
 
                 // Files in the "node-file" virtual namespace call "require()" on the

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	"scripts": {
 		"compile": "npm run prebuild-esm && node ./build/esbuild.build.cjs",
 		"build": "npm run prebuild-esm && node ./build/esbuild.build.cjs && npm run bundle-tools",
-		"vscode:prepublish": "npm install --ignore-scripts && npm run clean && npm run lint && npm run prebuild-esm && node ./build/esbuild.build.cjs --production && npm run bundle-tools && npm prune --omit=dev",
+		"vscode:prepublish": "npm install --ignore-scripts && npm rebuild cpu-features ssh2 && npm run clean && npm run lint && npm run prebuild-esm && node ./build/esbuild.build.cjs --production && npm run bundle-tools && npm prune --omit=dev",
 		"prebuild-esm": "node ./build/esbuild.transform-esm.cjs",
 		"watch:extension": "node ./build/esbuild.extension.cjs --watch",
 		"watch:webviews": "node ./build/esbuild.webviews.cjs --watch",


### PR DESCRIPTION
…n build

- Add npm rebuild cpu-features ssh2 to vscode:prepublish after npm install --ignore-scripts, so native .node binaries are compiled and bundled into the VSIX (matching CI workflow behavior)
- Handle missing .node files gracefully in nativeNodeModulesPlugin by catching require.resolve failures and marking them as external
- Exclude src/webview/** tsconfig.json files from copyJsonFiles() to prevent them from leaking into the VSIX
- Add .claude/ to .vscodeignore to exclude Claude config from VSIX


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>