### PR TITLE
[deps] Fix vulnerability in fast-uri 3.0.0-3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9761,9 +9761,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
fast-uri  3.0.0 - 3.1.2
Severity: high
fast-uri: host confusion via failed IDN canonicalization - https://github.com/advisories/GHSA-4c8g-83qw-93j6 fix available via `npm audit fix`
node_modules/fast-uri


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>