### PR TITLE
[deps] Fix vulnerability in immutable 5.0.0-beta.1 - 5.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10939,9 +10939,9 @@
 			"license": "MIT"
 		},
 		"node_modules/immutable": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+			"integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
 			"dev": true,
 			"license": "MIT"
 		},


### PR DESCRIPTION
immutable  5.0.0-beta.1 - 5.1.7
Severity: high
Immutable.js `List` 32-bit trie overflow → unrecoverable DoS - https://github.com/advisories/GHSA-v56q-mh7h-f735 Immutable: Hash-collision algorithmic complexity denial of service in Immutable.Map/Set - https://github.com/advisories/GHSA-xvcm-6775-5m9r fix available via `npm audit fix`
node_modules/immutable


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>