### PR TITLE
[build] Auto-kill esbuild watchers on debug stop and before tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,7 @@
                 "${workspaceFolder}/out/src/**/*.js"
             ],
             "preLaunchTask": "watch",
+            "postDebugTask": "kill-watchers",
             "env": {
                 "VSCODE_REDHAT_TELEMETRY_DEBUG":"true"
             }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -72,6 +72,14 @@
             },
         },
         {
+            "label": "kill-watchers",
+            "type": "shell",
+            "command": "pkill -f 'esbuild\\.(extension|webviews)\\.cjs --watch' 2>/dev/null; true",
+            "presentation": {
+                "reveal": "silent"
+            }
+        },
+        {
             "label": "instrument",
             "type": "shell",
             "command": ["${workspaceFolder}/node_modules/.bin/shx rm -rf ${workspaceFolder}/out/src-orig && ${workspaceFolder}/node_modules/.bin/shx mv ${workspaceFolder}/out/src ${workspaceFolder}/out/src-orig && ${workspaceFolder}/node_modules/.bin/istanbul instrument --complete-copy --embed-source --output out/src out/src-orig"],

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"test:build-extension": "npm run prebuild-esm && tsc -p tsconfig.json",
 		"test:build-webviews": "node ./build/esbuild.webviews.cjs",
 		"test:instrument": "shx rm -rf out/src-orig && shx mv out/src out/src-orig && istanbul instrument --complete-copy --embed-source --output out/src out/src-orig",
+		"pretest": "pkill -f 'esbuild\\.(extension|webviews)\\.cjs --watch' 2>/dev/null; true",
 		"test": "npm run test:prepare && node ./build/install-vscode.cjs && node ./build/run-tests.cjs unit",
 		"test:coverage": "npm run test:prepare && npm run test:instrument && node ./build/install-vscode.cjs && node ./build/run-tests.cjs unit",
 		"test-integration": "npm run test:prepare && node ./build/run-tests.cjs integration",


### PR DESCRIPTION
- Add kill-watchers task and postDebugTask to stop watchers when F5 ends
- Add pretest script to kill watchers before npm test runs
- Prevents esbuild watchers from overwriting tsc-compiled files in out/


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>