### PR TITLE
[deps] Fix high-severity brace-expansion <=5.0.7 DoS vulnerability (G…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6386,13 +6386,6 @@
 				"npm": ">=6"
 			}
 		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/bare-events": {
 			"version": "2.8.2",
 			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
@@ -6646,16 +6639,16 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/brace-expansion/node_modules/balanced-match": {
@@ -7525,13 +7518,6 @@
 				"validate.io-function": "^1.0.2",
 				"validate.io-integer-array": "^1.0.0"
 			}
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/content-disposition": {
 			"version": "1.0.0",
@@ -10311,16 +10297,6 @@
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"peer": true
-		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
 		},
 		"node_modules/glob/node_modules/jackspeak": {
 			"version": "3.4.3",
@@ -13142,17 +13118,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/minimist": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -13231,16 +13196,6 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/mocha/node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/mocha/node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
 		"yaml": "^2.9.0"
 	},
 	"overrides": {
+		"brace-expansion": "^5.0.8",
 		"cookie": "^2.0.1",
 		"cross-spawn": "^7.0.6",
 		"diff": "^9.0.0",


### PR DESCRIPTION
…HSA-mh99-v99m-4gvg)

Add npm override for brace-expansion >=5.0.8 to fix CVE causing DoS via unbounded expansion length (out-of-memory crash).

Fixes https://github.com/redhat-developer/vscode-openshift-tools/security/dependabot/192

```
$ npm audit
# npm audit report

brace-expansion  <=5.0.7
Severity: high
brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash - https://github.com/advisories/GHSA-mh99-v99m-4gvg
fix available via `npm audit fix --force`
Will install remap-istanbul@0.9.1, which is a breaking change
node_modules/brace-expansion
node_modules/glob/node_modules/brace-expansion
node_modules/minimatch/node_modules/brace-expansion
node_modules/mocha/node_modules/brace-expansion
  minimatch  2.0.0 - 10.0.2
  Depends on vulnerable versions of brace-expansion
  node_modules/glob/node_modules/minimatch
  node_modules/minimatch
  node_modules/mocha/node_modules/minimatch
    @eslint/config-array  <=0.22.0
    Depends on vulnerable versions of minimatch
    node_modules/@eslint/config-array
      eslint  0.12.0 - 2.0.0-rc.1 || 4.1.0 - 10.0.0-rc.2
      Depends on vulnerable versions of @eslint/config-array
      Depends on vulnerable versions of @eslint/eslintrc
      Depends on vulnerable versions of minimatch
      node_modules/eslint
    @eslint/eslintrc  0.0.1 || >=0.1.1
    Depends on vulnerable versions of minimatch
    node_modules/@eslint/eslintrc
    @vscode/vsce  <=3.9.1
    Depends on vulnerable versions of minimatch
    node_modules/@vscode/vsce
    eslint-plugin-import  >=1.15.0
    Depends on vulnerable versions of minimatch
    node_modules/eslint-plugin-import
    glob  4.3.0 - 10.5.0
    Depends on vulnerable versions of minimatch
    node_modules/glob
    node_modules/istanbul/node_modules/glob
      istanbul  0.4.5
      Depends on vulnerable versions of glob
      node_modules/istanbul
        remap-istanbul  >=0.7.0
        Depends on vulnerable versions of istanbul
        Depends on vulnerable versions of minimatch
        node_modules/remap-istanbul
      mocha  3.0.0-0 - 12.0.0-beta-9
      Depends on vulnerable versions of glob
      Depends on vulnerable versions of minimatch
      node_modules/mocha
        vscode-extension-tester  *
        Depends on vulnerable versions of mocha
        node_modules/vscode-extension-tester
    npm-run-all  >=1.2.0
    Depends on vulnerable versions of minimatch
    node_modules/npm-run-all

13 high severity vulnerabilities
```


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>