### PR TITLE
[deps] Temporarily ignore TypeScript >=7.0.0 in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   ignore:
+  - dependency-name: "typescript"
+    versions: [">=7.0.0"]
   - dependency-name: "@types/node"
     versions: [">=21.0.0"]
   - dependency-name: "@mui/icons-material"


### PR DESCRIPTION
Dependabot gets stuck on the TypeScript 7 upgrade and stops providing updates for other dependencies. Block it until the codebase is ready for the migration.


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>