### PR TITLE
[deps] Fix high-severity brace-expansion 4.0.0-5.0.8 DoS vulnerability (GHSA-rgw5-rvv9-x895)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6728,9 +6728,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
 		"yaml": "^2.9.0"
 	},
 	"overrides": {
-		"brace-expansion": "^5.0.8",
+		"brace-expansion": "^5.0.9",
 		"cookie": "^2.0.1",
 		"cross-spawn": "^7.0.6",
 		"diff": "^9.0.0",


### PR DESCRIPTION
Update npm override for brace-expansion to >=5.0.9 to fix DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation.

Fixes https://github.com/redhat-developer/vscode-openshift-tools/security/dependabot/193

```
$ npm audit
# npm audit report

brace-expansion  4.0.0 - 5.0.8
Severity: high
brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation - https://github.com/advisories/GHSA-rgw5-rvv9-x895
fix available via `npm audit fix`
node_modules/brace-expansion
```


Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>