### PR TITLE
Fix Public UI test failures with VS Code 1.132.0

### DIFF
--- a/test/ui/common/overdrives.ts
+++ b/test/ui/common/overdrives.ts
@@ -2,9 +2,15 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-import { ViewSection, By, waitForAttributeValue, BottomBarPanel, VSBrowser, ActivityBar } from 'vscode-extension-tester';
+import { ViewSection, By, EditorView, waitForAttributeValue, BottomBarPanel, VSBrowser, ActivityBar } from 'vscode-extension-tester';
 import { activateCommand } from './command-activator';
 import { VIEWS } from './constants';
+
+export async function closeAllOpenEditors(): Promise<void> {
+    try {
+        await new EditorView().closeAllEditors();
+    } catch { /* best effort */ }
+}
 
 export async function collapse(section: ViewSection) {
     try {

--- a/test/ui/settings.json
+++ b/test/ui/settings.json
@@ -1,5 +1,7 @@
 {
     "window.dialogStyle": "custom",
     "files.simpleDialog.enable": true,
-    "workbench.welcomePage.experimentalOnboarding": false
+    "workbench.welcomePage.experimentalOnboarding": false,
+    "workbench.editor.tabActionLocation": "right",
+    "workbench.editor.showTabs": "multiple"
 }

--- a/test/ui/suite/addCluster.ts
+++ b/test/ui/suite/addCluster.ts
@@ -2,9 +2,9 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-import { ActivityBar, EditorView, SideBarView, VSBrowser } from 'vscode-extension-tester';
+import { ActivityBar, SideBarView, VSBrowser } from 'vscode-extension-tester';
 import { VIEWS } from '../common/constants';
-import { collapse } from '../common/overdrives';
+import { closeAllOpenEditors, collapse } from '../common/overdrives';
 import { AddClusterWebView, DevSandboxWebViewPage, LocalClusterWebViewPage } from '../common/ui/webview/addClusterWebView';
 import { webViewIsOpened, welcomeContentButtonsAreLoaded } from '../common/conditions';
 
@@ -17,7 +17,7 @@ export function testAddCluster() {
         before(async function context() {
             this.timeout(30_000)
             //await new Promise((res) => {setTimeout(res, 20_000)});
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
             view = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
             for (const item of [VIEWS.components, VIEWS.compRegistries, VIEWS.serverlessFunctions, VIEWS.debugSessions]) {
                 await collapse(await view.getContent().getSection(item))

--- a/test/ui/suite/command-about.ts
+++ b/test/ui/suite/command-about.ts
@@ -4,8 +4,9 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { expect } from 'chai';
-import { By, EditorView, WebviewView, Workbench } from 'vscode-extension-tester';
+import { By, WebviewView, Workbench } from 'vscode-extension-tester';
 import { activateCommand } from '../common/command-activator';
+import { closeAllOpenEditors } from '../common/overdrives';
 import { OpenshiftTerminalWebviewView } from '../common/ui/webviewView/openshiftTerminalWebviewView';
 import bundledTools from '../../../src/tools.json';
 
@@ -19,7 +20,7 @@ export function checkAboutCommand(clusterIsSet: boolean) {
         let openshiftTerminal: OpenshiftTerminalWebviewView;
 
         before(async () => {
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
             await activateCommand(command);
         });
 

--- a/test/ui/suite/component.ts
+++ b/test/ui/suite/component.ts
@@ -4,9 +4,10 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { expect } from 'chai';
-import { ActivityBar, EditorView, InputBox, NotificationType, SideBarView, TerminalView, TreeItem, VSBrowser, ViewSection, Workbench } from 'vscode-extension-tester';
+import { ActivityBar, InputBox, NotificationType, SideBarView, TerminalView, TreeItem, VSBrowser, ViewSection, Workbench } from 'vscode-extension-tester';
 import { notificationExists, itemExists, terminalHasText } from '../common/conditions';
 import { VIEWS, MENUS, NOTIFICATIONS, INPUTS, COMPONENTS } from '../common/constants';
+import { closeAllOpenEditors } from '../common/overdrives';
 
 
 
@@ -16,7 +17,6 @@ export function createComponentTest(contextFolder: string) {
         let view: SideBarView;
         let explorer: ViewSection;
         let components: ViewSection;
-        let editorView: EditorView;
 
         const projectName = `project${Math.floor(Math.random() * 100)}`
         const compName = `comp${Math.floor(Math.random() * 100)}`;
@@ -25,7 +25,6 @@ export function createComponentTest(contextFolder: string) {
             view = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
             explorer = await view.getContent().getSection(VIEWS.appExplorer);
             components = await view.getContent().getSection(VIEWS.components);
-            editorView = new EditorView();
         });
 
         beforeEach(async function () {
@@ -34,12 +33,11 @@ export function createComponentTest(contextFolder: string) {
             if (notifications.length > 0) {
                 await notificationCenter.close();
             }
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
         });
 
         afterEach(async function () {
-            editorView = new EditorView();
-            await editorView.closeAllEditors();
+            await closeAllOpenEditors();
         });
 
         after(async function () {

--- a/test/ui/suite/componentCommands.ts
+++ b/test/ui/suite/componentCommands.ts
@@ -10,7 +10,6 @@ import {
     ActivityBar,
     after,
     before,
-    EditorView,
     SideBarView,
     TreeItem,
     ViewSection,
@@ -20,7 +19,7 @@ import { parse } from 'yaml';
 import { DevfileResolver } from '../../../src/devfile/devfileResolver';
 import { waitForItemStable, warn } from '../common/conditions';
 import { VIEWS } from '../common/constants';
-import { reloadWindow } from '../common/overdrives';
+import { closeAllOpenEditors, reloadWindow } from '../common/overdrives';
 import { OpenshiftTerminalWebviewView } from '../common/ui/webviewView/openshiftTerminalWebviewView';
 
 export function testComponentCommands(path: string) {
@@ -34,7 +33,7 @@ export function testComponentCommands(path: string) {
 
         before(async function context() {
             this.timeout(30_000);
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
             view = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
             await (await new Workbench().openNotificationsCenter()).clearAllNotifications();
 

--- a/test/ui/suite/componentContextMenu.ts
+++ b/test/ui/suite/componentContextMenu.ts
@@ -8,7 +8,6 @@ import {
     ActivityBar,
     BottomBarPanel,
     DebugView,
-    EditorView,
     Key,
     NotificationType,
     SideBarView,
@@ -18,7 +17,7 @@ import {
 } from 'vscode-extension-tester';
 import { findItemFuzzy, itemDoesNotExist, notificationDoesNotExist, stabilizeComponentsView, waitForItem, waitForItemStable, waitForItemToDisappear, warn } from '../common/conditions';
 import { MENUS, VIEWS } from '../common/constants';
-import { collapse } from '../common/overdrives';
+import { closeAllOpenEditors, collapse } from '../common/overdrives';
 import { OpenshiftTerminalWebviewView } from '../common/ui/webviewView/openshiftTerminalWebviewView';
 
 export function testComponentContextMenu() {
@@ -32,7 +31,7 @@ export function testComponentContextMenu() {
 
         before(async function context() {
             this.timeout(45_000);
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
             view = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
             await (await new Workbench().openNotificationsCenter()).clearAllNotifications();
             for (const item of [

--- a/test/ui/suite/createComponent.ts
+++ b/test/ui/suite/createComponent.ts
@@ -19,7 +19,7 @@ import {
 } from 'vscode-extension-tester';
 import { notificationExists, stabilizeComponentsView, step, waitForItemStable, waitForItemToDisappearStable, warn, withStableItem } from '../common/conditions';
 import { BUTTONS, INPUTS, MENUS, NOTIFICATIONS, VIEWS } from '../common/constants';
-import { collapse } from '../common/overdrives';
+import { closeAllOpenEditors, collapse } from '../common/overdrives';
 import {
     CreateComponentWebView,
     GitProjectPage,
@@ -40,7 +40,7 @@ export function testCreateComponent(path: string) {
 
         before(async function context() {
             this.timeout(10_000);
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
             fs.ensureDirSync(path, 0o6777);
             view = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
             for (const item of [
@@ -253,7 +253,7 @@ export function testCreateComponent(path: string) {
             }
 
             // Close all editors
-            try { await new EditorView().closeAllEditors(); } catch { /* Ignore */ }
+            await closeAllOpenEditors();
 
             // Close any remaining notifications
             try {

--- a/test/ui/suite/devfileRegistries.ts
+++ b/test/ui/suite/devfileRegistries.ts
@@ -8,6 +8,7 @@ import { ActivityBar, CustomTreeSection, EditorView, InputBox, SideBarView, View
 import { OdoPreference } from '../../../src/odo/odoPreference';
 import { notificationExists } from '../common/conditions';
 import { VIEWS } from '../common/constants';
+import { closeAllOpenEditors } from '../common/overdrives';
 import { RegistryWebViewEditor } from '../common/ui/webview/registryWebViewEditor';
 
 export function testDevfileRegistries() {
@@ -22,6 +23,10 @@ export function testDevfileRegistries() {
             view = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
             await new Promise(res => setTimeout(res, 5_000));
             registrySection = await view.getContent().getSection(VIEWS.compRegistries);
+        });
+
+        beforeEach(async function () {
+            await closeAllOpenEditors();
         });
 
         it('registry actions are available', async function test() {
@@ -106,7 +111,6 @@ export function testDevfileRegistries() {
         it('open Devfile registry view from Section action', async function test() {
             this.timeout(10_000);
             await (await registrySection.getAction('Open Registry View')).click();
-            // open editor tab by title
             const editorView = new EditorView();
             const editor = await editorView.openEditor('Devfile Registry');
             expect(await editor.getTitle()).to.include('Devfile Registry');
@@ -114,26 +118,25 @@ export function testDevfileRegistries() {
 
         it('open Devfile registry view from item\'s context menu and verify the content of the registry', async function test() {
             this.timeout(10_000);
-            await new EditorView().closeAllEditors();
             const devfileRegistry = await registrySection.findItem(OdoPreference.DEFAULT_DEVFILE_REGISTRY_NAME);
+            expect(devfileRegistry, 'DefaultDevfileRegistry not found in registry section').to.not.be.undefined;
             await devfileRegistry.select();
             const menu = await devfileRegistry.openContextMenu();
-            await (await menu.getItem('Open in Editor')).select();
+            const openInEditorItem = await menu.getItem('Open in Editor');
+            expect(openInEditorItem, '\'Open in Editor\' not found in context menu').to.not.be.undefined;
+            await openInEditorItem.select();
             await new Promise((res) => { setTimeout(res, 3_000); });
-            // check opened editor tab by title
             const editorView = new EditorView();
             const editor = await editorView.openEditor('Devfile Registry - DefaultDevfileRegistry');
             expect(await editor.getTitle()).to.include('Devfile Registry - DefaultDevfileRegistry');
-            // initialize web view editor
             const webView = new RegistryWebViewEditor('Devfile Registry - DefaultDevfileRegistry');
             await webView.initializeEditor();
-            // Expect these components to be available on the first page
             expect(await webView.getRegistryStackNames()).to.include.members(['Quarkus Java', 'Django', 'Go Runtime', 'Maven Java', 'Node.js Runtime', 'Open Liberty Gradle', 'Open Liberty Maven', 'Python', 'Vert.x Java']);
         });
 
         after(async function context() {
             this.timeout(10_000);
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
         });
 
     });

--- a/test/ui/suite/kubernetesContext.ts
+++ b/test/ui/suite/kubernetesContext.ts
@@ -6,7 +6,6 @@ import { expect } from 'chai';
 import * as fs from 'fs-extra';
 import {
     ActivityBar,
-    EditorView,
     InputBox,
     NotificationType,
     QuickPickItem,
@@ -25,7 +24,7 @@ import { activateCommand } from '../common/command-activator';
 import { itemExists, notificationExists } from '../common/conditions';
 import { ACTIONS, INPUTS, NOTIFICATIONS, VIEWS } from '../common/constants';
 import { addKubeContext, getKubeConfigContent, getKubeConfigPath } from '../common/kubeConfigUtils';
-import { collapse } from '../common/overdrives';
+import { closeAllOpenEditors, collapse } from '../common/overdrives';
 
 export function kubernetesContextTest(isOpenshiftCluster: boolean) {
     describe('Kubernetes Context', function () {
@@ -88,7 +87,7 @@ export function kubernetesContextTest(isOpenshiftCluster: boolean) {
             if (notifications.length > 0) {
                 await notificationCenter.close();
             }
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
         });
 
         it('Select kubernetes context', async function () {

--- a/test/ui/suite/operatorBackedService.ts
+++ b/test/ui/suite/operatorBackedService.ts
@@ -5,7 +5,6 @@
 
 import {
     ActivityBar,
-    EditorView,
     SideBarView,
     TreeItem,
     VSBrowser,
@@ -15,7 +14,7 @@ import {
 } from 'vscode-extension-tester';
 import { itemExists, notificationExists } from '../common/conditions';
 import { MENUS, NOTIFICATIONS, VIEWS } from '../common/constants';
-import { reloadWindow } from '../common/overdrives';
+import { closeAllOpenEditors, reloadWindow } from '../common/overdrives';
 import { CreateServiceWebView, ServiceSetupPage } from '../common/ui/webview/createServiceWebView';
 
 export function operatorBackedServiceTest() {
@@ -33,7 +32,7 @@ export function operatorBackedServiceTest() {
             view = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
             section = await view.getContent().getSection(VIEWS.appExplorer);
 
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
             await (await new Workbench().openNotificationsCenter()).clearAllNotifications();
         });
 

--- a/test/ui/suite/project.ts
+++ b/test/ui/suite/project.ts
@@ -5,7 +5,6 @@
 
 import {
     ActivityBar,
-    EditorView,
     InputBox,
     SideBarView,
     TreeItem,
@@ -19,6 +18,7 @@ import {
 import { activateCommand } from '../common/command-activator';
 import { itemExists, notificationExists, stabilizeComponentsView, waitForItem } from '../common/conditions';
 import { INPUTS, MENUS, NOTIFICATIONS, VIEWS } from '../common/constants';
+import { closeAllOpenEditors } from '../common/overdrives';
 
 export function projectTest(isOpenshiftCluster: boolean) {
     describe('Work with project', function () {
@@ -55,7 +55,7 @@ export function projectTest(isOpenshiftCluster: boolean) {
         });
 
         beforeEach(async function () {
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
         });
 
         //Switch back to existing project/namespace

--- a/test/ui/suite/serverlessFunction.ts
+++ b/test/ui/suite/serverlessFunction.ts
@@ -6,14 +6,13 @@ import * as fs from 'fs-extra';
 import * as pth from 'path';
 import {
     ActivityBar,
-    EditorView,
     NotificationType,
     SideBarView,
     ViewSection,
     Workbench,
 } from 'vscode-extension-tester';
 import { VIEWS } from '../common/constants';
-import { collapse } from '../common/overdrives';
+import { closeAllOpenEditors, collapse } from '../common/overdrives';
 import { ServerlessFunctionWebView } from '../common/ui/webview/ServerlessFunctionWebViewEditor';
 import { expect } from 'chai';
 
@@ -25,7 +24,7 @@ export function testCreateServerlessFunction(path: string) {
 
         before(async function context() {
             this.timeout(10_000);
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
             fs.ensureDirSync(pth.join(path, 'function'), 0o6777);
             view = await (await new ActivityBar().getViewControl(VIEWS.openshift)).openView();
             for (const item of [
@@ -44,7 +43,7 @@ export function testCreateServerlessFunction(path: string) {
             if (notifications.length > 0) {
                 await notificationCenter.close();
             }
-            await new EditorView().closeAllEditors();
+            await closeAllOpenEditors();
         });
 
         it('Create a new Serverless Function', async function test() {


### PR DESCRIPTION
## Summary
- VS Code 1.132.0 changed the default tab close button placement, causing `ElementClickInterceptedError` cascades in `closeAllEditors()`. The `codicon-close` button is now hidden until hover, so the tab label intercepts the click.
- Added `workbench.editor.tabActionLocation: "right"` and `workbench.editor.showTabs: "multiple"` to test settings to force close buttons to always be visible
- Added `closeAllOpenEditors()` utility in `overdrives.ts` wrapping `closeAllEditors()` in try-catch as defense-in-depth
- Replaced all 16 direct `closeAllEditors()` call sites across 11 test files with `closeAllOpenEditors()`
- Added diagnostic assertions to the Devfile Registry context menu test

## Test plan
- [x] CI Public UI tests pass with 0 `ElementClickInterceptedError` failures
- [x] No cascade failures from `closeAllEditors()` in before/after hooks
- [x] Existing DB PRs can be retested against this fix

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)