### PR TITLE
Bump js-yaml from 4.3.0 to 4.3.1 (CVE-2026-59870)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2015,9 +2015,9 @@
 			}
 		},
 		"node_modules/@kubernetes/client-node/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
 		"js-cookie": "^3.0.8",
 		"js-yaml": "^5.2.3",
 		"@kubernetes/client-node": {
-			"js-yaml": "^4.3.0"
+			"js-yaml": "^4.3.1"
 		},
 		"serialize-javascript": "^7.0.7",
 		"tar-fs": "^3.1.3",


### PR DESCRIPTION
## Summary
- Bumps `js-yaml` override for `@kubernetes/client-node` from `^4.3.0` to `^4.3.1`
- Fixes quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870)

Fixes: https://github.com/redhat-developer/vscode-openshift-tools/security/dependabot/203

## Test plan
- [x] `npm audit` no longer reports js-yaml vulnerability
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)