### PR TITLE
[build] Pin ExTester UI tests to its own max-supported VS Code version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,9 @@
 		"test:coverage": "npm run test:prepare && npm run test:instrument && node ./build/install-vscode.cjs && node ./build/run-tests.cjs unit",
 		"test-integration": "npm run test:prepare && node ./build/run-tests.cjs integration",
 		"test-integration:coverage": "npm run test:prepare && npm run test:instrument && node ./build/run-tests.cjs integration",
-		"cluster-ui-test": ". test/ui/extester.env && extest setup-tests -e ./test-resources/extensions -i && npm run test:prepare && extest run-tests out/test/ui/cluster-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions",
-		"ui-test:prepare": ". test/ui/extester.env && extest setup-tests -e ./test-resources/extensions -i && npm run test:prepare",
+		"extest-use-max": "rm -f .vscode-version",
+		"cluster-ui-test": "npm run extest-use-max && . test/ui/extester.env && extest setup-tests -e ./test-resources/extensions -i && npm run test:prepare && extest run-tests out/test/ui/cluster-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions",
+		"ui-test:prepare": "npm run extest-use-max && . test/ui/extester.env && extest setup-tests -e ./test-resources/extensions -i && npm run test:prepare",
 		"public-ui-test": "extest run-tests out/test/ui/public-ui-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions",
 		"public-ui-kind-test": "extest run-tests out/test/ui/public-ui-kind-test.js -o test/ui/settings.json -m test/ui/.mocharc.js -e ./test-resources/extensions"
 	},


### PR DESCRIPTION
ExTester lags VS Code releases and only officially supports up to its own declared max version, but our setup pipeline overwrites `.vscode-version` with whatever `@vscode/test-electron` resolves as latest stable for the unit tests - which just broke UI tests when that hit VS Code 1.134.0 (every webview-dependent test failed to find elements).

Adds an `extest-use-max` script that clears `.vscode-version` before `test/ui/extester.env` is sourced, so ExTester falls back to its own tested ceiling instead of chasing Electron's version. Revertable later by removing the single `npm run extest-use-max &&` prefix.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>