### PR TITLE
Skip check-*.yml tool-update workflows on forks

### DIFF
--- a/.github/workflows/check-alizer.yml
+++ b/.github/workflows/check-alizer.yml
@@ -6,7 +6,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  guard:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/fork-guard.yml
+
   check-alizer-repo:
+    needs: guard
+
+    if: needs.guard.outputs.is_fork == 'false'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-crc.yml
+++ b/.github/workflows/check-crc.yml
@@ -6,7 +6,15 @@ on:
     workflow_dispatch:
 
 jobs:
+    guard:
+        permissions:
+            contents: read
+        uses: ./.github/workflows/fork-guard.yml
+
     check-crc-repo:
+        needs: guard
+
+        if: needs.guard.outputs.is_fork == 'false'
 
         runs-on: ubuntu-latest
 

--- a/.github/workflows/check-func.yml
+++ b/.github/workflows/check-func.yml
@@ -6,7 +6,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  guard:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/fork-guard.yml
+
   check-func-repo:
+    needs: guard
+
+    if: needs.guard.outputs.is_fork == 'false'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-helm.yml
+++ b/.github/workflows/check-helm.yml
@@ -6,7 +6,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  guard:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/fork-guard.yml
+
   check-helm-repo:
+    needs: guard
+
+    if: needs.guard.outputs.is_fork == 'false'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-oc.yml
+++ b/.github/workflows/check-oc.yml
@@ -6,7 +6,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  guard:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/fork-guard.yml
+
   check-oc-repo:
+    needs: guard
+
+    if: needs.guard.outputs.is_fork == 'false'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-odo.yml
+++ b/.github/workflows/check-odo.yml
@@ -10,7 +10,15 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  guard:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/fork-guard.yml
+
   check-odo:
+    needs: guard
+
+    if: needs.guard.outputs.is_fork == 'false'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/fork-guard.yml
+++ b/.github/workflows/fork-guard.yml
@@ -1,0 +1,24 @@
+name: fork-guard
+
+on:
+  workflow_call:
+    outputs:
+      is_fork:
+        description: "Whether the calling repository is a fork"
+        value: ${{ jobs.check.outputs.is_fork }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    outputs:
+      is_fork: ${{ steps.check.outputs.is_fork }}
+
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: echo "is_fork=$(gh api repos/${{ github.repository }} --jq .fork)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The check-crc/alizer/func/helm/oc/odo workflows run on a daily cron and open PRs in whatever repo they execute in. Forks that have Actions enabled were running these too, opening bump PRs against themselves. Add a fork-guard reusable workflow that queries the repo's own `fork` flag via the GitHub API and gate each check-*.yml job on it, with no hardcoded owner/repo name.


Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>