### PR TITLE
[tests] Fix commands not being loaded issue in Component Commands UI …

### DIFF
--- a/test/ui/suite/componentCommands.ts
+++ b/test/ui/suite/componentCommands.ts
@@ -91,13 +91,13 @@ export function testComponentCommands(path: string) {
 
             //check component has child with label Commands
             expect(await component.hasChildren()).to.be.true;
-            const commandsItem = await component.findChildItem('Commands');
 
             //check Commands has children - expanding the item alone doesn't guarantee all
             //child rows have rendered yet, so poll until at least as many as the devfile
             //declares actually show up (checking for any one row is not enough).
-            await commandsItem.expand();
             await VSBrowser.instance.driver.wait(async () => {
+                const commandsItem = await component.findChildItem('Commands');
+                await commandsItem.expand();
                 commands = await commandsItem.getChildren();
                 return commands.length >= expectedCommands.length;
             }, 15_000, 'Commands node children did not populate');
@@ -111,7 +111,6 @@ export function testComponentCommands(path: string) {
             // The sets of devfile component commands (expectedCommands) and actual component commands (actualCommands)
             // are to be the same
             expect(actualCommands).to.have.members(expectedCommands);
-
         });
 
         it('Command can be ran', async function () {


### PR DESCRIPTION
…Test

```
    Component Commands
      1) Commands are listed
      2) Command can be ran

...

  19 passing (4m)
  1 pending
  2 failing

  1) Extension public-facing UI tests with Kind cluster
       Component Commands
         Commands are listed:

      AssertionError: expected false to be true
      + expected - actual

      -false
      +true

      at Context.<anonymous> (test/ui/suite/componentCommands.ts:93:56)
      at Generator.next (<anonymous>)
      at fulfilled (out/test/ui/suite/componentCommands.js:42:58)
      at processTicksAndRejections (node:internal/process/task_queues:104:5)

  2) Extension public-facing UI tests with Kind cluster
       Component Commands
         Command can be ran:
     TypeError: Cannot read properties of undefined (reading '0')
      at Context.<anonymous> (test/ui/suite/componentCommands.ts:120:47)
      at Generator.next (<anonymous>)
      at /home/runner/work/vscode-openshift-tools/vscode-openshift-tools/out/test/ui/suite/componentCommands.js:45:71
      at new Promise (<anonymous>)
      at __awaiter (out/test/ui/suite/componentCommands.js:41:12)
      at Context.<anonymous> (out/test/ui/suite/componentCommands.js:140:20)
      at processImmediate (node:internal/timers:534:21)
```