### PR TITLE
Fix 'rejected promise not handled' error in selectResourceByName

### DIFF
--- a/src/k8s/build.ts
+++ b/src/k8s/build.ts
@@ -105,7 +105,8 @@ export class Build implements Disposable {
                 'Select a BuildConfig to see the builds',
             );
             if (buildConfig) {
-                const selBuild = await window.showQuickPick(this.getBuildNames(buildConfig), {
+                const builds = await this.getBuildNames(buildConfig);
+                const selBuild = await window.showQuickPick(builds, {
                     placeHolder: text,
                     ignoreFocusOut: true,
                 });

--- a/src/k8s/common.ts
+++ b/src/k8s/common.ts
@@ -27,7 +27,8 @@ export async function getQuickPicks(cmd: CommandText, errorMessage: string, conv
 }
 
 export async function selectResourceByName(config: Promise<QuickPickItem[]> | QuickPickItem[], placeHolderText: string): Promise<string> {
-    const resource: any = await window.showQuickPick(config, {placeHolder: placeHolderText, ignoreFocusOut: true});
+    const items: QuickPickItem[] = await config;
+    const resource: any = await window.showQuickPick(items, {placeHolder: placeHolderText, ignoreFocusOut: true});
     return resource ? resource.label : null;
 }
 

--- a/test/unit/k8s/build.test.ts
+++ b/test/unit/k8s/build.test.ts
@@ -203,6 +203,7 @@ suite('K8s/build', () => {
 
         setup(() => {
             execStub.resolves({ error: null, stdout: buildData, stderr: '' });
+            sandbox.stub(Build, 'getBuildNames').resolves([{label: 'nodejs-copm-nodejs-comp-8'}]);
             const buidConfig = {label: 'nodejs-copm-nodejs-comp'};
             sandbox.stub(Build, 'getBuildConfigNames').resolves([buidConfig]);
             quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
@@ -231,6 +232,8 @@ suite('K8s/build', () => {
 
         setup(() => {
             sandbox.stub<any, any>(Build, 'getBuildNames').resolves('nodejs-copm-nodejs-comp');
+            const buidConfig = {label: 'nodejs-copm-nodejs-comp'};
+            sandbox.stub(Build, 'getBuildConfigNames').resolves([buidConfig]);
             quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
             quickPickStub.resolves({label: 'nodejs-copm-nodejs-comp-8'});
 
@@ -263,6 +266,8 @@ suite('K8s/build', () => {
         setup(() => {
             execStub.resolves({ error: null, stdout: buildData, stderr: '' });
             sandbox.stub<any, any>(Build, 'getBuildNames').resolves('nodejs-copm-nodejs-comp');
+            const buidConfig = {label: 'nodejs-copm-nodejs-comp'};
+            sandbox.stub(Build, 'getBuildConfigNames').resolves([buidConfig]);
             quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
             quickPickStub.resolves({label: 'nodejs-copm-nodejs-comp-8'});
         });
@@ -288,6 +293,8 @@ suite('K8s/build', () => {
         setup(() => {
             execToolStub.resolves({ error: null, stdout: buildData, stderr: '' });
             sandbox.stub<any, any>(Build, 'getBuildNames').resolves('nodejs-copm-nodejs-comp');
+            const buidConfig = {label: 'nodejs-copm-nodejs-comp'};
+            sandbox.stub(Build, 'getBuildConfigNames').resolves([buidConfig]);
             quickPickStub = sandbox.stub(vscode.window, 'showQuickPick');
             quickPickStub.resolves({label: 'nodejs-copm-nodejs-comp-8'});
         });


### PR DESCRIPTION
```
rejected promise not handled within 1 second: Error: You have no builds available
stack trace: Error: You have no builds available
    at Object.<anonymous> (/home/runner/work/vscode-openshift-tools/vscode-openshift-tools/out/src/k8s/common.js:9:3427)
    at Generator.next (<anonymous>)
    at fulfilled (/home/runner/work/vscode-openshift-tools/vscode-openshift-tools/out/src/k8s/common.js:9:988)
```