### PR TITLE
[deps] Update dependency overrides to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
 				"git-up": "^8.1.1",
 				"got": "^15.1.0",
 				"istanbul": "^0.4.5",
-				"js-yaml": "^5.3.0",
+				"js-yaml": "^5.4.1",
 				"json-schema": "^0.4.0",
 				"json-to-ast": "^2.1.0",
 				"leasot": "^14.4.0",
@@ -12070,9 +12070,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
-			"integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+			"integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -16380,9 +16380,9 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
-			"integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+			"integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -18649,9 +18649,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+			"integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
 		"git-up": "^8.1.1",
 		"got": "^15.1.0",
 		"istanbul": "^0.4.5",
-		"js-yaml": "^5.3.0",
+		"js-yaml": "^5.4.1",
 		"json-schema": "^0.4.0",
 		"json-to-ast": "^2.1.0",
 		"leasot": "^14.4.0",
@@ -205,12 +205,12 @@
 		"diff": "^9.0.0",
 		"globals": "^17.11.0",
 		"js-cookie": "^3.0.8",
-		"js-yaml": "^5.3.0",
-		"serialize-javascript": "^7.1.0",
+		"js-yaml": "^5.4.1",
+		"serialize-javascript": "^7.1.1",
 		"tar-fs": "^3.1.3",
 		"tough-cookie": "^6.0.2",
 		"typescript": "^6.0.3",
-		"uuid": "^14.0.1"
+		"uuid": "^14.0.2"
 	},
 	"activationEvents": [
 		"onView:openshiftProjectExplorer",


### PR DESCRIPTION
Changed overrides:

- js-yaml: ^5.3.0 -> ^5.4.1
- serialize-javascript: ^7.1.0 -> ^7.1.1
- uuid: ^14.0.1 -> ^14.0.2