### PR TITLE
[tests] Disable VS Code AI features during tests

### DIFF
--- a/test/fixtures/components/components.code-workspace
+++ b/test/fixtures/components/components.code-workspace
@@ -8,5 +8,8 @@
 			"name": "comp2",
 			"path": "comp2"
 		}
-	]
+	],
+	"settings": {
+		"chat.disableAIFeatures": true
+	}
 }

--- a/test/fixtures/components/empty.code-workspace
+++ b/test/fixtures/components/empty.code-workspace
@@ -1,6 +1,7 @@
 {
 	"folders": [],
 	"settings": {
-		"redhat.telemetry.enabled": false
+		"redhat.telemetry.enabled": false,
+		"chat.disableAIFeatures": true
 	}
 }

--- a/test/ui/settings.json
+++ b/test/ui/settings.json
@@ -1,5 +1,6 @@
 {
     "window.dialogStyle": "custom",
+    "chat.disableAIFeatures": true,
     "files.simpleDialog.enable": true,
     "workbench.welcomePage.experimentalOnboarding": false,
     "workbench.editor.tabActionLocation": "right",


### PR DESCRIPTION
Disable built-in AI features in the unit, integration, and UI test configurations. This prevents the VS Code agent host from starting during test runs.


Assisted-By: Codex: gpt-5.6-terra