### PR TITLE
[tests] Fix CI Codecov uploads for protected branches

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -156,6 +156,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: (success() || failure()) && runner.os == 'Linux'
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/unit/coverage-final.json,./coverage/integration/coverage-final.json
 
       - name: Save tool binaries cache

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  allow_pseudo_compare: false


### PR DESCRIPTION
Use `CODECOV_TOKEN` for coverage uploads and disable pseudo-comparisons to prevent Codecov from falling back to outdated base commits when the main branch report is unavailable.