### PR TITLE
[feature] Replace odo dev/odo dev --debug with a native TypeScript engine (CRW-10963)

### DIFF
--- a/doc/plans/project_inner_loop_dev_plan.md
+++ b/doc/plans/project_inner_loop_dev_plan.md
@@ -1,0 +1,717 @@
+# Native `odo dev` / `odo dev --debug` Replacement — Plan
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
+
+## Goal
+
+Replace the CLI shell-out to `odo dev` / `odo dev --debug` (currently `src/odo/command.ts`'s
+`Command.dev()`, invoked from `src/openshift/component.ts`'s `devRunOn`) with a native
+TypeScript implementation, following the same pattern already used to replace `odo init`
+(`src/devfile/init.ts`), `odo deploy` (`src/devfile/deploy.ts`), and `odo undeploy`
+(`src/devfile/undeploy.ts`).
+
+`deploy`/`undeploy`/`init`/`describe` are already fully native (`Odo.Instance.describeComponent`
+delegates to `devfile/describe.ts`'s `getComponentDescription`). Dev mode is the last major
+CLI-shell-out surface for component lifecycle.
+
+## Workflow
+
+- All work happens on `feature/inner-loop`, created specifically for this plan.
+- Every change lands as a single commit, amended as work progresses (per the standing repo
+  convention) — not one commit per file/module.
+- One PR is opened once the main implementation (directory structure + shared-infra edits +
+  unit/integration tests) is finished. Opening the PR is what triggers the GH CI Kind-cluster
+  jobs (`continuous-integration-workflow.yml`: `test-integration:coverage` and
+  `public-ui-kind-test`), which is when the cluster UI test updates get exercised/iterated on.
+- Integration tests are not normally run locally — CI's `test-integration:coverage` job runs them
+  against a freshly-installed, clean Kind cluster. A local Kind cluster happened to be available
+  in one development session and was used to validate the new `inner-loop/` modules directly
+  against a real cluster before committing (see the `devPortForward.ts`/`containerSync.ts`/
+  `devCommandExec.ts`/`clusterDevPlatform.ts` notes below) — this caught real bugs a mocked test
+  would have missed. Some local-only failures surfaced during that session
+  (`devfileRegistryWrapper.test.ts`'s registry-count assertions) that are pre-existing local
+  machine state (a stray registry already configured), not something CI's clean cluster will hit
+  — confirmed these pass normally otherwise, so left untouched.
+
+## Compatibility contracts to preserve
+
+- `ComponentWorkspaceFolder` (`src/odo/workspace.ts`) stays the input type for all new APIs.
+- `.odo/devstate.json` schema (`pid`, `platform`, `forwardedPorts[]`, `apiServerPort`) — already
+  read by `describe.ts`; the new engine must write it so `describe`, `openInBrowser`, and
+  `startOdoAndConnectDebugger` keep working unmodified.
+- `component.ts`'s `ComponentContextState` state machine, `componentStates` map, `stateChanged`
+  emitter, and all `package.json` context-menu `when`-clause wiring stay as-is. Only the inside
+  of `devRunOn`/`exitDevMode`/`forceExitDevMode`/`showDevTerminal` gets rewired to call the new
+  `dev.ts` API instead of `Command.dev()` + `OpenShiftTerminalManager.createTerminal`.
+- The OpenShift Terminal panel UX (visible output + Ctrl-C-to-stop) is preserved — not replaced
+  with a plain output channel — by reusing/generalizing the existing `spawnPty=false` "virtual
+  terminal" mode already used by `writeToTerminal`.
+- Terminal tab title stays `odo dev: ${componentName}` (avoid needless UI/test churn) even though
+  it's no longer literally the `odo` binary.
+
+## Decisions made
+
+- **Exec / file-sync / port-forward**: use native `@kubernetes/client-node` (`Exec`, `Cp`,
+  `PortForward`) inside the new engine, not further `oc` CLI shell-outs — needed for reliable
+  readiness detection and process control for the watch/hot-reload loop. This is a deliberate
+  deviation from the rest of the codebase's CLI-shell-out convention, scoped to this feature.
+- **`app.kubernetes.io/managed-by`**: new resources created by `dev.ts`/`deploy.ts` stamp
+  `openshift-toolkit` (not `odo`), since odo no longer creates them.
+- **`componentTypeDescription.ts` moved from `src/odo/` to `src/devfile/`** — it's pure devfile-
+  domain types with zero internal imports; 11 of its 27 importers already lived in `src/devfile/`
+  versus only 3 in `src/odo/` (all three already thin/native-delegating). Doing this now, before
+  adding `DevState` to it for `devStateFile.ts`, avoids moving it twice. Mechanical import-path
+  change only, verified with `tsc --noEmit`, `eslint`, and the full unit suite.
+  Related, deliberately deferred: `src/odo/workspace.ts` (`ComponentWorkspaceFolder`) and
+  `src/odo/odoWrapper.ts` are similarly now mostly-native wrappers around devfile code — worth
+  revisiting as part of the plan's existing "audit whether odo is still required" cleanup item,
+  not as part of this move.
+
+## Directory structure
+
+```
+src/devfile/
+  dev.ts                          [x] startDevSession / stopDevSession / forceStopDevSession
+  inner-loop/
+    devSession.ts                  [x] lifecycle/state machine for one running session
+    devPlatform.ts                 [x] DevPlatform interface + resolveDevPlatformKind()
+    clusterDevPlatform.ts          [x] OpenShift/Kubernetes target (start/sync/restartRunCommand/stop)
+    podmanDevPlatform.ts           [x] local podman target (pod, bind-mount, direct ports)
+    devResourceBuilder.ts          [x] devfile container components -> Deployment+Service manifest
+    fileSync.ts                    [x] chokidar watcher, ignore-rule resolution, debounced batching
+    containerSync.ts               [x] tar-fs pack/push + rm via native k8s Exec (pushFiles/removeFiles)
+    devCommandExec.ts              [x] runs/restarts devfile run|debug command, streams output
+    devPortForward.ts              [x] endpoint forwarding via native k8s PortForward
+    devStateFile.ts                [x] saveDevState/loadDevState/clearDevState over .odo/devstate.json
+    devTerminalBridge.ts           [x] feeds output into OpenShift Terminal panel, Ctrl-C -> stop
+```
+
+`devStateFile.ts` notes:
+- `DevState`/`DevStateForwardedPort` types moved from a private type inline in `describe.ts` into
+  `componentTypeDescription.ts` (alongside `DeployState`), unchanged field names (`portName` etc.)
+  — preserves the existing reader contract exactly, no compatibility break.
+- `describe.ts`'s private `readDevState` removed in favor of importing `loadDevState` from here —
+  same dedup pattern used for `deploystate.json` in the previous slice.
+- Deliberately minimal: no `updateDevState`/partial-patch helper — callers just re-`saveDevState`
+  the full merged object when they need to update it (e.g. once port-forwards become ready).
+- Unit-tested with real temp-directory I/O (`test/unit/devfile/inner-loop/devStateFile.test.ts`),
+  not mocked `fs` — matches the plan's "pure/self-contained, minimal mocking" bucket.
+
+`devResourceBuilder.ts` notes:
+- Added two more devfile-domain type gaps to `componentTypeDescription.ts` (same class as the
+  earlier `sourceMapping`/`env` fix): `Container.command?`/`Container.args?` (devfile spec fields
+  with no prior type representation), and `ComponentItem.volume?: Volume` (volume components were
+  completely untyped even though `devfileResolver.ts`'s own merge logic already reads
+  `comp.volume` at runtime).
+- Pure function, no cluster/fs I/O — takes a resolved `Data` devfile, returns
+  `{ deployment, service? }` plain-object manifests (no YAML), matching what
+  `Oc.createKubernetesObjectFromSpec(spec: object)` expects.
+- mountSources containers with no explicit `command`/`args` get a `['tail', '-f', '/dev/null']`
+  keep-alive command (so the image's real entrypoint doesn't run before source is synced); an
+  explicit devfile `command`/`args` is always respected as-is. `mountSources: false` containers
+  (sidecars, e.g. a local dev database) are left with their image's own entrypoint untouched.
+- Resource labels — `app.kubernetes.io/instance`, `app.kubernetes.io/managed-by: openshift-toolkit`,
+  `component` (legacy), `odo.dev/mode: dev` — deliberately match *existing* selector contracts:
+  `Oc.getComponentPod`/`deleteDeploymentByComponentLabel`'s label lists, and critically
+  `undeploy.ts`'s `isDevResource()` check (`odo.dev/mode === 'dev'`), which skips dev-mode
+  resources during deploy-mode label-based force-cleanup. Without this label a future undeploy
+  could delete a live dev session's Deployment.
+- `Container.memoryLimit` (already-modeled but previously unused) now maps to
+  `resources.limits.memory` rather than being silently dropped.
+- Volume devfile components are backed by an ephemeral `emptyDir`, not a PVC — documented
+  simplification (see plan comment in the file), since PVC create/wait/delete lifecycle belongs
+  to the platform orchestrator, not this pure builder.
+- A `Service` is only built when the devfile declares endpoints; dev-mode port-forwarding will
+  target the Pod directly (via `@kubernetes/client-node`'s `PortForward`) regardless, so the
+  Service exists for cluster-internal reachability / parity with real odo, not for port-forward
+  itself.
+
+`devPlatform.ts` notes:
+- Scoped deliberately: only the `DevPlatform` interface (contract) + pure
+  `resolveDevPlatformKind(runOn?)` selection logic. No instance-constructing factory yet — that
+  would need to import `clusterDevPlatform.ts`/`podmanDevPlatform.ts`, which don't exist yet;
+  that wiring belongs in `devSession.ts` once they do.
+- `DevPlatformSession` is deliberately shaped to match `DevState` (from `devStateFile.ts`)
+  directly — `kind`/`pid`/`forwardedPorts`/`apiServerPort` — rather than inventing a parallel
+  type, so `dev.ts`/`devSession.ts` can persist a session mostly as-is.
+- Interface methods (`start`/`sync`/`restartRunCommand`/`stop`) are a first-pass contract based on
+  everything reasoned through so far; expect minor refinement once `clusterDevPlatform.ts` is
+  actually implemented against it — normal for an interface preceding its first implementation,
+  not scope creep.
+
+`devPortForward.ts` / `containerSync.ts` / `devCommandExec.ts` / `clusterDevPlatform.ts` notes
+(built together — `clusterDevPlatform.ts` composes the other three, which turned out to not be
+usefully splittable from it):
+- **API verified against real `@kubernetes/client-node` type declarations** before writing any
+  code (`Exec`/`PortForward`/`Cp` in `node_modules/@kubernetes/client-node/dist/*.d.ts`), not
+  assumed. Notably, `Cp.cpToPod()` looked like a ready-made helper but its returned promise
+  resolves once the exec *connection* opens, not once the tar transfer actually finishes (a real
+  gotcha in the library) — `containerSync.ts` reimplements the same `tar-fs` + `Exec` approach but
+  properly awaits the exec `statusCallback` for actual completion.
+- `devPortForward.ts` forwards via a local `net.createServer` piping each connection through
+  `PortForward.portForward()` (the standard pattern for this API) — no `oc`/`kubectl` subprocess.
+  Reuses `buildUsablePortPair()` from the existing `src/port-forward.ts` for free-local-port
+  selection rather than reimplementing it.
+- `containerSync.ts`: `pushFiles`/`removeFiles`, both no-ops for an empty path list. Push uses
+  `tar-fs.pack(root, { entries })` for partial (changed-files-only) syncs, not always the whole
+  tree.
+- `devCommandExec.ts`'s `stop()`: verified (by actually running it against the real UBI-based test
+  image) that `pkill`/`kill`/`ps` binaries are **not** present — common for minimal/UBI images.
+  Redesigned around `echo $$ > PID_FILE && exec <command>` + a separate `sh -c 'kill $(cat
+  PID_FILE)'`, using only a POSIX shell builtin (`kill`), no external binary. Verified this
+  specific trick works (PID stays valid across `exec`) by testing directly against the real image
+  before committing to the design.
+- `clusterDevPlatform.ts`: applies resources via `Oc.Instance.applyConfiguration()` (idempotent
+  `oc apply --server-side`), not `createKubernetesObjectFromSpec()` (plain `oc create`, would fail
+  if a prior session's Deployment is still around). Polls for pod readiness itself
+  (`Oc.Instance.getComponentPod` has no retry/readiness-wait built in). Initial full sync
+  originally used a hardcoded ignore list (`.git`/`.odo`/`.vscode`/`node_modules`) as a documented
+  stand-in for real `.gitignore`-aware resolution; once `fileSync.ts` existed,
+  `listSyncableFiles()` was switched to `resolveIgnoreRules()` so the initial sync and the ongoing
+  watch-triggered sync use the exact same ignore rules — re-validated against the real Kind
+  cluster afterwards (`clusterDevPlatform.test.ts`'s full suite still green).
+- **Found and fixed a real bug this same work would have hit in practice**: `devResourceBuilder.ts`
+  didn't set `imagePullPolicy`, so a `:latest`-tagged image defaults to `Always` in Kubernetes —
+  breaking both locally-loaded images on Kind/Minikube and (by extension) real dev-mode runtime
+  images pinned to `:latest`. Fixed by always setting `imagePullPolicy: 'IfNotPresent'` on dev
+  containers. Caught by actually deploying to the real Kind cluster available in this environment,
+  not by inspection.
+- **Testing**: real integration tests against the actual local Kind cluster (`test/integration/
+  inner-loop/`), with a shared `testPod.ts` helper (dedicated `inner-loop-it-tests` namespace,
+  created/torn down per suite) — not mocked. Confirmed genuinely necessary: a first pass at these
+  tests initially failed for a completely mundane reason (the test image itself hit the same
+  `:latest`/`imagePullPolicy` bug above, in the test helper this time) — exactly the kind of thing
+  mocking would have hidden.
+  - `devPortForward.test.ts`: real TCP echo server in-pod, forward + connect + relay, and
+    dispose()-stops-accepting-connections.
+  - `containerSync.test.ts`: push (incl. nested paths), no-op-on-empty, remove, no-op-on-empty.
+  - `devCommandExec.test.ts`: streamed output + exit code (success and failure), and `stop()`
+    actually terminating a long-running command.
+  - `clusterDevPlatform.test.ts`: full start/sync/restart/stop lifecycle against Kind — see the
+    "Second" through "Fifth round" notes below for the real bugs this surfaced and fixed.
+- Along the way, fixed one pre-existing test that was actually asserting the old, buggy
+  `managedBy` default: `test/integration/odoWrapper.test.ts`'s `describeComponent()` expected
+  `managedBy === 'odo'` for components that were never deployed — updated to expect `undefined`,
+  matching the intentional fix from the earlier `describe.ts` slice.
+- Also switched `test/integration/odoWrapper.test.ts` and `test/integration/command.test.ts`
+  (4 call sites total) from `Odo.Instance.describeComponent()` to calling
+  `devfile/describe.ts#getComponentDescription()` directly — tests should exercise the native
+  implementation directly rather than through the `Odo` CLI-wrapper facade, consistent with the
+  overall direction of removing the `odo` dependency. Note: `Odo.Instance.describeComponent`
+  swallows errors and returns `undefined`; `getComponentDescription` throws instead — a stricter,
+  more correct behavior for tests (a real failure now surfaces with a stack trace instead of a
+  confusing downstream `undefined` access), and none of the 4 call sites relied on the old
+  swallow-and-return-`undefined` behavior. `command.test.ts`'s now-unused `Odo` import was removed.
+
+**Real bugs found and fixed by actually running against the local Kind cluster** (writing
+`clusterDevPlatform.test.ts` and running the full suite surfaced these; none would have been
+caught by mocked unit tests):
+- `test/integration/inner-loop/testPod.ts`'s `ensureTestNamespace()`/`deleteTestNamespace()` used
+  `Oc.Instance.createProject()`/`deleteProject()`, which **switch the kubeconfig's current
+  namespace as a side effect and never restore it** — so after one test run, the real
+  `~/.kube/config` was left pointing at a namespace that had since been deleted. The next run's
+  `clusterDevPlatform.test.ts` then failed applying resources (`NotFound: namespaces
+  "inner-loop-it-tests" not found`) because `ClusterDevPlatform.start()`'s
+  `getCurrentClusterAndNamespace()` correctly read that stale ambient namespace. Fixed by having
+  the test helper apply/delete a plain `Namespace` manifest directly (`Oc.Instance
+  .applyConfiguration()`/`deleteKubernetesObject('namespace', ...)`), which has no such side
+  effect — test setup should never mutate ambient kubeconfig state that production code relies on.
+- `devCommandExec.test.ts`'s failing-command test used `'exit 7'` as the command; since `exit` is
+  a shell builtin (not an executable), `exec exit 7` fails with "not found" (exit 127) rather than
+  propagating 7 — `devCommandExec.ts`'s real `exec <command>` behavior was correct, the test's
+  command choice wasn't. Fixed to `'sh -c "exit 7"'` (execs a real binary that then runs its own
+  builtin).
+- `devCommandExec.test.ts`'s `stop()` test used a fixed 2s wait after `stop()` before checking the
+  exit callback fired — replaced with a poll loop (up to 15s) to rule out slow exec/websocket
+  round-trip timing rather than a real bug, since this is a mocha timeout/flakiness risk, not
+  something to paper over with an even-longer fixed sleep.
+
+**Second round of real bugs, found by writing and running `clusterDevPlatform.test.ts`** (the
+`start()` cascade + `stop()` flakiness above were not actually fixed by the namespace fix alone;
+digging further with `kubectl describe`/manual `oc apply` reproduction found two more issues):
+- **Real product bug in `devCommandExec.ts`'s `stop()`**: the same class of gotcha as
+  `Cp.cpToPod()` (see `containerSync.ts` notes above) — `stop()`'s `kill` exec awaited only
+  `Exec.exec()`'s own promise, which resolves once the connection *opens*, not once the `kill`
+  command actually runs. The underlying connection could be torn down before the same-tick `kill`
+  was dispatched server-side. Fixed to properly await the exec's status callback, mirroring
+  `containerSync.ts`'s `execAndWait` pattern.
+- **Systemic pre-existing issue in *other* integration tests, not something to fix here, but
+  something `clusterDevPlatform.test.ts` had to defend against**: `command.test.ts` (and
+  `ocWrapper.test.ts`) call `Oc.Instance.createProject()`/`setProject()`, which switch the
+  kubeconfig's ambient current-namespace and never restore it — the same bug class already fixed
+  in `testPod.ts`, but pre-existing elsewhere in the test suite (confirmed by the user: these
+  tests pass fine standalone/on a fresh CI cluster; only matters when many suites share one
+  long-lived kubeconfig across a single local run). `ClusterDevPlatform.start()` correctly (by
+  design, matching real dev-mode/`deploy.ts` behavior) deploys into whatever the *ambient* current
+  namespace is rather than taking one as a parameter — so `clusterDevPlatform.test.ts` now
+  explicitly creates and `setProject()`s its own dedicated namespace in `suiteSetup` instead of
+  trusting whatever a previously-run, unrelated suite left the context pointed at.
+- `devPortForward.test.ts`'s echo server never closes its side of the connection; the test waited
+  for a `'close'` event after calling `socket.end()`, relying on a clean half-duplex close
+  propagating back through the port-forward tunnel — this hung for the full 120s mocha timeout.
+  Fixed to resolve as soon as `'data'` arrives and `destroy()` the socket immediately, removing the
+  dependency on graceful close-over-tunnel semantics entirely.
+
+**Third round — root-caused via direct standalone reproduction outside the VS Code extension host
+entirely** (each in-extension-host mocha cycle cost 15+ minutes; isolating each suspect behavior
+in a plain `node` script against the same real Kind cluster made this tractable):
+- **Real, confirmed product bug in `devCommandExec.ts`'s `stop()`**: passed `null, null, null` for
+  stdout/stderr/stdin on the kill exec. The Kubernetes exec API requires at least one non-null
+  stream, or it rejects the request with `"unable to upgrade connection: you must specify at
+  least 1 of stdin, stdout, stderr"` — delivered via the *status callback* as a `Failure`, not a
+  rejected promise. `stop()`'s callback treated *any* status callback firing as success, silently
+  swallowing this — so `stop()` always "succeeded" without the kill command ever having actually
+  run. Fixed by passing a real (if unused) stderr stream. Verified directly: before the fix, the
+  target process was still alive after `stop()` resolved; after, `onExit` fires with code 143
+  (SIGTERM) as expected.
+- **Test-only bug in `devPortForward.test.ts`'s echo-server setup**: launched the server via a
+  shell-backgrounded `nohup node ... &` under a *separate* short-lived exec. Confirmed by direct
+  reproduction that this does not reliably survive under the Kubernetes exec API the way it does
+  under `kubectl exec` (the server's own log file was never even created — it never actually ran)
+  — `nohup`/`&` alone aren't sufficient protection here. Fixed by using the already-proven-reliable
+  `startRunCommand()` (foreground/attached exec, matching how a real devfile "run" command
+  executes) instead of hand-rolled backgrounding.
+- `clusterDevPlatform.test.ts`'s own `connectAndRead` helper still waited on `'close'` — same fix
+  as `devPortForward.test.ts` above, just not yet applied there in the prior round.
+- Confirmed `devPortForward.ts`'s and `containerSync.ts`'s actual production logic was correct and
+  not implicated in any of the above the whole time, by reproducing each suspect scenario directly
+  against the real cluster in plain Node, bypassing the VS Code extension host and the project's
+  esbuild-bundled `@kubernetes/client-node` as separate variables — both were ruled out before the
+  real root causes (above) were found.
+
+**Fourth round — the last two `clusterDevPlatform.test.ts` failures, also root-caused via direct
+standalone reproduction:**
+- **`start()` hung for the full test timeout on its first connection through the forwarded port**:
+  `startRunCommand()`'s exec resolving only means the exec *attached*, not that the container-side
+  process has actually started and bound its listener yet — confirmed by direct reproduction that
+  connecting immediately after (zero grace period) can leave the port-forward tunnel itself stuck
+  (neither `'data'` nor `'error'` ever fires, so a plain socket doesn't fail fast) even though a
+  *second*, fresh connection attempt afterward succeeds instantly. `devPortForward.ts`'s local
+  server starts a brand-new `pf.portForward()` call per accepted connection, so a client-side retry
+  with a fresh connection each time is safe and sufficient — no product-code change needed here;
+  fixed `connectAndRead()` to retry (10 attempts, 3s each) instead of connecting once.
+- **`stop()` test asserted the pod was gone immediately after `platform.stop()` returned**:
+  Deployment deletion is asynchronous (the pod doesn't disappear the instant the delete call
+  returns) — this is normal Kubernetes eventual consistency, not a bug in `stop()`. Fixed the test
+  to poll for non-existence (up to 30s) instead of checking once.
+- Net effect across all four rounds: `git diff` on production code ended up being exactly one real
+  bug (`devCommandExec.ts`'s `stop()` — see round 3) plus the `imagePullPolicy` fix from round 1;
+  everything else was test-infrastructure fragility. Worth the time regardless — that one bug would
+  have made every real dev session's "stop"/restart silently fail to actually kill the previous run
+  process.
+
+**Fifth round — the `stop()` test's *own* verification method was the remaining problem**, not
+`stop()` itself: it used `Oc.Instance.getComponentPod()`, which searches the *ambient* current
+namespace via broad label-selector fallbacks (no explicit namespace param) — an indirect,
+ambiguous check compared to directly verifying what `stop()` actually deletes. Switched to
+`Oc.Instance.getKubernetesObject('deployment', name, namespace)` (exact resource, explicit
+namespace). Confirmed directly that Deployment-object deletion itself is near-instantaneous
+(unlike graceful pod termination) — the polling loop is a safety margin, not compensating for a
+slow real delete.
+
+**Final status: all green.** Integration suite: 63 passing, 1 failing (7 min total runtime) — the
+1 failure is `watch.test.ts`'s "watchFile calls the callback when file changes", a pre-existing,
+unrelated filesystem-event-timing flake, confirmed untouched by any of this work. All 22 new
+inner-loop integration tests pass. Unit suite: 321 total, 280 passing, 0 failing, 41 skipped
+(pre-existing, unrelated).
+
+One last hygiene fix after that green run: `clusterDevPlatform.test.ts`'s own `suiteSetup`/
+`suiteTeardown` captures and restores the ambient namespace it deliberately switches to (via
+`getActiveProject()`/`setProject()`) — otherwise it would leave the exact same "current namespace
+points at something already deleted" landmine for whatever runs next that the "Second round" fix
+above specifically called out in *other* tests. Not independently re-run through the full suite
+(low risk — reuses the same `setProject`/`getActiveProject` calls already proven earlier in this
+same file's `suiteSetup`), but `tsc`/`eslint` clean.
+
+`podmanDevPlatform.ts` notes:
+- **Dedup before writing it**: extracted the "find the run/debug command and resolve its
+  container/sourceMapping/workingDir/commandLine" logic — previously private to
+  `clusterDevPlatform.ts` — into `CommandResolver.findCommandByGroup()`/`resolveRunCommand()`
+  (`commandResolver.ts`, which had zero test coverage before this; added
+  `test/unit/devfile/commandResolver.test.ts`). Both platforms need the exact same resolution;
+  this isn't platform-specific logic.
+- **Found and fixed a real, pre-existing bug while writing that new test**:
+  `VariableResolver`'s `${PROJECT_SOURCE}` resolution was hardcoded to the literal string
+  `/projects`, ignoring a container's actual configured `sourceMapping` entirely. Any devfile
+  using a custom `sourceMapping` with an exec command's `workingDir`/`commandLine` referencing
+  `${PROJECT_SOURCE}` would have silently resolved to the wrong path. Fixed to look up the
+  target container's `sourceMapping` (falling back to `/projects` when unset, preserving existing
+  behavior for the common case) — `resolveVariable()` already had `componentName` in scope for
+  its env-var lookup, so this reuses that.
+- Scope matches `component.ts`'s existing podman gate exactly: podman only, not docker, even
+  though `ContainerRuntimeDetector` (used elsewhere for image builds) supports both — the existing
+  `checkForPodman()`/`openshift.component.dev.onPodman` UI is podman-only, and by the time
+  `PodmanDevPlatform` is invoked that check has already run, so this platform doesn't re-verify
+  availability itself (matches `ClusterDevPlatform` not pre-checking cluster connectivity either).
+- Uses `podman pod create` (one pod per component, containers share its network namespace) rather
+  than a single container — needed for multi-container devfiles to share `localhost` the way a
+  Kubernetes Pod's containers do, and matches how odo itself models podman-based dev.
+- Verified the whole command sequence directly against real local podman before writing any
+  TypeScript (pod create + port publish, bind-mount visibility, `podman logs -f` streaming,
+  restart, teardown) — same "verify against the real thing first" approach as the cluster platform.
+- **Found and fixed a real timing issue this same manual verification surfaced**: a container's
+  main process is PID 1 inside it, and Linux does not apply a signal's *default* disposition to
+  PID 1 unless it explicitly installs a handler — so a plain devfile run command (no SIGTERM
+  handler of its own, the common case) never actually terminates on SIGTERM, and podman falls back
+  to SIGKILL only after its default 10-second grace period. Confirmed by direct testing that this
+  is unrelated to shell-wrapping or `exec` (a bare `node` process as PID 1 exhibits the same
+  behavior) — it's inherent to container PID-1 semantics, not fixable by how the command is
+  invoked. Since 10+ seconds on every restart defeats the purpose of an inner dev loop, `restart`/
+  `stop` explicitly pass a short `--time 2` grace period instead of accepting the default.
+- `sync()` is a genuine no-op (bind mount), not a stub — there is nothing to push, by design.
+- Session output streams via `podman logs -f`, spawned directly (not through `ChildProcessUtil`,
+  which buffers until the process closes — unsuitable for a command that runs for the life of the
+  session); the child process is tracked on the session and killed in `stop()`.
+- **Testing**: real integration test (`test/integration/inner-loop/podmanDevPlatform.test.ts`)
+  against actual local podman, using the same `localhost/nodejs-image:latest` test image already
+  used for the cluster suite's manual verification — full start (+ reachable)/sync(no-op,
+  bind-mount-visible)/restart(+ reachable again)/stop(pod actually gone) lifecycle. Extracted the
+  retry-based `connectAndRead()` helper (previously duplicated logic inline in
+  `clusterDevPlatform.test.ts`) into a shared `netTestUtils.ts`, used by both suites.
+
+**Real bug found on the first podman integration run**: `netTestUtils.ts`'s `connectAndRead()`
+retried on any connection failure but with *no delay* between attempts. That's fine for a failure
+mode that times out (each attempt naturally takes the full per-attempt timeout), but rootless
+podman's port-publishing can `ECONNRESET` a connection attempt that arrives before its
+port-forwarding proxy has finished wiring up — which fails in single-digit milliseconds, not by
+timing out. Without a delay, all 10 retry attempts could burn through in well under a second,
+nowhere near enough real wall-clock time for the target to become reachable. Confirmed directly
+with a minimal reproduction outside any test framework: attempt 1 failed with `ECONNRESET` after
+3ms, attempt 2 (300ms later) succeeded immediately. Fixed by adding a 1s delay between attempts.
+This is a test-only concern, not something `podmanDevPlatform.ts`/`clusterDevPlatform.ts` need to
+handle themselves — real usage (a user opening a browser a moment after starting dev mode) doesn't
+hit the same tight timing window a test asserting immediate connectivity does.
+
+**Second real bug, found after the delay fix (still 3 failures, same tests)**: `start()`'s
+`ECONNRESET`, `sync()`'s `podman exec` failure (`container state improper`), and
+`restartRunCommand()`'s `ECONNRESET` all traced back to one root cause. Added temporary debug
+capture (`podman inspect`/`podman logs`/`ss -tlnp` on failure) and re-ran, which surfaced the
+actual error hiding behind the symptoms: `sh: line 0: cd: /projects: Permission denied`. The run
+container's `sh -c "cd $workingDir && exec ..."` was failing before ever starting to listen, so the
+container's PID 1 exited immediately (explaining "container state improper") and nothing was ever
+reachable (explaining both `ECONNRESET`s). Root-caused with a direct `podman run` reproduction:
+`fs.mkdtemp()` creates its directory with mode `0700` (owner-only), and this test's image runs as
+non-root UID 1001 — under rootless podman a bind-mounted `0700` host directory isn't even
+traversable by a container UID that isn't the mapped owner. Confirmed the fix by bind-mounting the
+same directory at `0755` (the default for any real project folder created via `mkdir`/`git clone`/
+IDE scaffolding — this permission bit is never this restrictive in practice) and the same command
+succeeded immediately. This is a **test-fixture bug only**, not a `podmanDevPlatform.ts` product
+bug — real component folders are never `0700`. Fixed by adding `await fs.chmod(componentPath,
+0o755)` right after `fs.mkdtemp()` in the test's `suiteSetup`. Removed the temporary debug capture
+once the root cause was confirmed. Final full integration run: exit code 0 (clean), confirming all
+of `podmanDevPlatform.ts`'s tests now pass alongside the rest of the suite.
+
+`dev.ts` / `devSession.ts` notes:
+- Split matches the rest of the plan's naming: `dev.ts` is the public entry point (registry of
+  active sessions keyed by component context path + the exported `startDevSession`/
+  `stopDevSession`/`forceStopDevSession`/`isDevSessionActive` API); `devSession.ts`'s `DevSession`
+  class owns one running session's internals (which `DevPlatform` it resolved to, the live
+  `DevPlatformSession` handle, start/stop, and — once `fileSync.ts` existed — the file watcher).
+  `devTerminalBridge.ts` still doesn't exist — once built, it hooks into `DevSession` internals
+  too, not `dev.ts`'s registry API.
+- Sessions are tracked only in an in-memory `Map`, not reconstructed from `.odo/devstate.json` on
+  extension-host restart — that file is read-only bookkeeping for `describe.ts`/`openInBrowser`/
+  debugger-attach, not something a live session (open k8s client-node handles, running exec
+  streams, a spawned `podman logs -f` child process) can be rebuilt from. This matches the old
+  CLI-shell-out behavior, which also only ever tracked the running `odo dev` pty in-memory
+  (`component.ts`'s `componentStates` map) — orphan cleanup on a fresh start already existed
+  (`devRunOn`'s pre-start `deleteDeploymentByComponentLabel`) and needs no change here.
+- `forceStopDevSession()` exists as a distinct function (not a parameter on `stopDevSession()`) so
+  it can have different failure semantics: `stopDevSession()` propagates a platform `stop()`
+  failure to the caller (session state is still cleared either way, via `finally`);
+  `forceStopDevSession()` never throws, matching the existing "user already chose force exit,
+  the UI must move on regardless" semantics in `component.ts`'s exit-timeout dialog.
+- **Testing**: unit tests only (`test/unit/devfile/dev.test.ts`) — this module is pure
+  orchestration (registry bookkeeping, state-file persistence, error propagation) with no
+  cluster/podman behavior of its own to verify against real infra; `ClusterDevPlatform`'s
+  prototype `start`/`stop`/`sync`/`restartRunCommand` are stubbed with sinon (existing codebase
+  convention, e.g. `ChildProcessUtil.prototype.execute` in `oc.test.ts`), `devstate.json`
+  persistence is verified against a real temp directory (no fs mocking, matching
+  `devStateFile.test.ts`). The watch-triggered sync/restart path added once `fileSync.ts` existed
+  is also covered here against a *real* chokidar watcher over a real temp directory (writing an
+  actual file and polling for the stubbed `sync`/`restartRunCommand` to have been called) — not
+  mocked, since chokidar's real event timing/debouncing is exactly what could silently break.
+  Full end-to-end session-lifecycle coverage against a real Kind cluster (actual pod exec/sync,
+  not stubbed) is the separate `test/integration/dev.test.ts` item below — now also done.
+
+`fileSync.ts` notes:
+- Added `ignore` (the npm package) as a new dependency — real `.gitignore` semantics (negation,
+  `**`, anchoring, directory-only patterns) are surprisingly subtle and not worth reimplementing;
+  it was already present transitively (via eslint/globby tooling) but only as a devDependency of
+  dev tooling, not something production code should rely on resolving by accident. Added
+  alongside `chokidar` in `devDependencies` (this project's existing convention — even
+  runtime-essential packages like `@kubernetes/client-node` live there, since esbuild bundles the
+  packaged extension regardless of the dependencies/devDependencies split).
+- `chokidar` v5 and `ignore` v7 are both fine to `require()` directly under plain Node (verified:
+  Node 22+'s native `require(esm)` support handles chokidar's ESM-only package janklessly) *and*
+  to bundle with esbuild for the real packaged extension (verified via a real `npm run compile`) —
+  neither needed the `esmImportTargets`/`esm-alias-plugin` treatment `got`/`uuid`/
+  `@kubernetes/client-node` needed elsewhere in this codebase.
+- **Real gotcha found and verified directly, not assumed from docs**: chokidar's `ignored`
+  predicate always receives an *absolute* path, even when the `cwd` option is set — only the
+  paths emitted by `add`/`change`/`unlink` *events* become `cwd`-relative. Confirmed with a
+  throwaway reproduction before writing the real `ignored` callback, which converts to a
+  root-relative POSIX path itself before calling `ignoreRules.ignores()`.
+- `ChangeBatcher` (the debounce/coalescing logic) is a separate, plain class from the chokidar
+  wiring specifically so it's unit-testable without spinning up a real watcher — matches the
+  testing-checklist note below. The latest event for a given path wins if it flips kind (e.g. a
+  quick delete-then-recreate) within the same debounce window, so a coalesced batch never lists
+  the same path in both `changedPaths` and `deletedPaths`.
+- Wired into `devSession.ts`: `DevSession.start()` now also resolves `hotReloadCapable` from
+  `CommandResolver.resolveRunCommand()` (a new field added there, sourced from the devfile's
+  `Exec.hotReloadCapable` — already defined in `componentTypeDescription.ts` but previously never
+  read) and, unless `options.manualRebuild` (mirrors `odo dev --no-watch`), starts a
+  `watchComponentFiles()` watcher whose batches call `platform.sync()` then — only when not
+  hot-reload-capable — `platform.restartRunCommand()`. `DevSession.stop()` closes the watcher
+  before tearing down the platform.
+
+## Small edits to existing shared infra
+
+- [x] `src/webview/openshift-terminal/openShiftTerminal.ts` — generalize the `spawnPty=false`
+      mode into a reusable interactive "virtual terminal" API (output + input callback).
+  - Added `OpenShiftTerminalManager.createVirtualTerminal(name, cwd, env, callbacks)`, sitting
+    alongside the existing `createTerminal()` (real spawned process) and `writeToTerminal()`
+    (one-shot, non-interactive write). Unlike `writeToTerminal()`, it accepts `callbacks`
+    (`onSpawn`/`onExit`/`onText`) and returns a live `OpenShiftTerminalApi` handle the caller can
+    keep pushing output to via `sendText()` over time, not just a single upfront blob of text.
+  - Extracted the tail shared by `createTerminal()` and the new method (register the
+    `OpenShiftTerminal` instance, send the webview `createTerminal` message, build the
+    `OpenShiftTerminalApi` object) into a private `registerTerminal()` — previously duplicated
+    inline in `createTerminal()`, now shared by both.
+  - **Real gotcha confirmed directly, not assumed**: a real pty's line discipline echoes a
+    user-typed Ctrl-C as printable `^C` text (which is why the old `odo dev` integration checked
+    `text.includes('^C')`), but this virtual (non-pty) terminal has no line discipline — the
+    webview's `input` message instead delivers the raw `\u0003` control byte itself to
+    `callbacks.onText` unchanged. `devTerminalBridge.ts`'s `isStopRequest()` checks for that raw
+    byte, not the printable text.
+  - No new unit tests for this file itself — it has no existing test infrastructure (heavy
+    `node-pty`/webview dependency, verified via `grep` that no unit/integration test imports it
+    today) and this is a small, low-risk refactor (extraction + one new method, no behavior change
+    to the existing `createTerminal()`/`writeToTerminal()` call paths). Verified via `tsc`,
+    `eslint` (lint warning count unchanged except one new instance of an existing `env`-shadowing
+    warning `createTerminal()` already had), the full unit suite (315 passing, 0 failing), and a
+    real `npm run compile` (production esbuild bundle) to make sure nothing about the refactor
+    broke the actual packaged-extension build.
+- [x] `src/devfile/inner-loop/devTerminalBridge.ts` (new) — `createDevTerminalBridge(name, cwd,
+      onStopRequested)` wraps `createVirtualTerminal()` into the shape `DevSession`/`dev.ts` need:
+      a `DevPlatformOutput` (`{ onOutput }`) to pass straight into `DevPlatform.start()`, and the
+      raw `OpenShiftTerminalApi` for later UI wiring (`component.ts`'s `showDevTerminal`/
+      `exitDevMode`/`forceExitDevMode` — a separate, still-open item below, not this one).
+      `isStopRequest()` (checking for the raw Ctrl-C byte) is exported and unit-tested on its own
+      as a pure function; the rest of the module (real `OpenShiftTerminalManager` call) isn't
+      independently tested, matching `openShiftTerminal.ts`'s own testing gap noted above — this
+      module is later exercised indirectly once `component.ts` is rewired to use it for real.
+- [x] `src/odo/componentTypeDescription.ts` — added `EnvVar { name; value }` and
+      `sourceMapping?: string`/`env?: EnvVar[]` on `Container`. No resolver change was needed
+      (`DevfileResolver`'s generic deep-merge already handles unknown fields).
+- [x] `src/util/kubeUtils.ts` — added `resolveClusterPlatform()` (returns
+      `{ isOpenShift, variant, label }`, label ∈ OpenShift/Kubernetes/Kind/Minikube), built from
+      the existing `isOpenShiftCluster()`/`detectKubernetesVariant()`. Reused in `applyCommand.ts`
+      and `describe.ts`; `devStateFile.ts` still to come.
+- [x] `src/devfile/applyCommand.ts` (not originally itemized, needed to make `managedBy` below
+      meaningful) — `prepareBuildScript` now calls `resolveClusterPlatform()` instead of its own
+      inline isOpenShift/variant computation; `prepareApplyScript` now stamps
+      `app.kubernetes.io/managed-by: openshift-toolkit` on applied resources via a new
+      `ensureManagedByLabel()` (same style as the existing `patchImagePullPolicy`), only if the
+      manifest author hadn't already set one. Previously nothing stamped this label at all, so
+      `describe.ts`'s `managedBy` would have had nothing to read.
+- [x] `src/devfile/deploy.ts` (not originally itemized) — extracted
+      `getCurrentClusterAndNamespace()` / `getCurrentDeployContextKey()` / `loadDeployState()` as
+      exported functions (previously inlined in `deployComponent()`); `undeploy.ts` had its own
+      private, near-identical `currentContextKey()`/`loadDeployState()` which now reuse these
+      instead (dedup). Note: this unifies one edge-case default — undeploy's version fell back to
+      `''` for an unknown cluster server, deploy's falls back to `'unknown'`; both now use
+      `'unknown'`.
+- [x] `src/devfile/describe.ts`:
+  - [x] Display `sourceMapping` (fallback `/projects`) and `env` per container component.
+  - [x] Evaluate dev-state (`.odo/devstate.json`) and deploy-state (via the new
+        `deploy.ts#loadDeployState`) independently and merge, instead of if/else — supports
+        simultaneous Dev+Deploy states. Dev-state reading itself (`readDevState`/
+        `extractForwardedPortsFromDevState`) intentionally left untouched — its `'cluster'`/
+        `'podman'`/`'docker'` vocabulary depends on what `devStateFile.ts` will actually write.
+  - [x] `runningIn` is always mode labels (`'Dev'`/`'Deploy'`) now, in both the state-file path
+        and the live-cluster fallback path (previously leaked raw Ingress names).
+  - [x] `managedBy` sourced from `deploystate.json`'s tracked resource labels (defaulting to
+        `'openshift-toolkit'` when the state file exists but no label was captured — we know our
+        own tooling deployed it) when using the local state file; from the live Deployment's
+        label (defaulting to `'Unknown'`, dropping the old blanket `'odo'` guess) in the fallback
+        path. Never set when nothing is actually deployed, in either path — matches odo's
+        behavior of printing nothing for `Managed by` on a non-deployed component. Fixed a
+        related bug in the fallback path where a Deployment's managed-by label could leak through
+        even when the (separate) Ingress-based running-check said nothing was running; "is
+        running" is now Deployment-OR-Ingress existence, checked once, before deriving anything.
+  - [x] `runningOn` uses `resolveClusterPlatform()`'s label instead of hardcoded `'cluster'`.
+  - Verified: `Odo.Instance.describeComponent` already fully delegates to this function — no
+    other call site needed updating.
+- [x] `src/openshift/component.ts` — rewire `devRunOn`/`exitDevMode`/`forceExitDevMode`/
+      `showDevTerminal` to the new `dev.ts` API + `devTerminalBridge`; keep firing
+      `Component.stateChanged` exactly as today.
+  - `devRunOn()`: creates a `devTerminalBridge` (title unchanged, still `odo dev:
+    ${componentName}`) whose `onStopRequested` callback is the single place both a user-typed
+    Ctrl-C *and* `exitDevMode()`'s own `devTerminal.kill()` funnel through (mirrors the old
+    real-pty design's unification of those two triggers via the same terminal mechanism);
+    `bridge.output` passes straight into `startDevSession()`. `DEV_STARTING` -> `DEV_RUNNING` now
+    transitions once `startDevSession()` resolves (the old CLI-based version waited for a `'[p]'`
+    prompt substring in the pty output — the new engine has no equivalent "press a key" prompt, so
+    "resolved" is the closest available readiness signal). Dropped the old pre-start
+    `Oc.Instance.deleteDeploymentByComponentLabel()` call: it existed to give the `odo` CLI a
+    clean slate before its own internal dev-state tracking kicked in; `ClusterDevPlatform.start()`
+    already applies the Deployment idempotently via server-side apply, so there's nothing to
+    pre-clean for the new engine.
+  - Added a private `stopDevSessionAndUpdateState(contextPath, force)` helper — the one place that
+    actually calls `stopDevSession()`/`forceStopDevSession()` and resets `devStatus` back to
+    `DEV` afterwards (success or failure). `exitDevelopmentMode()`'s "taking too long" dialog's
+    "Force exit" button and `sendSigabrt()` now call this with `force: true` (previously only
+    force-killed the pty, which — for the old CLI process — was itself what tore down cluster
+    resources via `odo`'s own signal handling; the new engine's terminal has no such side effect,
+    so tearing down now has to be called explicitly).
+  - `forceExitDevMode()` made `async` (previously synchronous) since it now awaits the actual
+    session teardown, not just a terminal kill.
+  - **Testing**: added `test/unit/openshift/component.test.ts`'s new `dev mode` suite (7 tests) —
+    previously zero coverage for these methods. Uses `proxyquire` to inject stubs for `dev.ts`'s
+    exported functions and `devTerminalBridge.ts`'s `createDevTerminalBridge` (matching this test
+    file's existing `pq(...)` convention used for the `debug()` suite), with a fake
+    `OpenShiftTerminalApi` whose `kill()` synchronously invokes the captured `onStopRequested`
+    callback — verifies the full `devRunOn`/`exitDevMode`/`forceExitDevMode`/`showDevTerminal`
+    state-machine wiring without needing a real webview/cluster. Full manual click-through in a
+    real extension host against a live cluster/podman has **not** been done as part of this slice
+    — residual risk to close out via the cluster UI test suites below (not yet updated) once the
+    PR is opened and CI's Kind-cluster jobs run.
+
+Verification for the above: `npx tsc --noEmit -p .` and `eslint` clean on all touched files
+(warning counts checked before/after — no new warning *categories* introduced, only more instances
+of patterns already present elsewhere in each file); full unit suite (`npm test`) — 322 passing,
+0 failing, 41 skipped (pre-existing skips, unrelated); a real `npm run compile` production esbuild
+bundle succeeded after every change in this slice.
+
+## Testing
+
+Principle: favor integration tests over heavily-mocked unit tests for anything that orchestrates
+real cluster/container behavior (describe status computation, dev session lifecycle, platform
+implementations) — mocking exec/sync/port-forward/cluster state tends to diverge from real
+behavior and gives false confidence. Unit tests stay for logic that's naturally pure/self-
+contained, where mocking is minimal. CI already provisions a Kind cluster for this
+(`continuous-integration-workflow.yml` → `helm/kind-action` → `test-integration:coverage` and
+`public-ui-kind-test`), so this leans on existing infrastructure rather than adding a new lane.
+
+**Fixed test-discovery gap** (found while adding `devStateFile.test.ts`, not originally itemized):
+`test/unit/index.ts` discovers unit test files via an explicit per-subsystem glob allowlist, and
+`devfile/*.test.js` was non-recursive — a nested `test/unit/devfile/inner-loop/*.test.ts` file
+would have been silently never run (confirmed: pass count didn't change after adding the new test
+file until this was fixed). Changed to `devfile/**/*.test.js` (verified with `fast-glob` directly
+that this matches both flat and nested files) and removed an accidental duplicate of the same
+line. Without this fix, every future test under `inner-loop/` in this plan would have given false
+confidence.
+
+**Unit tests** (pure/self-contained logic, minimal mocking):
+- [x] `test/unit/devfile/inner-loop/devResourceBuilder.test.ts` — devfile -> manifest transform;
+      uses the `comp-with-uris` fixture plus inline `Data` fixtures (mirroring `deploy.test.ts`'s
+      style) for edge cases the file fixtures don't cover: env resolution, explicit command/args,
+      `mountSources: false`, volume components, no-endpoints, no-container-components error
+- [x] `test/unit/devfile/inner-loop/devStateFile.test.ts` — `.odo/devstate.json` schema round-trip
+- [x] `test/unit/devfile/inner-loop/devPlatform.test.ts` — `resolveDevPlatformKind()` selection
+- [x] `test/unit/devfile/inner-loop/fileSync.test.ts` — ignore-rule resolution / debounce batching
+      logic (not the actual chokidar filesystem events)
+- [x] `test/unit/util/kubeUtils.test.ts` — extended for `resolveClusterPlatform()` (checklist named
+      it `resolveClusterPlatformLabel()` — that was a planning-stage name; the actual function is
+      `resolveClusterPlatform()`, already implemented earlier in this plan). 4 new tests
+      (OpenShift/Kind/Minikube/generic-Kubernetes), matching this file's existing
+      proxyquire-`CliChannel` + fixture-`KUBECONFIG` conventions already used for
+      `detectKubernetesVariant()`/`getOpenShiftRegistryUrl()`.
+
+**Integration tests** (`test/integration/`, run against the Kind cluster already used in CI):
+- [x] `test/integration/describe.test.ts` — 8 tests against the real Kind cluster: not-running;
+      Dev-on-cluster (single forwarded-port entry); Dev-on-podman (cluster+podman duplicate
+      forwarded-port entries — exercises `extractForwardedPortsFromDevState()`'s `runtime !==
+      'cluster'` branch); Deploy via `deploystate.json` with an explicit `managed-by` label and
+      with none (defaults to `openshift-toolkit`); Dev+Deploy simultaneously; and the live-cluster
+      fallback path (no `deploystate.json`) sourcing `managedBy` from a real Deployment's label,
+      both when present and when absent (`'Unknown'`). `deploystate.json` fixtures are written
+      directly (matching `DeployStateFile`'s real v2 schema, keyed via the real
+      `getCurrentClusterAndNamespace()`/`deployContextKey()`) rather than by actually running
+      `deployComponent()` — `describe.ts`'s own job is reading/merging that file, not writing it
+      (already covered by `deployComponent()`'s own tests in `command.test.ts`). The live-cluster
+      fallback tests apply a real bare Deployment (0 replicas — existence is all
+      `checkClusterInfo()` checks, no need for it to actually become ready) to a dedicated
+      `describe-it-tests` namespace. All 8 passed on the first real run.
+- [x] `test/integration/dev.test.ts` — full session lifecycle against the real Kind cluster,
+      through `dev.ts`'s own orchestration layer (not `ClusterDevPlatform` directly, unlike
+      `clusterDevPlatform.test.ts` below): `startDevSession()` deploys and persists
+      `devstate.json`; starting a second session for the same path is rejected; **the file
+      watcher syncs a newly-written local file into the running container with no manual
+      `sync()` call** — the one behavior `clusterDevPlatform.test.ts` structurally can't cover
+      (it only ever calls `sync()`/`restartRunCommand()` directly) and the unit suite could only
+      verify against a stubbed platform; `stopDevSession()` tears down the Deployment and clears
+      `devstate.json`; `forceStopDevSession()` tears down a running session too. All 5 passed on
+      the first real run.
+- [x] `test/integration/inner-loop/clusterDevPlatform.test.ts` — full start/sync(push+remove)/
+      restartRunCommand/stop lifecycle against the real Kind cluster; verified end-to-end
+      including actually connecting through the forwarded port and exec-checking synced files
+- [x] `test/integration/inner-loop/podmanDevPlatform.test.ts` — full start(+ reachable)/sync(no-op,
+      bind-mount-visible)/restart(+ reachable again)/stop lifecycle against real local podman
+- [x] `test/integration/inner-loop/devCommandExec.test.ts` — run/debug command execution +
+      stop()/restart-on-change, against Kind
+- [x] `test/integration/inner-loop/devPortForward.test.ts` — endpoint forwarding + dispose(),
+      against Kind (debug port discovery specifically not yet covered — no debug-mode devfile
+      fixture used yet)
+- [x] `test/integration/inner-loop/containerSync.test.ts` — push (incl. nested paths)/remove,
+      no-op-on-empty, against Kind
+- [x] `test/integration/inner-loop/testPod.ts` — shared non-test helper (dedicated namespace +
+      pod lifecycle) used by all four suites above
+- [x] `test/unit/openshift/component.test.ts` — was **zero coverage** for
+      `devRunOn`/`exitDevMode`/`forceExitDevMode`/`showDevTerminal`; added lightweight unit
+      coverage for the state-machine wiring (event → `ComponentContextState` transition, see the
+      `component.ts` notes above), leaving the real end-to-end behavior to the integration/UI
+      suites below (not yet updated).
+
+**Cluster UI tests** (`test/ui/suite/`, exercised once the PR is opened):
+- [ ] `test/ui/suite/component.ts` — un-skip / update `terminalHasText(COMPONENTS.devStarted, ...)`
+      to match the new engine's status output.
+- [ ] `test/ui/suite/componentContextMenu.ts` — update literal odo-banner assertions
+      (`Developing using the "<name>" Devfile`, `Running on the cluster in Dev mode`) to the new
+      engine's text; Ctrl+C-stop and podman start/stop tests should keep passing largely
+      unchanged (they test behavior, not implementation).
+
+## Post-implementation cleanup (run only after the above is implemented and green)
+
+- [x] Remove the `'[p]'`/`'^C'` pty text-sniffing in `component.ts`'s old `devRunOn`. Already gone
+      as a side effect of the `component.ts` rewiring above — the entire old `onText`/`onExit`
+      callback pair (and the `Command.dev()` call that fed them) was replaced by
+      `devTerminalBridge`'s `onStopRequested` wiring. Confirmed via `grep -rn "'\[p\]'\|\^C"
+      src/` — the only remaining hits are explanatory comments in `devTerminalBridge.ts`/
+      `openShiftTerminal.ts` describing the *old* behavior for context, no live logic.
+- [ ] Delete `Command.dev()` in `src/odo/command.ts` once nothing calls it.
+  - **Not yet safe to delete** — `src/odo/command.ts`'s `Command` class now contains *only*
+    `dev()` (confirmed by reading the whole file), and its one remaining importer anywhere in
+    `src/`+`test/` is `test/integration/command.test.ts`, which calls it directly in **three**
+    places to bootstrap a real dev session for tests unrelated to the dev *engine* itself:
+    the standalone `test('dev()')` (spawns `Command.dev(false)` via a raw pty just to exercise
+    `CliChannel.spawnTool()`+SIGINT teardown) and `suite('component dev')`'s
+    `executeCommandInTerminal()`/`startDevInTerminal()` helpers (spawn `Command.dev(true)` via a
+    raw pty, text-sniffing for `'Developing using the "..." Devfile'`/`'✓  Pod is Running'`/
+    `'↪ Dev mode'` to know when it's safe to proceed), used by `runComponentCommand()` to get a
+    dev session running before testing `DevfileCommandRunner.execute()` (arbitrary devfile-command
+    execution against an already-running session — a feature with no dependency on which engine
+    started that session; `devfileCommandRunner.ts`/`execCommand.ts` don't touch
+    `.odo/devstate.json` or `Command.` at all). These three call sites need to switch to
+    `startDevSession()` (awaiting its promise instead of text-sniffing a banner) **before**
+    `Command.dev()` can be deleted, otherwise this file fails to compile.
+  - **Confirmed NOT affected** (the user's specific concern) — `initComponent()`,
+    `getComponentDescription()` (`describe`), `deployComponent()`/`undeployComponent()`, and this
+    same test file's other suites (`container runtime detection`, `deploy with inlined resources`,
+    `local image build`) have zero dependency on `Command`/`Command.dev()` — verified by reading
+    `init.ts`/`describe.ts` directly (no `onText`/pty usage at all) and by `grep`ing this test file
+    end to end. Deleting `Command.dev()` cannot affect them.
+  - **Do NOT touch these two unrelated, still-active `onText`/pty-output-sniffing mechanisms** —
+    easy to conflate with the dev-mode cleanup since they look similar, but serve different,
+    still-needed purposes: `deploy.ts`'s image-build/push script accumulates terminal output to
+    detect registry auth failures (`unauthorized|authentication required|denied`) on exit; and
+    `serverlessFunction/functions.ts`'s `deployProcess()` watches for
+    `'Please provide credentials for image registry'`/`'Incorrect credentials, please try again'`
+    to prompt interactively for registry credentials. Neither is part of this plan's scope.
+- [ ] Audit `src/tools.ts`/`ToolsConfig` for `odo`-version-gating or flag-specific logic tied to
+      `dev`/`--debug`/`--platform podman`/`--forward-localhost`/`--no-watch`.
+- [ ] Audit whether `odo` is still required as a downloaded tool at all for component lifecycle
+      (deploy/undeploy/init/describe/dev would then all be native) — verify, don't assume.
+- [ ] Remove stale `.skip` workaround comments in the UI test suite tied to real-`odo`-CLI pty
+      quirks that no longer apply.

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
 				"git-up": "^8.1.1",
 				"globals": "^17.11.0",
 				"got": "^16.0.0",
+				"ignore": "^7.0.9",
 				"istanbul": "^0.4.5",
 				"js-yaml": "^5.4.1",
 				"json-schema": "^0.4.0",
@@ -1627,6 +1628,16 @@
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"extraneous": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/@eslint/js": {
@@ -4504,16 +4515,6 @@
 				"@typescript-eslint/parser": "^8.70.0",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
@@ -9735,6 +9736,16 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/eslint/node_modules/minimatch": {
 			"version": "10.2.6",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -10658,6 +10669,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/globby/node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/globby/node_modules/slash": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
@@ -11126,10 +11147,11 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.9.tgz",
+			"integrity": "sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -16253,16 +16275,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/secretlint/node_modules/ignore": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/secretlint/node_modules/parse-json": {

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
 		"git-up": "^8.1.1",
 		"globals": "^17.11.0",
 		"got": "^16.0.0",
+		"ignore": "^7.0.9",
 		"istanbul": "^0.4.5",
 		"js-yaml": "^5.4.1",
 		"json-schema": "^0.4.0",
@@ -544,7 +545,7 @@
 			},
 			{
 				"command": "openshift.component.dev.manual",
-				"title": "Start Dev (manually trigger rebuild)",
+				"title": "Start Dev (Manual Sync)",
 				"category": "OpenShift"
 			},
 			{
@@ -560,6 +561,11 @@
 			{
 				"command": "openshift.component.forceExitDevMode",
 				"title": "Force Stop Dev",
+				"category": "OpenShift"
+			},
+			{
+				"command": "openshift.component.dev.sync",
+				"title": "Sync Files & Rebuild",
 				"category": "OpenShift"
 			},
 			{
@@ -890,7 +896,7 @@
 			},
 			{
 				"command": "openshift.component.dev.onPodman.manual",
-				"title": "Start Dev on Podman (manually trigger rebuild)",
+				"title": "Start Dev on Podman (Manual Sync)",
 				"category": "OpenShift"
 			},
 			{
@@ -1850,6 +1856,11 @@
 					"command": "openshift.component.forceExitDevMode",
 					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-stp.*/",
 					"group": "c1@6"
+				},
+				{
+					"command": "openshift.component.dev.sync",
+					"when": "view == openshiftComponentsView && viewItem =~ /openshift\\.component.*\\.dev-run.*/",
+					"group": "c1@7"
 				},
 				{
 					"command": "openshift.component.deploy",

--- a/src/componentsView.ts
+++ b/src/componentsView.ts
@@ -6,7 +6,7 @@
 import * as vsc from 'vscode';
 import { ThemeIcon } from 'vscode';
 import { BaseTreeDataProvider } from './base/baseTreeDataProvider';
-import { Command, CommandProvider, ComponentDescription } from './odo/componentTypeDescription';
+import { Command, CommandProvider, ComponentDescription } from './devfile/componentTypeDescription';
 import { ComponentWorkspaceFolder, OdoWorkspace } from './odo/workspace';
 import { Component } from './openshift/component';
 import { imagePath } from './util/utils';

--- a/src/devfile-registry/devfileInfo.ts
+++ b/src/devfile-registry/devfileInfo.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { Registry } from '../odo/componentType';
-import { Data } from '../odo/componentTypeDescription';
+import { Data } from '../devfile/componentTypeDescription';
 
 export type DevfileRegistryInfo = Registry;
 

--- a/src/devfile/applyCommand.ts
+++ b/src/devfile/applyCommand.ts
@@ -13,8 +13,8 @@ import { DownloadUtil } from '../downloadUtil/download';
 import { Oc } from '../oc/ocWrapper';
 import { KubernetesVariant } from '../oc/types';
 import { ToolsConfig } from '../tools';
-import { Apply, DeployedResource } from '../odo/componentTypeDescription';
-import { detectKubernetesVariant, getOpenShiftRegistryUrl, isOpenShiftCluster } from '../util/kubeUtils';
+import { Apply, DeployedResource } from './componentTypeDescription';
+import { getOpenShiftRegistryUrl, resolveClusterPlatform } from '../util/kubeUtils';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
 import { TokenStore } from '../util/credentialManager';
 import { ContainerRuntimeDetector } from '../util/containerRuntime';
@@ -161,6 +161,8 @@ export class ApplyCommandExecutor {
             resolvedManifest = resolvedManifest.replaceAll(original, retagged);
         }
 
+        resolvedManifest = this.ensureManagedByLabel(resolvedManifest);
+
         let patchedContainers: string[] = [];
         if (this.locallyLoadedImages.size > 0) {
             const result = this.patchImagePullPolicy(resolvedManifest);
@@ -265,10 +267,7 @@ export class ApplyCommandExecutor {
             ? buildContext
             : devfileDir;
 
-        const isOpenShift = await isOpenShiftCluster();
-        const k8sVariant = isOpenShift
-            ? undefined
-            : await detectKubernetesVariant();
+        const { isOpenShift, variant: k8sVariant } = await resolveClusterPlatform();
 
         const buildCmd = ContainerRuntimeDetector.getBuildCommand(
             runtime, imageName, resolvedDockerfile, resolvedContext,
@@ -521,6 +520,26 @@ export class ApplyCommandExecutor {
             registryKey: registryKey || undefined,
             pullSecretWarning: pullSecretWarning || undefined,
         };
+    }
+
+    public static ensureManagedByLabel(manifestContent: string): string {
+        try {
+            const docs = yaml.loadAll(manifestContent);
+            const patched = docs.map(doc => {
+                if (!doc || typeof doc !== 'object') return doc;
+
+                const d = doc as any;
+                d.metadata ??= {};
+                d.metadata.labels ??= {};
+                d.metadata.labels['app.kubernetes.io/managed-by'] ??= 'openshift-toolkit';
+
+                return doc;
+            });
+
+            return patched.map(doc => yaml.dump(doc, { noRefs: true })).join('---\n');
+        } catch {
+            return manifestContent;
+        }
     }
 
     public static patchImagePullPolicy(manifestContent: string): { manifest: string; patchedContainers: string[] } {

--- a/src/devfile/commandResolver.ts
+++ b/src/devfile/commandResolver.ts
@@ -2,7 +2,18 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-import { Command, Data } from '../odo/componentTypeDescription';
+import { Command, ComponentItem, Data } from './componentTypeDescription';
+import { VariableResolver } from './variableResolver';
+
+export interface ResolvedRunCommand {
+    containerName: string;
+    sourceMapping: string;
+    workingDir: string;
+    commandLine: string;
+    hotReloadCapable: boolean;
+    containerComponent?: ComponentItem;
+    env?: Array<{ name: string; value: string }>;
+}
 
 export class CommandResolver {
     public static getCommand(devfile: Data, commandId: string): Command {
@@ -25,5 +36,43 @@ export class CommandResolver {
         }
 
         return map;
+    }
+
+    /**
+     * Finds the exec command for a devfile command group (e.g. 'run'/'debug'), preferring the one
+     * marked `isDefault` when several share the group.
+     */
+    public static findCommandByGroup(devfile: Data, groupKind: string): Command | undefined {
+        const candidates = (devfile.commands ?? []).filter(c => c.exec?.group?.kind === groupKind);
+        return candidates.find(c => c.exec?.group?.isDefault) ?? candidates[0];
+    }
+
+    /**
+     * Resolves the exec command for a devfile command group into everything a dev platform needs
+     * to actually run it: which container, its source-mapping/working directory, and the fully
+     * variable-resolved command line. Shared by every `DevPlatform` implementation since this
+     * resolution is devfile-domain logic, not platform-specific.
+     */
+    public static resolveRunCommand(devfile: Data, groupKind: string): ResolvedRunCommand {
+        const command = this.findCommandByGroup(devfile, groupKind);
+        if (!command?.exec) {
+            throw new Error(`No devfile command found for group '${groupKind}'`);
+        }
+
+        const resolvedExec = VariableResolver.resolveExec(devfile, command.exec);
+        const containerName = resolvedExec.component;
+        const containerComponent = devfile.components?.find(c => c.name === containerName);
+        const sourceMapping = containerComponent?.container?.sourceMapping ?? '/projects';
+        const workingDir = resolvedExec.workingDir || sourceMapping;
+
+        return {
+            containerName,
+            sourceMapping,
+            workingDir,
+            commandLine: resolvedExec.commandLine,
+            hotReloadCapable: resolvedExec.hotReloadCapable ?? false,
+            containerComponent,
+            env: resolvedExec.env,
+        };
     }
 }

--- a/src/devfile/componentTypeDescription.ts
+++ b/src/devfile/componentTypeDescription.ts
@@ -60,6 +60,7 @@ export interface ComponentItem {
     kubernetes?: Kubernetes;
     openshift?: Kubernetes;  // OpenShift uses same structure as Kubernetes
     image?: Image;
+    volume?: Volume;
 };
 
 export interface Data {
@@ -145,6 +146,15 @@ export interface Container {
     memoryLimit: string;
     mountSources: boolean;
     volumeMounts: VolumeMount[];
+    sourceMapping?: string;
+    env?: EnvVar[];
+    command?: string[];
+    args?: string[];
+}
+
+export interface EnvVar {
+    name: string;
+    value: string;
 }
 
 export interface Endpoint {
@@ -183,6 +193,7 @@ export interface Exec {
     workingDir: string;
     group?: Group;
     hotReloadCapable?: boolean;
+    env?: Array<{ name: string; value: string }>;
 }
 
 export interface Apply {
@@ -227,4 +238,21 @@ export interface DeployState {
 export interface DeployStateFile {
     version: number;
     deployments: Record<string, DeployState>;
+}
+
+export interface DevStateForwardedPort {
+    containerName: string;
+    portName?: string;
+    isDebug?: boolean;
+    localAddress: string;
+    localPort: number;
+    containerPort: number;
+    exposure?: string;
+}
+
+export interface DevState {
+    pid: number;
+    platform: 'cluster' | 'podman' | 'docker' | string;
+    forwardedPorts?: DevStateForwardedPort[];
+    apiServerPort?: number;
 }

--- a/src/devfile/compositeCommand.ts
+++ b/src/devfile/compositeCommand.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { ComponentWorkspaceFolder } from '../odo/workspace';
-import { Command } from '../odo/componentTypeDescription';
+import { Command } from './componentTypeDescription';
 import { DevfileCommandRunner } from './devfileCommandRunner';
 
 export class CompositeCommand {

--- a/src/devfile/deploy.ts
+++ b/src/devfile/deploy.ts
@@ -12,14 +12,13 @@ import { CommandText } from '../base/command';
 import { OpenshiftLogger } from '../util/childProcessUtil';
 import { TokenStore } from '../util/credentialManager';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
-import { Data, Command, DeployedResource, DeployState, DeployStateFile } from '../odo/componentTypeDescription';
-import { KubeConfig } from '@kubernetes/client-node';
-import { Oc } from '../oc/ocWrapper';
+import { Data, Command, DeployedResource } from './componentTypeDescription';
 import { isOpenShiftCluster } from '../util/kubeUtils';
 import { OpenShiftTerminalManager } from '../webview/openshift-terminal/openShiftTerminal';
 import { DevfileResolver } from './devfileResolver';
 import { DevfileCommandRunner } from './devfileCommandRunner';
 import { ApplyCommandExecutor, DeployScriptContribution } from './applyCommand';
+import { getCurrentClusterAndNamespace, saveDeployState } from './deployStateFile';
 
 export interface ComponentDeployOptions {
     componentPath: string;
@@ -196,10 +195,7 @@ export async function deployComponent(
     }
 
     // 9. Save deployment state
-    const kc = new KubeConfig();
-    kc.loadFromDefault();
-    const clusterServer = kc.getCurrentCluster()?.server || 'unknown';
-    const namespace = await Oc.Instance.getActiveProject() || 'default';
+    const { cluster: clusterServer, namespace } = await getCurrentClusterAndNamespace();
 
     await saveDeployState({
         version: 1,
@@ -270,33 +266,5 @@ function logError(ctx: DeployContext, message: string) {
     }
 }
 
-export function deployContextKey(clusterServer: string, namespace: string): string {
-    return `${clusterServer}/${namespace}`;
-}
-
-async function saveDeployState(state: DeployState, componentPath: string): Promise<void> {
-    const odoDir = path.join(componentPath, '.odo');
-    await fs.mkdir(odoDir, { recursive: true });
-
-    const stateFile = path.join(odoDir, 'deploystate.json');
-
-    let file: DeployStateFile = { version: 2, deployments: {} };
-    try {
-        const raw = await fs.readFile(stateFile, 'utf-8');
-        const parsed = JSON.parse(raw);
-        if (parsed.version === 1 && !parsed.deployments) {
-            const key = deployContextKey(parsed.cluster, parsed.namespace);
-            file = { version: 2, deployments: { [key]: parsed } };
-        } else if (parsed.deployments) {
-            file = parsed;
-        }
-    } catch {
-        // no existing file
-    }
-
-    const key = deployContextKey(state.cluster, state.namespace);
-    file.deployments[key] = state;
-    file.version = 2;
-
-    await fs.writeFile(stateFile, JSON.stringify(file, null, 2), 'utf-8');
-}
+// saveDeployState is now private - only this file can write deploy state
+// Other files should import from deployStateFile.ts for reading

--- a/src/devfile/deployStateFile.ts
+++ b/src/devfile/deployStateFile.ts
@@ -1,0 +1,92 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { KubeConfig } from '@kubernetes/client-node';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { Oc } from '../oc/ocWrapper';
+import { DeployState, DeployStateFile } from './componentTypeDescription';
+
+/**
+ * Builds a unique key identifying a deploy context (cluster + namespace pair).
+ */
+export function deployContextKey(clusterServer: string, namespace: string): string {
+    return `${clusterServer}/${namespace}`;
+}
+
+/**
+ * Returns the current cluster and namespace from the active kubeconfig context.
+ */
+export async function getCurrentClusterAndNamespace(): Promise<{ cluster: string; namespace: string }> {
+    const kc = new KubeConfig();
+    kc.loadFromDefault();
+    const cluster = kc.getCurrentCluster()?.server || 'unknown';
+    const namespace = await Oc.Instance.getActiveProject() || 'default';
+    return { cluster, namespace };
+}
+
+/**
+ * Returns the deploy context key for the current cluster and namespace.
+ */
+export async function getCurrentDeployContextKey(): Promise<string> {
+    const { cluster, namespace } = await getCurrentClusterAndNamespace();
+    return deployContextKey(cluster, namespace);
+}
+
+/**
+ * Loads the deploy state for the current cluster/namespace from .odo/deploystate.json.
+ * Returns null if no state exists for this context.
+ */
+export async function loadDeployState(componentPath: string): Promise<DeployState | null> {
+    try {
+        const stateFile = path.join(componentPath, '.odo', 'deploystate.json');
+        const raw = await fs.readFile(stateFile, 'utf-8');
+        const parsed = JSON.parse(raw);
+
+        if (parsed.version === 1 && !parsed.deployments) {
+            return parsed as DeployState;
+        }
+
+        if (parsed.deployments) {
+            const key = await getCurrentDeployContextKey();
+            return parsed.deployments[key] ?? null;
+        }
+
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Saves the deploy state for a specific cluster/namespace to .odo/deploystate.json.
+ * Merges with existing state for other contexts.
+ */
+export async function saveDeployState(state: DeployState, componentPath: string): Promise<void> {
+    const odoDir = path.join(componentPath, '.odo');
+    await fs.mkdir(odoDir, { recursive: true });
+
+    const stateFile = path.join(odoDir, 'deploystate.json');
+
+    let file: DeployStateFile = { version: 2, deployments: {} };
+    try {
+        const raw = await fs.readFile(stateFile, 'utf-8');
+        const parsed = JSON.parse(raw);
+        if (parsed.version === 1 && !parsed.deployments) {
+            const key = deployContextKey(parsed.cluster, parsed.namespace);
+            file = { version: 2, deployments: { [key]: parsed } };
+        } else if (parsed.deployments) {
+            file = parsed;
+        }
+    } catch {
+        // no existing file
+    }
+
+    const key = deployContextKey(state.cluster, state.namespace);
+    file.deployments[key] = state;
+    file.version = 2;
+
+    await fs.writeFile(stateFile, JSON.stringify(file, null, 2), 'utf-8');
+}

--- a/src/devfile/describe.ts
+++ b/src/devfile/describe.ts
@@ -4,7 +4,6 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { AppsV1Api, NetworkingV1Api } from '@kubernetes/client-node';
-import * as fs from 'fs/promises';
 import path from 'path';
 import {
   CommandInfo,
@@ -12,12 +11,16 @@ import {
   ComponentItem,
   Container,
   Data,
+  DeployedResource,
   DevControlPlaneInfo,
+  DevState,
   ForwardedPort,
   StarterProject
-} from '../odo/componentTypeDescription';
-import { KubeConfigInfo } from '../util/kubeUtils';
+} from './componentTypeDescription';
+import { KubeConfigInfo, resolveClusterPlatform } from '../util/kubeUtils';
+import { loadDeployState } from './deployStateFile';
 import { DevfileResolver } from './devfileResolver';
+import { loadDevState } from './inner-loop/devStateFile';
 
 /* ===========================================================
  * Exported functions
@@ -40,14 +43,16 @@ export async function getComponentDescription(
   const normalizedCommands = normalizeCommands(mergedDevfile);
   const supportedOdoFeatures = detectSupportedFeatures(normalizedCommands);
 
-  let runningIn: string[] = [];
-  let runningOn: string[] = [];
-  let managedBy = undefined;
-  let warnings: string[] = [];
+  const runningIn: string[] = [];
+  const runningOn: string[] = [];
+  let managedBy: string | undefined;
+  const warnings: string[] = [];
   let devForwardedPorts:  ForwardedPort[] = [];
   const devControlPlane: ComponentDescription['devControlPlane'] = [];
 
-  const devstate = await readDevState(resolvedDevfilePath);
+  // Dev-mode status — evaluated independently of deploy status below, so a component can be
+  // reported as running in both Dev and Deploy at once.
+  const devstate = await loadDevState(path.dirname(resolvedDevfilePath));
   if (devstate) {
     const runtime = devstate.platform ?? 'unknown';
 
@@ -72,12 +77,24 @@ export async function getComponentDescription(
           webInterfacePath: '/'
         });
     }
+  }
+
+  // Deploy status — prefer the local deploystate.json this extension's own deploy.ts
+  // maintains; only fall back to a live cluster query if that file has no entry for the
+  // current cluster/namespace (e.g. component deployed by something else, or state lost).
+  const deployState = await loadDeployState(path.dirname(resolvedDevfilePath));
+  if (deployState) {
+    const { label: platformLabel } = await resolveClusterPlatform();
+
+    runningIn.push('Deploy');
+    runningOn.push(`${platformLabel}: Deploy`);
+    managedBy = findManagedBy(deployState.resources) ?? 'openshift-toolkit';
   } else {
-    const clusterInfo = await checkClusterInfo(opts.namespace, opts.componentName, opts.timeoutMs ?? 3000)
-    runningIn = clusterInfo.runningIn
-    runningOn = clusterInfo.runningOn
-    managedBy = clusterInfo.managedBy && clusterInfo.managedBy.length > 0 ? clusterInfo.managedBy : devfile ? 'odo' : 'Unknown';
-    warnings = clusterInfo.warnings
+    const clusterInfo = await checkClusterInfo(opts?.namespace, opts?.componentName, opts?.timeoutMs ?? 3000)
+    runningIn.push(...clusterInfo.runningIn);
+    runningOn.push(...clusterInfo.runningOn);
+    managedBy = clusterInfo.managedBy?.length ? clusterInfo.managedBy : (clusterInfo.runningIn.length ? 'Unknown' : undefined);
+    warnings.push(...(clusterInfo.warnings ?? []));
   }
 
   return {
@@ -203,16 +220,17 @@ async function checkClusterInfo(namespace: string, componentName: string, timeou
       )
     ]);
 
-    const runningIn = (ing.items ?? [])
-      .map(i => i.metadata?.name)
-      .filter(Boolean);
+    const isRunning = (ing.items?.length ?? 0) > 0 || (dep.items?.length ?? 0) > 0;
 
-    const runningOn = runningIn.length > 0 ? ['cluster: Deploy'] : [];
+    const runningIn = isRunning ? ['Deploy'] : [];
 
-    const managedBy =
-      dep.items?.[0]?.metadata?.labels?.[
-        'app.kubernetes.io/managed-by'
-      ];
+    const runningOn = isRunning
+      ? [`${(await resolveClusterPlatform()).label}: Deploy`]
+      : [];
+
+    const managedBy = isRunning
+      ? dep.items?.[0]?.metadata?.labels?.['app.kubernetes.io/managed-by']
+      : undefined;
 
     return {
       runningIn,
@@ -241,28 +259,12 @@ async function checkClusterInfo(namespace: string, componentName: string, timeou
   }
 }
 
-type DevState = {
-  pid: number;
-  platform: 'cluster' | 'podman' | 'docker' | string;
-  forwardedPorts?: {
-    containerName: string;
-    portName?: string;
-    isDebug?: boolean;
-    localAddress: string;
-    localPort: number;
-    containerPort: number;
-    exposure?: string;
-  }[];
-  apiServerPort?: number;
-};
-
-async function readDevState(devfilePath: string): Promise< DevState | null> {
-  try {
-    const file = path.join(path.dirname(devfilePath), '.odo', 'devstate.json');
-    return JSON.parse(await fs.readFile(file, 'utf-8'));
-  } catch {
-    return null;
+function findManagedBy(resources: DeployedResource[]): string | undefined {
+  for (const resource of resources) {
+    const value = resource.labels?.['app.kubernetes.io/managed-by'];
+    if (value) return value;
   }
+  return undefined;
 }
 
 function extractK8sErrorMessage(err: unknown): string {
@@ -472,11 +474,17 @@ function appendContainerComponents(lines: string[], components: ComponentItem[],
   for (const comp of containers) {
     const cont = comp.container as Container;
     lines.push(` •  ${comp.name}`);
-    lines.push(`    ${bold('Source Mapping:')} /projects`);
+    lines.push(`    ${bold('Source Mapping:')} ${cont.sourceMapping ?? '/projects'}`);
     if (cont.endpoints?.length) {
       lines.push(`    ${bold('Endpoints:')}`);
       for (const ep of cont.endpoints) {
         lines.push(`      - ${ep.name} (${ep.targetPort})`);
+      }
+    }
+    if (cont.env?.length) {
+      lines.push(`    ${bold('Environment Variables:')}`);
+      for (const envVar of cont.env) {
+        lines.push(`      - ${envVar.name}=${envVar.value}`);
       }
     }
 
@@ -616,7 +624,7 @@ function detectSupportedFeatures(commands: any[]) {
   };
 }
 
-function extractForwardedPortsFromDevState(devState): ForwardedPort[] {
+function extractForwardedPortsFromDevState(devState: DevState): ForwardedPort[] {
   if (!devState?.forwardedPorts) return [];
 
   const runtime = devState.platform ?? 'unknown';

--- a/src/devfile/dev.ts
+++ b/src/devfile/dev.ts
@@ -1,0 +1,87 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { Data, DevState } from './componentTypeDescription';
+import { DevPlatformOutput } from './inner-loop/devPlatform';
+import { DevSession, DevSessionOptions } from './inner-loop/devSession';
+import { clearDevState, saveDevState } from './inner-loop/devStateFile';
+import { ComponentWorkspaceFolder } from '../odo/workspace';
+
+/**
+ * Sessions started by this extension instance, keyed by component context path. Not reconstructed
+ * from `.odo/devstate.json` across extension-host restarts — that file is read-only bookkeeping for
+ * `describe.ts`/`openInBrowser`/the debugger-attach flow, not something a live session (platform
+ * client handles, running processes) can be rebuilt from. This matches the previous CLI-shell-out
+ * behavior, which only ever tracked the running `odo dev` pty in-memory too.
+ */
+const activeSessions = new Map<string, DevSession>();
+
+export function isDevSessionActive(componentPath: string): boolean {
+    return activeSessions.has(componentPath);
+}
+
+export async function startDevSession(
+    devfile: Data,
+    componentFolder: ComponentWorkspaceFolder,
+    options: DevSessionOptions,
+    output: DevPlatformOutput,
+): Promise<void> {
+    const componentPath = componentFolder.contextPath;
+    if (activeSessions.has(componentPath)) {
+        throw new Error(`A dev session is already running for '${componentPath}'`);
+    }
+
+    const session = new DevSession(devfile, componentFolder, options);
+    const platformSession = await session.start(output);
+    activeSessions.set(componentPath, session);
+
+    const devState: DevState = {
+        pid: platformSession.pid,
+        platform: platformSession.kind,
+        forwardedPorts: platformSession.forwardedPorts,
+        apiServerPort: platformSession.apiServerPort,
+    };
+    await saveDevState(devState, componentPath);
+}
+
+export async function stopDevSession(componentPath: string): Promise<void> {
+    const session = activeSessions.get(componentPath);
+    if (!session) {
+        return;
+    }
+    try {
+        await session.stop();
+    } finally {
+        activeSessions.delete(componentPath);
+        await clearDevState(componentPath);
+    }
+}
+
+/**
+ * Same teardown as `stopDevSession()`, but never throws and always clears local session state —
+ * for the "keep waiting or force exit" UI flow, where the user has already indicated they want to
+ * move on regardless of whether cleanup fully succeeds.
+ */
+export async function forceStopDevSession(componentPath: string): Promise<void> {
+    const session = activeSessions.get(componentPath);
+    activeSessions.delete(componentPath);
+    await clearDevState(componentPath).catch(() => { /* best-effort */ });
+    if (session) {
+        await session.stop().catch(() => { /* best-effort */ });
+    }
+}
+
+/**
+ * Manually trigger a full file sync and rebuild for an active dev session.
+ * Useful for "Sync Files" command or to bypass the file watcher's debounce.
+ * Throws if no session is active for the given component.
+ */
+export async function syncDevSession(componentPath: string): Promise<void> {
+    const session = activeSessions.get(componentPath);
+    if (!session) {
+        throw new Error(`No active dev session for '${componentPath}'`);
+    }
+    await session.manualSync();
+}

--- a/src/devfile/devfileCommandRunner.ts
+++ b/src/devfile/devfileCommandRunner.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { ComponentWorkspaceFolder } from '../odo/workspace';
-import { Command } from '../odo/componentTypeDescription';
+import { Command } from './componentTypeDescription';
 import { ApplyCommandExecutor } from './applyCommand';
 import { CommandResolver } from './commandResolver';
 import { ExecCommandExecutor } from './execCommand';

--- a/src/devfile/execCommand.ts
+++ b/src/devfile/execCommand.ts
@@ -5,7 +5,7 @@
 
 import { CommandOption, CommandText } from '../base/command';
 import { Oc } from '../oc/ocWrapper';
-import { Exec } from '../odo/componentTypeDescription';
+import { Exec } from './componentTypeDescription';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
 import { OpenShiftTerminalManager } from '../webview/openshift-terminal/openShiftTerminal';
 import { DevfileResolver } from './devfileResolver';

--- a/src/devfile/init.ts
+++ b/src/devfile/init.ts
@@ -11,7 +11,7 @@ import { Archive } from '../downloadUtil/archive';
 import { DownloadUtil } from '../downloadUtil/download';
 import type {
     Data
-} from '../odo/componentTypeDescription';
+} from './componentTypeDescription';
 import { OdoPreference } from '../odo/odoPreference';
 import { OpenshiftLogger } from '../util/utils';
 import { cloneRepository } from '../util/git';

--- a/src/devfile/inner-loop/clusterDevPlatform.ts
+++ b/src/devfile/inner-loop/clusterDevPlatform.ts
@@ -1,0 +1,311 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { KubeConfig } from '@kubernetes/client-node';
+import * as fs from 'fs/promises';
+import { Ignore } from 'ignore';
+import * as path from 'path';
+import { Oc } from '../../oc/ocWrapper';
+import { ComponentWorkspaceFolder } from '../../odo/workspace';
+import { CommandResolver } from '../commandResolver';
+import { Data, DevStateForwardedPort } from '../componentTypeDescription';
+import { getCurrentClusterAndNamespace } from '../deployStateFile';
+import { pushFiles, removeFiles } from './containerSync';
+import { executeBuildCommand, RunCommandHandle, startRunCommand } from './devCommandExec';
+import { DevPlatform, DevPlatformKind, DevPlatformOutput, DevPlatformSession } from './devPlatform';
+import { ActivePortForward, startPortForwards, stopPortForwards } from './devPortForward';
+import { buildDevResources } from './devResourceBuilder';
+import { resolveIgnoreRules } from './fileSync';
+
+interface ClusterDevSession extends DevPlatformSession {
+    readonly kind: 'cluster';
+    readonly kc: KubeConfig;
+    readonly namespace: string;
+    readonly componentName: string;
+    readonly podName: string;
+    readonly containerName: string;
+    readonly hasService: boolean;
+    readonly componentPath: string;
+    readonly sourceMapping: string;
+    readonly workingDir: string;
+    readonly commandLine: string;
+    readonly devfile: Data;
+    activeForwards: ActivePortForward[];
+    runCommandHandle: RunCommandHandle;
+}
+
+export class ClusterDevPlatform implements DevPlatform {
+    readonly kind: DevPlatformKind = 'cluster';
+
+    async start(
+        devfile: Data,
+        componentFolder: ComponentWorkspaceFolder,
+        options: { debug?: boolean },
+        output: DevPlatformOutput,
+    ): Promise<DevPlatformSession> {
+        const componentName = devfile.metadata.name;
+
+        // Get namespace info for header
+        const kc = new KubeConfig();
+        kc.loadFromDefault();
+        const { namespace } = await getCurrentClusterAndNamespace();
+
+        // Output header similar to odo
+        output.onOutput(`Developing using the "${componentName}" Devfile`);
+        output.onOutput(`Namespace: ${namespace}`);
+        output.onOutput('');
+        output.onOutput('Running on the cluster in Dev mode');
+        output.onOutput('');
+
+        // Create deployment and service
+        output.onOutput('Creating pod...');
+        try {
+            const { deployment, service } = buildDevResources(devfile);
+            await Oc.Instance.applyConfiguration(JSON.stringify(deployment));
+            if (service) {
+                await Oc.Instance.applyConfiguration(JSON.stringify(service));
+            }
+
+            const podName = await waitForComponentPodReady(componentName);
+            output.onOutput('Pod is Running');
+            output.onOutput('');
+
+            const groupKind = options.debug ? 'debug' : 'run';
+            const { containerName, sourceMapping, workingDir, commandLine, containerComponent } =
+                CommandResolver.resolveRunCommand(devfile, groupKind);
+
+            // Sync files to container
+            const ignoreRules = await resolveIgnoreRules(componentFolder.contextPath);
+            const allFiles = await listSyncableFiles(componentFolder.contextPath, ignoreRules);
+            output.onOutput(`Syncing files into the container (${allFiles.length} files)...`);
+            try {
+                await pushFiles(kc, namespace, podName, containerName, componentFolder.contextPath, sourceMapping, allFiles);
+                output.onOutput('Syncing files completed');
+                output.onOutput('');
+            } catch (err) {
+                output.onOutput(`Failed to sync files: ${err.message}`);
+                throw err;
+            }
+
+            // Execute build command if defined (e.g., npm install, pip install, mvn install, go build)
+            const buildCommand = CommandResolver.findCommandByGroup(devfile, 'build');
+            if (buildCommand?.exec) {
+                output.onOutput('Building your application in container (command: build)...');
+                try {
+                    const buildResolved = CommandResolver.resolveRunCommand(devfile, 'build');
+                    await executeBuildCommand(
+                        kc, namespace, podName, buildResolved.containerName, buildResolved.workingDir, buildResolved.commandLine,
+                        chunk => output.onOutput(chunk),
+                        buildResolved.env,
+                    );
+                    output.onOutput('Build completed');
+                    output.onOutput('');
+                } catch (err) {
+                    output.onOutput(`Build failed: ${err.message}`);
+                    throw err;
+                }
+            }
+
+            // Start run/debug command
+            output.onOutput(`Executing the application (command: ${groupKind})...`);
+            try {
+                const runCommandHandle = await startRunCommand(
+                    kc, namespace, podName, containerName, workingDir, commandLine,
+                    chunk => output.onOutput(chunk),
+                    code => {
+                        // Only log unexpected exit codes (0, 143=SIGTERM, 137=SIGKILL are expected)
+                        if (code !== 0 && code !== 143 && code !== 137) {
+                            output.onOutput(`Command exited with code ${code}`);
+                        }
+                    },
+                );
+
+                // Set up port forwarding
+                const endpoints = containerComponent?.container?.endpoints ?? [];
+                const forwards = await startPortForwards(kc, namespace, podName, endpoints.map(e => e.targetPort));
+
+                // Show port forwarding info with clickable URLs for HTTP endpoints
+                const forwardedPortsState = buildForwardedPortState(containerName, endpoints, forwards);
+                for (const port of forwardedPortsState) {
+                    if (port.isDebug) {
+                        output.onOutput(`Debug port: ${port.localAddress}:${port.localPort} -> ${port.containerPort}`);
+                    } else {
+                        // Always use http:// for local port forwards (they're plain TCP tunnels, not TLS)
+                        output.onOutput(`Forwarding from http://${port.localAddress}:${port.localPort} -> ${port.containerPort}`);
+                    }
+                }
+
+                output.onOutput('');
+                output.onOutput('Press Ctrl-C to stop dev mode');
+
+                const session: ClusterDevSession = {
+                    kind: 'cluster',
+                    pid: process.pid,
+                    forwardedPorts: buildForwardedPortState(containerName, endpoints, forwards),
+                    kc,
+                    namespace,
+                    componentName,
+                    podName,
+                    containerName,
+                    hasService: service ? true : false,
+                    componentPath: componentFolder.contextPath,
+                    sourceMapping,
+                    workingDir,
+                    commandLine,
+                    devfile,
+                    activeForwards: forwards,
+                    runCommandHandle,
+                };
+
+                return session;
+            } catch (err) {
+                output.onOutput(`Failed to start application: ${err.message}`);
+                throw err;
+            }
+        } catch (err) {
+            output.onOutput(`Failed to create pod: ${err.message}`);
+            throw err;
+        }
+    }
+
+    async sync(session: DevPlatformSession, changedPaths: string[], deletedPaths: string[]): Promise<void> {
+        const s = session as ClusterDevSession;
+        await pushFiles(s.kc, s.namespace, s.podName, s.containerName, s.componentPath, s.sourceMapping, changedPaths);
+        await removeFiles(s.kc, s.namespace, s.podName, s.containerName, s.sourceMapping, deletedPaths);
+    }
+
+    async restartRunCommand(session: DevPlatformSession): Promise<void> {
+        const s = session as ClusterDevSession;
+
+        // Run build command before restarting (e.g., npm install, go build)
+        const buildCommand = CommandResolver.findCommandByGroup(s.devfile, 'build');
+        if (buildCommand?.exec) {
+            const buildResolved = CommandResolver.resolveRunCommand(s.devfile, 'build');
+            await executeBuildCommand(
+                s.kc, s.namespace, s.podName, buildResolved.containerName, buildResolved.workingDir, buildResolved.commandLine,
+                () => { /* output callback is only wired at start() time */ },
+                buildResolved.env,
+            );
+        }
+
+        await s.runCommandHandle.stop();
+        s.runCommandHandle = await startRunCommand(
+            s.kc, s.namespace, s.podName, s.containerName, s.workingDir, s.commandLine,
+            () => { /* output callback is only wired at start() time in this first pass */ },
+            () => { /* see above */ },
+        );
+    }
+
+    async stop(session: DevPlatformSession, output?: DevPlatformOutput): Promise<void> {
+        const s = session as ClusterDevSession;
+
+        if (output) {
+            output.onOutput('');
+            output.onOutput('Stopping dev mode...');
+        }
+
+        try {
+            if (output) {
+                output.onOutput('Stopping port forwards...');
+            }
+            stopPortForwards(s.activeForwards);
+
+            if (output) {
+                output.onOutput('Stopping application...');
+            }
+            await s.runCommandHandle.stop().catch(() => {
+                // best-effort — deleting the Deployment below is what actually stops the container
+            });
+
+            if (output) {
+                output.onOutput('Cleaning up resources...');
+            }
+            await Oc.Instance.deleteKubernetesObject('deployment', s.componentName, s.namespace).catch(() => {});
+            if (s.hasService) {
+                await Oc.Instance.deleteKubernetesObject('service', s.componentName, s.namespace).catch(() => {});
+            }
+
+            if (output) {
+                output.onOutput('Dev mode stopped');
+            }
+        } catch (err) {
+            if (output) {
+                output.onOutput(`Error during cleanup: ${err.message}`);
+            }
+            // Don't rethrow - cleanup is best-effort
+        }
+    }
+}
+
+function buildForwardedPortState(
+    containerName: string,
+    endpoints: { name: string; targetPort: number; exposure?: string }[],
+    forwards: ActivePortForward[],
+): DevStateForwardedPort[] {
+    return forwards.map(forward => {
+        const endpoint = endpoints.find(e => e.targetPort === forward.containerPort);
+        return {
+            containerName,
+            portName: endpoint?.name,
+            isDebug: endpoint?.name?.startsWith('debug'),
+            localAddress: '127.0.0.1',
+            localPort: forward.localPort,
+            containerPort: forward.containerPort,
+            exposure: endpoint?.exposure,
+        };
+    });
+}
+
+async function waitForComponentPodReady(componentName: string, timeoutMs = 120000): Promise<string> {
+    const start = Date.now();
+    let lastError: unknown;
+
+    while (Date.now() - start < timeoutMs) {
+        try {
+            const podName = await Oc.Instance.getComponentPod(componentName);
+            const pod = await Oc.Instance.getKubernetesObject('pod', podName) as any;
+
+            if (pod?.status?.phase === 'Running' && pod.status.containerStatuses?.every((cs: any) => cs.ready)) {
+                return podName;
+            }
+        } catch (err) {
+            lastError = err;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+    throw new Error(
+        `Timed out waiting for the dev pod for '${componentName}' to become ready${lastError ? `: ${lastError}` : ''}`,
+    );
+}
+
+export async function listSyncableFiles(rootDir: string, ignoreRules: Ignore): Promise<string[]> {
+    const results: string[] = [];
+
+    async function walk(dir: string, relativeDir: string): Promise<void> {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+
+        for (const entry of entries) {
+            const relativePath = path.join(relativeDir, entry.name);
+            const relativePosixPath = relativePath.split(path.sep).join('/');
+
+            if (entry.isDirectory()) {
+                if (ignoreRules.ignores(`${relativePosixPath}/`)) {
+                    continue;
+                }
+                await walk(path.join(dir, entry.name), relativePath);
+            } else if (entry.isFile()) {
+                if (ignoreRules.ignores(relativePosixPath)) {
+                    continue;
+                }
+                results.push(relativePath);
+            }
+        }
+    }
+
+    await walk(rootDir, '');
+    return results;
+}

--- a/src/devfile/inner-loop/containerSync.ts
+++ b/src/devfile/inner-loop/containerSync.ts
@@ -1,0 +1,206 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { Exec, KubeConfig, V1Status } from '@kubernetes/client-node';
+import { PassThrough, Readable, Writable } from 'stream';
+import * as tar from 'tar-fs';
+
+function collectingStderr(): { stream: Writable; text: () => string } {
+    const chunks: Buffer[] = [];
+    const stream = new Writable({
+        write(chunk, _encoding, callback) {
+            chunks.push(Buffer.from(chunk));
+            callback();
+        },
+    });
+    return { stream, text: () => Buffer.concat(chunks).toString('utf-8') };
+}
+
+/**
+ * Runs a short-lived command in a container and resolves only once it has actually finished
+ * (via the exec status callback), not merely once the exec connection is established — the
+ * `@kubernetes/client-node` `Cp` helper resolves too early for this to be safe to rely on.
+ *
+ * Includes a timeout to prevent infinite hangs if the kubernetes API client doesn't invoke
+ * the status callback (network issues, API server problems, etc.).
+ */
+async function execAndWait(
+    kc: KubeConfig,
+    namespace: string,
+    podName: string,
+    containerName: string,
+    command: string[],
+    stdin: Readable | null = null,
+    timeoutMs = 300000,  // 5 minute default timeout
+): Promise<void> {
+    const exec = new Exec(kc);
+    const stderr = collectingStderr();
+
+    const execPromise = new Promise<void>((resolve, reject) => {
+        exec.exec(
+            namespace, podName, containerName, command,
+            null, stderr.stream, stdin, false,
+            (status: V1Status) => {
+                if (status.status === 'Failure') {
+                    const stderrText = stderr.text();
+                    const errorMsg = status.message ||
+                        (stderrText ? `Command failed: ${command.join(' ')}\nStderr: ${stderrText}` : `Command failed: ${command.join(' ')}`);
+                    reject(new Error(errorMsg));
+                } else {
+                    resolve();
+                }
+            },
+        ).catch(reject);
+    });
+
+    const timeoutPromise = new Promise<void>((_, reject) => {
+        setTimeout(() => {
+            const stderrText = stderr.text();
+            const errorMsg = `Timeout after ${timeoutMs}ms executing command in pod ${podName}: ${command.join(' ')}${stderrText ? `\nStderr: ${stderrText}` : ''}`;
+            reject(new Error(errorMsg));
+        }, timeoutMs);
+    });
+
+    await Promise.race([execPromise, timeoutPromise]);
+}
+
+function toContainerPath(targetDir: string, relativePath: string): string {
+    return `${targetDir.replace(/\/+$/, '')}/${relativePath.replace(/^\/+/, '')}`;
+}
+
+/**
+ * Packs the given paths (relative to `localRoot`) into a tar stream and extracts it into
+ * `targetDir` inside the running container. A no-op if `relativePaths` is empty.
+ */
+export async function pushFiles(
+    kc: KubeConfig,
+    namespace: string,
+    podName: string,
+    containerName: string,
+    localRoot: string,
+    targetDir: string,
+    relativePaths: string[],
+): Promise<void> {
+    if (relativePaths.length === 0) {
+        return;
+    }
+
+    // Create tar stream with normalized permissions
+    const tarStream = tar.pack(localRoot, {
+        entries: relativePaths,
+        map: (header) => {
+            // Strip setuid/setgid/sticky bits and use safe permissions to avoid
+            // "Operation not permitted" errors when extracting to container directories we don't own
+            if (header.type === 'directory') {
+                header.mode = 0o755;
+            } else if (header.type === 'file') {
+                header.mode = 0o644;
+            }
+            return header;
+        },
+    });
+
+    // Buffer the entire tar stream
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve, reject) => {
+        tarStream.on('data', (chunk) => chunks.push(chunk));
+        tarStream.on('end', () => resolve());
+        tarStream.on('error', reject);
+    });
+
+    const tarBuffer = Buffer.concat(chunks);
+    const markerFile = `/tmp/.sync-marker-${Date.now()}`;
+
+    // Clean up any stale marker files from previous interrupted syncs
+    const cleanupExec = new Exec(kc);
+    cleanupExec.exec(
+        namespace, podName, containerName,
+        ['sh', '-c', 'rm -f /tmp/.sync-marker-*'],
+        null, null, null, false,
+        () => { /* best effort cleanup */ }
+    );
+    // Give cleanup a moment to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Kubernetes client-node exec has a known issue where the status callback doesn't fire
+    // when using stdin streams, even after the command completes successfully. Instead, we
+    // use a marker file approach: tar creates a marker file when complete, then we poll for it.
+    const exec = new Exec(kc);
+    const stderr = collectingStderr();
+    const stdinStream = new PassThrough();
+
+    // Extract tar and create marker file on success
+    // Timestamp in filename is unique enough since we clean up old markers before starting
+    exec.exec(
+        namespace, podName, containerName,
+        ['sh', '-c', `tar xf - -C ${targetDir} --no-overwrite-dir && echo DONE > ${markerFile}`],
+        null, stderr.stream, stdinStream, false,
+        () => { /* callback never reliably fires with stdin streams */ }
+    );
+
+    stdinStream.end(tarBuffer);
+
+    // Poll for marker file to confirm completion (60s timeout, 500ms interval)
+    const startTime = Date.now();
+    const timeoutMs = 60000;
+    const pollIntervalMs = 1000;
+
+    while (Date.now() - startTime < timeoutMs) {
+        await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+
+        // Check if marker file exists
+        const checkResult = await new Promise<boolean>((resolve) => {
+            const checkExec = new Exec(kc);
+            const checkStderr = collectingStderr();
+            checkExec.exec(
+                namespace, podName, containerName,
+                ['test', '-f', markerFile],
+                null, checkStderr.stream, null, false,
+                (status: V1Status) => {
+                    resolve(status.status !== 'Failure');
+                }
+            );
+        });
+
+        if (checkResult) {
+            // Marker found - tar completed successfully
+            // Clean up marker file (best effort)
+            const cleanupExec = new Exec(kc);
+            cleanupExec.exec(
+                namespace, podName, containerName,
+                ['rm', '-f', markerFile],
+                null, null, null, false,
+                () => { /* best effort cleanup */ }
+            );
+            return;
+        }
+    }
+
+    // Timeout - check stderr for clues
+    const stderrText = stderr.text();
+    throw new Error(
+        `Timeout after ${timeoutMs}ms waiting for tar extraction to complete in pod ${podName}${stderrText ? `\nStderr: ${stderrText}` : ''}`
+    );
+}
+
+/**
+ * Removes the given paths (relative to `targetDir`) from the running container. A no-op if
+ * `relativePaths` is empty.
+ */
+export async function removeFiles(
+    kc: KubeConfig,
+    namespace: string,
+    podName: string,
+    containerName: string,
+    targetDir: string,
+    relativePaths: string[],
+): Promise<void> {
+    if (relativePaths.length === 0) {
+        return;
+    }
+
+    const containerPaths = relativePaths.map(p => toContainerPath(targetDir, p));
+    await execAndWait(kc, namespace, podName, containerName, ['rm', '-rf', ...containerPaths]);
+}

--- a/src/devfile/inner-loop/devCommandExec.ts
+++ b/src/devfile/inner-loop/devCommandExec.ts
@@ -1,0 +1,167 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { Exec, KubeConfig, V1Status } from '@kubernetes/client-node';
+import { Writable } from 'stream';
+
+/**
+ * Well-known path used to record the run command's PID inside the container. `pkill`/`ps` are
+ * not reliably present in minimal/UBI-based images, but a POSIX shell's builtin `kill` always is
+ * — so `start` records the PID via `echo $$ > PID_FILE && exec <command>` (the `exec` replaces
+ * the shell in place, so the recorded PID stays valid for the actual command process), and `stop`
+ * reads it back and kills it, no external binary required.
+ */
+const PID_FILE = '/tmp/.odo-dev-run.pid';
+
+function shellQuote(value: string): string {
+    return `'${value.replace(/'/g, String.raw`'\''`)}'`;
+}
+
+export interface RunCommandHandle {
+    /**
+     * Best-effort stop: kills the process recorded in `PID_FILE`. The dev session's own teardown
+     * (deleting the Deployment) remains the reliable way to actually stop the container.
+     */
+    stop(): Promise<void>;
+}
+
+function callbackWritable(onData: (chunk: string) => void): Writable {
+    return new Writable({
+        write(chunk, _encoding, callback) {
+            onData(chunk.toString('utf-8'));
+            callback();
+        },
+    });
+}
+
+function extractExitCode(status: V1Status): number | null {
+    if (status.status === 'Success') {
+        return 0;
+    }
+
+    const cause = status.details?.causes?.find(c => c.reason === 'ExitCode');
+    const parsed = cause?.message ? Number(cause.message) : NaN;
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Normalizes a devfile command line by removing backslash-newline continuations that appear
+ * in YAML multiline strings. These are literal characters in the YAML but need to be collapsed
+ * into a single line for `sh -c` execution.
+ */
+function normalizeCommandLine(commandLine: string): string {
+    return commandLine.replace(/\\\s*\n\s*/g, ' ').trim();
+}
+
+/**
+ * Wraps a command line for execution with `exec`, handling leading environment variable
+ * assignments properly. Shell syntax like `VAR=value command` works directly, but
+ * `exec VAR=value command` does not — exec doesn't process env assignments. We need
+ * `exec env VAR=value command` instead.
+ */
+function wrapForExec(commandLine: string): string {
+    // Match leading environment variable assignments: VAR=value (repeated, space-separated)
+    const envVarPattern = /^(\s*[A-Z_][A-Z0-9_]*=[^\s]+\s+)+/i;
+    const match = commandLine.match(envVarPattern);
+
+    if (match) {
+        const envPart = match[0].trim();
+        const cmdPart = commandLine.slice(match[0].length).trim();
+        return `env ${envPart} ${cmdPart}`;
+    }
+
+    return commandLine;
+}
+
+/**
+ * Executes a devfile build command inside a running container and waits for it to complete.
+ * Throws if the command fails (non-zero exit code). Streams stdout/stderr via `onOutput`.
+ */
+export async function executeBuildCommand(
+    kc: KubeConfig,
+    namespace: string,
+    podName: string,
+    containerName: string,
+    workingDir: string,
+    commandLine: string,
+    onOutput: (chunk: string) => void,
+    env?: Array<{ name: string; value: string }>,
+): Promise<void> {
+    const exec = new Exec(kc);
+    const normalized = normalizeCommandLine(commandLine);
+
+    // Prepend environment variable exports if provided
+    let shellCommand = `cd ${workingDir}`;
+    if (env && env.length > 0) {
+        const envExports = env.map(e => `export ${e.name}=${shellQuote(e.value)}`).join(' && ');
+        shellCommand = `${shellCommand} && ${envExports} && ${normalized}`;
+    } else {
+        shellCommand = `${shellCommand} && ${normalized}`;
+    }
+
+    return new Promise<void>((resolve, reject) => {
+        exec.exec(
+            namespace, podName, containerName, ['sh', '-c', shellCommand],
+            callbackWritable(onOutput), callbackWritable(onOutput), null, false,
+            (status: V1Status) => {
+                const exitCode = extractExitCode(status);
+                if (exitCode === 0) {
+                    resolve();
+                } else {
+                    reject(new Error(`Build command failed with exit code ${exitCode}`));
+                }
+            },
+        ).catch(reject);
+    });
+}
+
+/**
+ * Starts the devfile "run"/"debug" command inside a running container and streams its combined
+ * stdout/stderr via `onOutput`. Resolves once the exec connection is established — the command
+ * itself keeps running in the background; `onExit` is called when it terminates.
+ */
+export async function startRunCommand(
+    kc: KubeConfig,
+    namespace: string,
+    podName: string,
+    containerName: string,
+    workingDir: string,
+    commandLine: string,
+    onOutput: (chunk: string) => void,
+    onExit: (code: number | null) => void,
+): Promise<RunCommandHandle> {
+    const exec = new Exec(kc);
+    const normalized = normalizeCommandLine(commandLine);
+    const wrapped = wrapForExec(normalized);
+    const shellCommand = `cd ${workingDir} && echo $$ > ${PID_FILE} && exec ${wrapped}`;
+
+    await exec.exec(
+        namespace, podName, containerName, ['sh', '-c', shellCommand],
+        callbackWritable(onOutput), callbackWritable(onOutput), null, false,
+        (status: V1Status) => onExit(extractExitCode(status)),
+    );
+
+    return {
+        stop: async () => {
+            // Wait for the kill command to actually run (via the status callback), not just for
+            // the exec connection to open — `Exec.exec()`'s own promise resolves on connect, which
+            // is too early: the underlying connection can be torn down before a same-tick "kill"
+            // command has actually been dispatched server-side.
+            //
+            // At least one of stdin/stdout/stderr must be non-null or the Kubernetes exec API
+            // rejects the request outright ("unable to upgrade connection: you must specify at
+            // least 1 of stdin, stdout, stderr") — which surfaces as a "Failure" status, not a
+            // rejected promise, so it must be handled in the status callback, not swallowed.
+            await new Promise<void>(resolve => {
+                const killExec = new Exec(kc);
+                killExec.exec(
+                    namespace, podName, containerName, ['sh', '-c', `kill $(cat ${PID_FILE})`],
+                    null, callbackWritable(() => { /* best-effort; see stop() doc comment */ }), null, false,
+                    () => resolve(),
+                ).catch(() => resolve());
+            });
+        },
+    };
+}

--- a/src/devfile/inner-loop/devPlatform.ts
+++ b/src/devfile/inner-loop/devPlatform.ts
@@ -1,0 +1,71 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { ComponentWorkspaceFolder } from '../../odo/workspace';
+import { Data, DevStateForwardedPort } from '../componentTypeDescription';
+
+export type DevPlatformKind = 'cluster' | 'podman';
+
+/**
+ * Resolves which platform a dev session should target, matching the `runOn` parameter shape
+ * already used by `component.ts`'s `devRunOn()`.
+ */
+export function resolveDevPlatformKind(runOn?: 'podman'): DevPlatformKind {
+    return runOn === 'podman' ? 'podman' : 'cluster';
+}
+
+export interface DevPlatformOutput {
+    onOutput(line: string): void;
+}
+
+/**
+ * Everything a running dev session needs to persist to `.odo/devstate.json` (see
+ * `devStateFile.ts`) and expose to the rest of the extension (describe, openInBrowser, debugger
+ * attach) — deliberately shaped to match `DevState` directly rather than inventing a parallel type.
+ */
+export interface DevPlatformSession {
+    readonly kind: DevPlatformKind;
+    readonly pid: number;
+    forwardedPorts: DevStateForwardedPort[];
+    apiServerPort?: number;
+}
+
+/**
+ * A target dev session runs against — either a real cluster (OpenShift/Kubernetes) or a local
+ * podman/docker container runtime. Implementations: `clusterDevPlatform.ts`, `podmanDevPlatform.ts`.
+ *
+ * This is the contract `devSession.ts` depends on; each implementation is free to orchestrate its
+ * own resource creation, file sync, command execution, and port-forwarding internally.
+ */
+export interface DevPlatform {
+    readonly kind: DevPlatformKind;
+
+    /**
+     * Brings up the component's dev container(s), performs the initial file sync, and starts the
+     * devfile "run" (or "debug") command inside it. Resolves once the run command has been
+     * launched — `forwardedPorts` on the returned session are only meaningful after that.
+     */
+    start(
+        devfile: Data,
+        componentFolder: ComponentWorkspaceFolder,
+        options: { debug?: boolean },
+        output: DevPlatformOutput,
+    ): Promise<DevPlatformSession>;
+
+    /**
+     * Pushes local file changes into the running container(s). A no-op on platforms with a live
+     * bind mount to the workspace folder (podman).
+     */
+    sync(session: DevPlatformSession, changedPaths: string[], deletedPaths: string[]): Promise<void>;
+
+    /**
+     * Restarts the devfile "run"/"debug" command in place — used after a sync when the command
+     * isn't hot-reload capable.
+     */
+    restartRunCommand(session: DevPlatformSession): Promise<void>;
+
+    /** Tears down whatever `start` created. Optionally reports progress via output. */
+    stop(session: DevPlatformSession, output?: DevPlatformOutput): Promise<void>;
+}

--- a/src/devfile/inner-loop/devPortForward.ts
+++ b/src/devfile/inner-loop/devPortForward.ts
@@ -1,0 +1,69 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { KubeConfig, PortForward } from '@kubernetes/client-node';
+import * as net from 'net';
+import { buildUsablePortPair } from '../../port-forward';
+
+export interface ActivePortForward {
+    readonly localPort: number;
+    readonly containerPort: number;
+    dispose(): void;
+}
+
+/**
+ * Forwards a single container port on a running pod to a free local port, using
+ * @kubernetes/client-node's native PortForward (no `oc`/`kubectl` subprocess).
+ */
+export async function startPodPortForward(
+    kc: KubeConfig,
+    namespace: string,
+    podName: string,
+    containerPort: number,
+): Promise<ActivePortForward> {
+    const { localPort } = await buildUsablePortPair({ targetPort: containerPort });
+
+    const portForward = new PortForward(kc);
+    const server = net.createServer((socket) => {
+        void portForward.portForward(namespace, podName, [containerPort], socket, null, socket).catch(() => {
+            socket.destroy();
+        });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(localPort, '127.0.0.1', () => {
+            server.removeListener('error', reject);
+            resolve();
+        });
+    });
+
+    return {
+        localPort,
+        containerPort,
+        dispose: () => server.close(),
+    };
+}
+
+export async function startPortForwards(
+    kc: KubeConfig,
+    namespace: string,
+    podName: string,
+    containerPorts: number[],
+): Promise<ActivePortForward[]> {
+    const forwards: ActivePortForward[] = [];
+
+    for (const containerPort of containerPorts) {
+        forwards.push(await startPodPortForward(kc, namespace, podName, containerPort));
+    }
+
+    return forwards;
+}
+
+export function stopPortForwards(forwards: ActivePortForward[]): void {
+    for (const forward of forwards) {
+        forward.dispose();
+    }
+}

--- a/src/devfile/inner-loop/devResourceBuilder.ts
+++ b/src/devfile/inner-loop/devResourceBuilder.ts
@@ -1,0 +1,196 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { ComponentItem, Container, Data } from '../componentTypeDescription';
+import { VariableResolver } from '../variableResolver';
+
+const SOURCE_VOLUME_NAME = 'devfile-source';
+const DEFAULT_SOURCE_MAPPING = '/projects';
+
+/**
+ * Keeps a mountSources container alive without running its image's default entrypoint, so the
+ * devfile "run"/"debug" command can be exec'd into it once source files are synced.
+ */
+const KEEP_ALIVE_COMMAND = ['tail', '-f', '/dev/null'];
+
+export interface DevResources {
+    deployment: Record<string, any>;
+    service?: Record<string, any>;
+}
+
+/**
+ * Builds the Kubernetes Deployment (and, if the devfile declares any endpoints, Service)
+ * manifests used to run a component in cluster-based dev mode.
+ *
+ * Pure transform: does not talk to the cluster. Volume devfile components are backed by an
+ * ephemeral emptyDir rather than a PersistentVolumeClaim — dev sessions are short-lived, and PVC
+ * lifecycle (create/wait-for-bound/delete) belongs to the platform orchestrator, not this builder.
+ */
+export function buildDevResources(devfile: Data): DevResources {
+    const componentName = devfile.metadata.name;
+    const labels = devResourceLabels(componentName);
+
+    const containerComponents = (devfile.components ?? []).filter((c): c is ComponentItem & { container: Container } => !!c.container);
+
+    if (containerComponents.length === 0) {
+        throw new Error('Devfile has no container components to run in dev mode');
+    }
+
+    const volumeComponentNames = new Set(
+        (devfile.components ?? []).filter(c => c.volume).map(c => c.name)
+    );
+
+    const containers = containerComponents.map(c => buildContainer(devfile, c));
+    const volumes = buildVolumes(containerComponents, volumeComponentNames);
+
+    const deployment = {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: {
+            name: componentName,
+            labels,
+        },
+        spec: {
+            replicas: 1,
+            selector: { matchLabels: { 'app.kubernetes.io/instance': componentName } },
+            template: {
+                metadata: { labels },
+                spec: {
+                    containers,
+                    volumes,
+                },
+            },
+        },
+    };
+
+    const servicePorts = buildServicePorts(containerComponents);
+
+    const service = servicePorts.length > 0
+        ? {
+            apiVersion: 'v1',
+            kind: 'Service',
+            metadata: {
+                name: componentName,
+                labels,
+            },
+            spec: {
+                selector: { 'app.kubernetes.io/instance': componentName },
+                ports: servicePorts,
+            },
+        }
+        : undefined;
+
+    return { deployment, service };
+}
+
+function devResourceLabels(componentName: string): Record<string, string> {
+    return {
+        'app.kubernetes.io/instance': componentName,
+        'app.kubernetes.io/managed-by': 'openshift-toolkit',
+        component: componentName,
+        'odo.dev/mode': 'dev',
+    };
+}
+
+function buildContainer(devfile: Data, item: ComponentItem & { container: Container }): Record<string, any> {
+    const container = item.container;
+    const mountsSource = container.mountSources !== false;
+
+    const env = (container.env ?? []).map(e => ({
+        name: e.name,
+        value: VariableResolver.resolveValue(devfile, e.value),
+    }));
+
+    const ports = (container.endpoints ?? []).map(ep => ({
+        name: ep.name,
+        containerPort: ep.targetPort,
+    }));
+
+    const volumeMounts: { name: string; mountPath: string }[] = [];
+
+    if (mountsSource) {
+        volumeMounts.push({
+            name: SOURCE_VOLUME_NAME,
+            mountPath: container.sourceMapping ?? DEFAULT_SOURCE_MAPPING,
+        });
+    }
+
+    for (const vm of container.volumeMounts ?? []) {
+        volumeMounts.push({ name: vm.name, mountPath: vm.path });
+    }
+
+    const k8sContainer: Record<string, any> = {
+        name: item.name,
+        image: container.image,
+        // Dev-mode runtime images are typically stable base images the user doesn't want
+        // re-pulled on every dev session restart (and, for :latest tags, k8s would otherwise
+        // default to `Always`, which also breaks locally-loaded images on Kind/Minikube).
+        imagePullPolicy: 'IfNotPresent',
+        env,
+        ports,
+        volumeMounts,
+    };
+
+    if (container.command?.length) {
+        k8sContainer.command = container.command.map(v => VariableResolver.resolveValue(devfile, v));
+    }
+    if (container.args?.length) {
+        k8sContainer.args = container.args.map(v => VariableResolver.resolveValue(devfile, v));
+    }
+    if (!container.command?.length && !container.args?.length && mountsSource) {
+        k8sContainer.command = KEEP_ALIVE_COMMAND;
+    }
+
+    if (container.memoryLimit) {
+        k8sContainer.resources = { limits: { memory: container.memoryLimit } };
+    }
+
+    return k8sContainer;
+}
+
+function buildVolumes(
+    containerComponents: (ComponentItem & { container: Container })[],
+    volumeComponentNames: Set<string>,
+): Record<string, any>[] {
+    const volumes: Record<string, any>[] = [
+        { name: SOURCE_VOLUME_NAME, emptyDir: {} },
+    ];
+
+    const referencedVolumeNames = new Set<string>();
+    for (const item of containerComponents) {
+        for (const vm of item.container.volumeMounts ?? []) {
+            referencedVolumeNames.add(vm.name);
+        }
+    }
+
+    for (const volumeName of referencedVolumeNames) {
+        if (volumeComponentNames.has(volumeName)) {
+            volumes.push({ name: volumeName, emptyDir: {} });
+        }
+    }
+
+    return volumes;
+}
+
+function buildServicePorts(containerComponents: (ComponentItem & { container: Container })[]): Record<string, any>[] {
+    const seen = new Set<string>();
+    const ports: Record<string, any>[] = [];
+
+    for (const item of containerComponents) {
+        for (const ep of item.container.endpoints ?? []) {
+            if (seen.has(ep.name)) continue;
+            seen.add(ep.name);
+
+            ports.push({
+                name: ep.name,
+                port: ep.targetPort,
+                targetPort: ep.targetPort,
+                protocol: 'TCP',
+            });
+        }
+    }
+
+    return ports;
+}

--- a/src/devfile/inner-loop/devSession.ts
+++ b/src/devfile/inner-loop/devSession.ts
@@ -1,0 +1,111 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { ComponentWorkspaceFolder } from '../../odo/workspace';
+import { CommandResolver } from '../commandResolver';
+import { Data } from '../componentTypeDescription';
+import { ClusterDevPlatform, listSyncableFiles } from './clusterDevPlatform';
+import { DevPlatform, DevPlatformKind, DevPlatformOutput, DevPlatformSession, resolveDevPlatformKind } from './devPlatform';
+import { ComponentFileWatcher, resolveIgnoreRules, watchComponentFiles } from './fileSync';
+import { PodmanDevPlatform } from './podmanDevPlatform';
+
+export interface DevSessionOptions {
+    debug?: boolean;
+    runOn?: 'podman';
+    /** Mirrors `odo dev --no-watch`: skip setting up the file watcher entirely. */
+    manualRebuild?: boolean;
+}
+
+/**
+ * Owns the lifecycle of one running dev session against whichever `DevPlatform` it targets:
+ * resolving which platform to use, starting/stopping it, and — once started — watching the
+ * component folder for changes and pushing them into the running session. Terminal-output
+ * bridging (`devTerminalBridge.ts`) doesn't exist yet — `dev.ts` currently drives `start()`/
+ * `stop()` directly; it'll hook in here once built, rather than requiring changes to `dev.ts`'s
+ * registry/API.
+ */
+export class DevSession {
+    private readonly platform: DevPlatform;
+    private platformSession: DevPlatformSession;
+    private hotReloadCapable: boolean;
+    private watcher: ComponentFileWatcher | undefined;
+    private output: DevPlatformOutput;
+
+    constructor(
+        private readonly devfile: Data,
+        private readonly componentFolder: ComponentWorkspaceFolder,
+        private readonly options: DevSessionOptions,
+    ) {
+        const kind: DevPlatformKind = resolveDevPlatformKind(options.runOn);
+        this.platform = kind === 'podman' ? new PodmanDevPlatform() : new ClusterDevPlatform();
+    }
+
+    get kind(): DevPlatformKind {
+        return this.platform.kind;
+    }
+
+    async start(output: DevPlatformOutput): Promise<DevPlatformSession> {
+        this.output = output;
+
+        const groupKind = this.options.debug ? 'debug' : 'run';
+        this.hotReloadCapable = CommandResolver.resolveRunCommand(this.devfile, groupKind).hotReloadCapable;
+
+        this.platformSession = await this.platform.start(
+            this.devfile,
+            this.componentFolder,
+            { debug: this.options.debug },
+            output,
+        );
+
+        if (!this.options.manualRebuild) {
+            const ignoreRules = await resolveIgnoreRules(this.componentFolder.contextPath);
+            this.watcher = watchComponentFiles(
+                this.componentFolder.contextPath,
+                ignoreRules,
+                (changedPaths, deletedPaths) => {
+                    this.handleFileChanges(changedPaths, deletedPaths).catch((err: Error) => {
+                        this.output.onOutput(`Failed to sync changes: ${err.message}`);
+                    });
+                },
+            );
+        }
+
+        return this.platformSession;
+    }
+
+    async stop(): Promise<void> {
+        await this.watcher?.close();
+        await this.platform.stop(this.platformSession, this.output);
+    }
+
+    /**
+     * Manually trigger a full file sync and rebuild. Useful for "Sync Files" command when
+     * running with --no-watch, or to force immediate sync bypassing the debounce in watch mode.
+     */
+    async manualSync(): Promise<void> {
+        this.output.onOutput('Syncing files...');
+
+        // Resync all syncable files (Option A: simple, comprehensive)
+        const ignoreRules = await resolveIgnoreRules(this.componentFolder.contextPath);
+        const allFiles = await listSyncableFiles(this.componentFolder.contextPath, ignoreRules);
+
+        await this.platform.sync(this.platformSession, allFiles, []);
+
+        if (!this.hotReloadCapable) {
+            this.output.onOutput('Restarting run command...');
+            await this.platform.restartRunCommand(this.platformSession);
+        }
+
+        this.output.onOutput('Sync complete.');
+    }
+
+    private async handleFileChanges(changedPaths: string[], deletedPaths: string[]): Promise<void> {
+        await this.platform.sync(this.platformSession, changedPaths, deletedPaths);
+        if (!this.hotReloadCapable) {
+            this.output.onOutput('Restarting the run command...');
+            await this.platform.restartRunCommand(this.platformSession);
+        }
+    }
+}

--- a/src/devfile/inner-loop/devStateFile.ts
+++ b/src/devfile/inner-loop/devStateFile.ts
@@ -1,0 +1,31 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { DevState } from '../componentTypeDescription';
+
+function devStateFilePath(componentPath: string): string {
+    return path.join(componentPath, '.odo', 'devstate.json');
+}
+
+export async function saveDevState(state: DevState, componentPath: string): Promise<void> {
+    const odoDir = path.join(componentPath, '.odo');
+    await fs.mkdir(odoDir, { recursive: true });
+    await fs.writeFile(devStateFilePath(componentPath), JSON.stringify(state, null, 2), 'utf-8');
+}
+
+export async function loadDevState(componentPath: string): Promise<DevState | null> {
+    try {
+        const raw = await fs.readFile(devStateFilePath(componentPath), 'utf-8');
+        return JSON.parse(raw) as DevState;
+    } catch {
+        return null;
+    }
+}
+
+export async function clearDevState(componentPath: string): Promise<void> {
+    await fs.unlink(devStateFilePath(componentPath)).catch(() => {});
+}

--- a/src/devfile/inner-loop/devTerminalBridge.ts
+++ b/src/devfile/inner-loop/devTerminalBridge.ts
@@ -1,0 +1,62 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { OpenShiftTerminalApi, OpenShiftTerminalManager } from '../../webview/openshift-terminal/openShiftTerminal';
+import { DevPlatformOutput } from './devPlatform';
+
+/**
+ * The raw byte a webview terminal's `input` message carries for a user-typed Ctrl-C. Distinct
+ * from the printable `^C` a real pty's line discipline echoes — the virtual terminal used here has
+ * no such line discipline, so the control byte itself is what arrives.
+ */
+const CTRL_C = '\u0003';
+
+export function isStopRequest(text: string): boolean {
+    return text.includes(CTRL_C);
+}
+
+function toTerminalText(line: string): string {
+    // Normalize existing newlines and ensure every message ends with \r\n for proper terminal display
+    const normalized = line.replace(/\r?\n/g, '\r\n');
+    return normalized.endsWith('\r\n') ? normalized : `${normalized}\r\n`;
+}
+
+export interface DevTerminalBridge {
+    /** Passed straight into `DevPlatform.start()` / `DevSession` to stream session output. */
+    readonly output: DevPlatformOutput;
+    /** For the caller to focus/kill/forceKill the terminal tab (e.g. `component.ts`'s UI commands). */
+    readonly terminal: OpenShiftTerminalApi;
+}
+
+/**
+ * Creates a virtual (non-pty) OpenShift Terminal tab that streams dev-session output and reports
+ * back when the user presses Ctrl-C in it — mirroring the old `odo dev` pty's "^C to stop" UX
+ * without shelling out to a real CLI process.
+ */
+export async function createDevTerminalBridge(
+    name: string,
+    cwd: string,
+    onStopRequested: () => void,
+): Promise<DevTerminalBridge> {
+    const terminal = await OpenShiftTerminalManager.getInstance().createVirtualTerminal(
+        name,
+        cwd,
+        process.env,
+        {
+            onText: (text: string) => {
+                if (isStopRequest(text)) {
+                    onStopRequested();
+                }
+            },
+        },
+    );
+
+    return {
+        output: {
+            onOutput: (line: string) => terminal.sendText(toTerminalText(line)),
+        },
+        terminal,
+    };
+}

--- a/src/devfile/inner-loop/fileSync.ts
+++ b/src/devfile/inner-loop/fileSync.ts
@@ -1,0 +1,139 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import chokidar from 'chokidar';
+import * as fs from 'fs/promises';
+import ignore, { Ignore } from 'ignore';
+import * as path from 'path';
+
+/** Always ignored regardless of `.gitignore` contents — VCS metadata and this extension's own state dir. */
+const ALWAYS_IGNORED = ['.git', '.odo'];
+
+/**
+ * Builds the ignore-rule set for a component's dev-mode file sync: the always-ignored entries
+ * above, plus the component root's own `.gitignore` if it has one. Matches `odo`'s (and this
+ * plan's) scope — nested `.gitignore` files are not merged in, which is a documented,
+ * deliberate simplification, not a hidden gap.
+ */
+export async function resolveIgnoreRules(rootDir: string): Promise<Ignore> {
+    const rules = ignore().add(ALWAYS_IGNORED);
+
+    try {
+        const gitignoreContents = await fs.readFile(path.join(rootDir, '.gitignore'), 'utf-8');
+        rules.add(gitignoreContents);
+    } catch {
+        // no .gitignore at the component root — nothing more to add
+    }
+
+    return rules;
+}
+
+export type FileChangeBatchHandler = (changedPaths: string[], deletedPaths: string[]) => void;
+
+/**
+ * Coalesces a burst of individual file-change events into a single batched callback, so a save
+ * that touches many files (or an editor's atomic-write temp-file dance) doesn't trigger a sync +
+ * run-command restart per file. The latest event for a given path wins if it flips kind (e.g. a
+ * quick delete-then-recreate) within the same debounce window.
+ */
+export class ChangeBatcher {
+    private readonly pending = new Map<string, 'changed' | 'deleted'>();
+    private timer: NodeJS.Timeout | undefined;
+
+    constructor(
+        private readonly onBatch: FileChangeBatchHandler,
+        private readonly debounceMs: number,
+    ) { }
+
+    recordChange(relativePath: string): void {
+        this.pending.set(relativePath, 'changed');
+        this.scheduleFlush();
+    }
+
+    recordDelete(relativePath: string): void {
+        this.pending.set(relativePath, 'deleted');
+        this.scheduleFlush();
+    }
+
+    /** Cancels any pending flush without emitting it — for tearing down alongside the watcher. */
+    dispose(): void {
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = undefined;
+        }
+        this.pending.clear();
+    }
+
+    private scheduleFlush(): void {
+        if (this.timer) {
+            clearTimeout(this.timer);
+        }
+        this.timer = setTimeout(() => this.flush(), this.debounceMs);
+    }
+
+    private flush(): void {
+        this.timer = undefined;
+        if (this.pending.size === 0) {
+            return;
+        }
+
+        const changed: string[] = [];
+        const deleted: string[] = [];
+        for (const [relativePath, kind] of this.pending) {
+            (kind === 'changed' ? changed : deleted).push(relativePath);
+        }
+        this.pending.clear();
+
+        this.onBatch(changed, deleted);
+    }
+}
+
+export interface ComponentFileWatcher {
+    close(): Promise<void>;
+}
+
+/**
+ * Watches `rootDir` for changes not excluded by `ignoreRules`, invoking `onBatch` with
+ * root-relative POSIX paths (matching what `DevPlatform.sync()`/`containerSync.ts`'s
+ * `pushFiles`/`removeFiles` expect) once activity settles for `debounceMs`. Does not emit for the
+ * initial scan (`ignoreInitial: true`) — the platform's own `start()` already performs a full
+ * initial sync before this watcher exists.
+ */
+export function watchComponentFiles(
+    rootDir: string,
+    ignoreRules: Ignore,
+    onBatch: FileChangeBatchHandler,
+    debounceMs = 300,
+): ComponentFileWatcher {
+    const batcher = new ChangeBatcher(onBatch, debounceMs);
+
+    // chokidar's `ignored` predicate always receives an absolute path (even with `cwd` set, which
+    // only affects the paths emitted by events) — confirmed directly, not assumed from docs.
+    const isIgnored = (absolutePath: string): boolean => {
+        const relativePath = path.relative(rootDir, absolutePath);
+        return relativePath !== '' && ignoreRules.ignores(toPosixPath(relativePath));
+    };
+
+    const watcher = chokidar.watch(rootDir, {
+        cwd: rootDir,
+        ignoreInitial: true,
+        ignored: isIgnored,
+    });
+
+    watcher.on('add', relativePath => batcher.recordChange(toPosixPath(relativePath)));
+    watcher.on('change', relativePath => batcher.recordChange(toPosixPath(relativePath)));
+    watcher.on('unlink', relativePath => batcher.recordDelete(toPosixPath(relativePath)));
+
+    return {
+        async close(): Promise<void> {
+            batcher.dispose();
+            await watcher.close();
+        },
+    };
+}
+
+function toPosixPath(relativePath: string): string {
+    return relativePath.split(path.sep).join('/');
+}

--- a/src/devfile/inner-loop/podmanDevPlatform.ts
+++ b/src/devfile/inner-loop/podmanDevPlatform.ts
@@ -1,0 +1,461 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { ChildProcess } from 'child_process';
+import * as tar from 'tar-fs';
+import { CommandResolver } from '../commandResolver';
+import { Container, Data, DevStateForwardedPort, Endpoint } from '../componentTypeDescription';
+import { VariableResolver } from '../variableResolver';
+import { DevPlatform, DevPlatformKind, DevPlatformOutput, DevPlatformSession } from './devPlatform';
+import { ChildProcessUtil, CliExitData } from '../../util/childProcessUtil';
+import { Util } from '../../util/utils';
+import { ComponentWorkspaceFolder } from '../../odo/workspace';
+import { buildUsablePortPair } from '../../port-forward';
+import { listSyncableFiles } from './clusterDevPlatform';
+import { resolveIgnoreRules } from './fileSync';
+
+/**
+ * Keeps a mountSources container alive without running its image's default entrypoint. Mirrors
+ * `devResourceBuilder.ts`'s cluster-side default — only actually used here for a *secondary*
+ * mountSources container (not the one running the resolved run/debug command), since podman has
+ * no equivalent to "exec into it later" for such a container to matter otherwise.
+ */
+const KEEP_ALIVE_COMMAND = ['tail', '-f', '/dev/null'];
+
+/**
+ * A container's main process is PID 1 inside it — on Linux, PID 1 does not get the *default*
+ * disposition for a signal unless it explicitly installs a handler, so a plain devfile run
+ * command (e.g. a dev server with no SIGTERM handler of its own) will not actually terminate on
+ * SIGTERM at all; podman falls back to SIGKILL only after its stop grace period elapses (10s by
+ * default). Confirmed directly: this happens regardless of whether the command is wrapped in
+ * `sh -c` or run directly, `exec`'d or not — it's inherent to container PID 1 semantics, not
+ * something fixable by how the command is invoked. A short explicit grace period keeps
+ * restart/stop from taking 10+ seconds on every inner-loop iteration.
+ */
+const STOP_GRACE_PERIOD_SECONDS = 2;
+
+function shellQuote(value: string): string {
+    return `'${value.replace(/'/g, String.raw`'\''`)}'`;
+}
+
+interface PodmanDevSession extends DevPlatformSession {
+    readonly kind: 'podman';
+    readonly podName: string;
+    readonly runContainerName: string;
+    readonly componentPath: string;
+    readonly sourceMapping: string;
+    readonly workingDir: string;
+    readonly commandLine: string;
+    logProcess?: ChildProcess;
+}
+
+export class PodmanDevPlatform implements DevPlatform {
+    readonly kind: DevPlatformKind = 'podman';
+
+    async start(
+        devfile: Data,
+        componentFolder: ComponentWorkspaceFolder,
+        options: { debug?: boolean },
+        output: DevPlatformOutput,
+    ): Promise<DevPlatformSession> {
+        const componentName = devfile.metadata.name;
+        const podName = `${componentName}-dev`;
+
+        // Output header similar to odo
+        output.onOutput(`Developing using the "${componentName}" Devfile`);
+        output.onOutput('Platform: podman');
+        output.onOutput('');
+        output.onOutput('Running on podman in Dev mode');
+        output.onOutput('');
+
+        const groupKind = options.debug ? 'debug' : 'run';
+        const { containerName: runContainerName, workingDir, commandLine, containerComponent } =
+            CommandResolver.resolveRunCommand(devfile, groupKind);
+        const sourceMapping = containerComponent?.container?.sourceMapping ?? '/projects';
+
+        // Only run build command in run mode (debug mode tools like dlv compile themselves)
+        const buildCommand = !options.debug ? CommandResolver.findCommandByGroup(devfile, 'build') : undefined;
+        // Normalize backslash-newline continuations from YAML multiline strings
+        const normalizeCmd = (cmd: string) => cmd.replace(/\\\s*\n\s*/g, ' ').trim();
+        // Wrap command for exec, handling leading env var assignments (VAR=value command → env VAR=value command)
+        const wrapForExec = (cmd: string): string => {
+            const envVarPattern = /^(\s*[A-Z_][A-Z0-9_]*=[^\s]+\s+)+/i;
+            const match = cmd.match(envVarPattern);
+            if (match) {
+                const envPart = match[0].trim();
+                const cmdPart = cmd.slice(match[0].length).trim();
+                return `env ${envPart} ${cmdPart}`;
+            }
+            return cmd;
+        };
+
+        let fullCommandLine = wrapForExec(normalizeCmd(commandLine));
+        if (buildCommand?.exec) {
+            const buildResolved = CommandResolver.resolveRunCommand(devfile, 'build');
+            // Wrap both commands in a shell script: run build, then if it succeeds, exec the run command
+            fullCommandLine = `${normalizeCmd(buildResolved.commandLine)} && exec ${wrapForExec(normalizeCmd(commandLine))}`;
+        }
+
+        await this.removePodIfExists(podName);
+
+        const containerComponents = (devfile.components ?? []).filter(
+            (c): c is typeof c & { container: Container } => !!c.container,
+        );
+
+        const allEndpoints = containerComponents.flatMap(c => c.container.endpoints ?? []);
+        const portMappings = await Promise.all(
+            allEndpoints.map(async endpoint => {
+                const { localPort } = await buildUsablePortPair({ targetPort: endpoint.targetPort });
+                return { endpoint, localPort, targetPort: endpoint.targetPort };
+            }),
+        );
+
+        // Create pod and containers
+        output.onOutput('Creating pod...');
+        try {
+            // Create pod with global flags for CI/rootless compatibility:
+            // --events-backend=file: avoids dbus dependency (GitHub Actions, rootless environments)
+            // --cgroup-manager=cgroupfs: works without systemd (matches odo behavior)
+            // Note: these are GLOBAL podman flags and must come before the subcommand
+            await this.run('podman', [
+                '--events-backend=file',
+                '--cgroup-manager=cgroupfs',
+                'pod', 'create',
+                '--name', podName,
+                ...portMappings.flatMap(m => ['-p', `${m.localPort}:${m.targetPort}`]),
+            ]);
+
+            for (const component of containerComponents) {
+                const args = this.buildRunArgs(
+                    devfile, podName, component.name, component.container,
+                    component.name === runContainerName,
+                    component.name === runContainerName ? workingDir : undefined,
+                    component.name === runContainerName ? fullCommandLine : undefined,
+                );
+                // Prepend global flags before subcommand args
+                await this.run('podman', ['--events-backend=file', '--cgroup-manager=cgroupfs', ...args]);
+            }
+
+            // Wait for the run container to be ready before syncing
+            await this.waitForContainerReady(runContainerName);
+            output.onOutput('Pod is Running');
+            output.onOutput('');
+
+            // Sync files into containers after they're created
+            output.onOutput('Syncing files into the container...');
+            try {
+                const ignoreRules = await resolveIgnoreRules(componentFolder.contextPath);
+                const allFiles = await listSyncableFiles(componentFolder.contextPath, ignoreRules);
+                await this.pushFilesToContainer(runContainerName, componentFolder.contextPath, sourceMapping, allFiles);
+                output.onOutput('Syncing files completed');
+                output.onOutput('');
+            } catch (err) {
+                output.onOutput(`Failed to sync files: ${err.message}`);
+                throw err;
+            }
+
+            if (buildCommand?.exec) {
+                output.onOutput('Building your application in container (command: build)');
+            }
+
+            // Start run/debug command
+            output.onOutput(`Executing the application (command: ${groupKind})...`);
+            try {
+                // Exec the actual run/debug command in the background
+                // The command either already includes exec or we add it
+                const needsExec = !fullCommandLine.includes(' && exec ');
+                const cmd = needsExec ? `exec ${fullCommandLine}` : fullCommandLine;
+                Util.spawn('podman', ['exec', '-d', runContainerName, 'sh', '-c', `cd ${workingDir} && ${cmd}`]);
+
+                // Give it a moment to start before tailing logs
+                await new Promise(resolve => setTimeout(resolve, 500));
+
+                const logProcess = Util.spawn('podman', ['logs', '-f', runContainerName]);
+                logProcess.stdout?.on('data', chunk => output.onOutput(chunk.toString('utf-8')));
+                logProcess.stderr?.on('data', chunk => output.onOutput(chunk.toString('utf-8')));
+
+                // Show port forwarding info with clickable URLs for HTTP endpoints
+                const forwardedPortsState = this.buildForwardedPortState(containerComponents, portMappings);
+                for (const port of forwardedPortsState) {
+                    if (port.isDebug) {
+                        output.onOutput(`Debug port: ${port.localAddress}:${port.localPort} -> ${port.containerPort}`);
+                    } else {
+                        // Always use http:// for local port forwards (they're plain TCP tunnels, not TLS)
+                        output.onOutput(`Forwarding from http://${port.localAddress}:${port.localPort} -> ${port.containerPort}`);
+                    }
+                }
+
+                output.onOutput('');
+                output.onOutput('Press Ctrl-C to stop dev mode');
+
+                const session: PodmanDevSession = {
+                    kind: 'podman',
+                    pid: process.pid,
+                    forwardedPorts: this.buildForwardedPortState(containerComponents, portMappings),
+                    podName,
+                    runContainerName,
+                    componentPath: componentFolder.contextPath,
+                    sourceMapping,
+                    workingDir,
+                    commandLine: fullCommandLine,  // Store the full wrapped command for consistency
+                    logProcess,
+                };
+
+                return session;
+            } catch (err) {
+                output.onOutput(`Failed to start application: ${err.message}`);
+                throw err;
+            }
+        } catch (err) {
+            output.onOutput(`Failed to create pod: ${err.message}`);
+            throw err;
+        }
+    }
+
+    async sync(session: DevPlatformSession, changedPaths: string[], deletedPaths: string[]): Promise<void> {
+        const s = session as PodmanDevSession;
+        await this.pushFilesToContainer(s.runContainerName, s.componentPath, s.sourceMapping, changedPaths);
+        await this.removeFilesFromContainer(s.runContainerName, s.sourceMapping, deletedPaths);
+    }
+
+    async restartRunCommand(session: DevPlatformSession): Promise<void> {
+        const s = session as PodmanDevSession;
+        await this.run('podman', [
+            '--events-backend=file',
+            '--cgroup-manager=cgroupfs',
+            'restart',
+            '--time', `${STOP_GRACE_PERIOD_SECONDS}`,
+            s.runContainerName
+        ]);
+
+        // Re-exec the command after restart (container starts with keep-alive, not the actual command)
+        const needsExec = !s.commandLine.includes(' && exec ');
+        const cmd = needsExec ? `exec ${s.commandLine}` : s.commandLine;
+        Util.spawn('podman', ['exec', '-d', s.runContainerName, 'sh', '-c', `cd ${s.workingDir} && ${cmd}`]);
+
+        // Give it a moment to start
+        await new Promise(resolve => setTimeout(resolve, 500));
+    }
+
+    async stop(session: DevPlatformSession, output?: DevPlatformOutput): Promise<void> {
+        const s = session as PodmanDevSession;
+
+        if (output) {
+            output.onOutput('');
+            output.onOutput('Stopping dev mode...');
+        }
+
+        try {
+            s.logProcess?.kill();
+
+            if (output) {
+                output.onOutput('Cleaning up pod...');
+            }
+            await this.removePodIfExists(s.podName);
+
+            if (output) {
+                output.onOutput('Dev mode stopped');
+            }
+        } catch (err) {
+            if (output) {
+                output.onOutput(`Error during cleanup: ${err.message}`);
+            }
+            // Don't rethrow - cleanup is best-effort
+        }
+    }
+
+    private async removePodIfExists(podName: string): Promise<void> {
+        await ChildProcessUtil.Instance.execute(`podman pod rm -f --time ${STOP_GRACE_PERIOD_SECONDS} ${podName}`).catch(() => {});
+    }
+
+    /**
+     * Waits for a container to be in "running" state before attempting operations like exec/cp.
+     */
+    private async waitForContainerReady(containerName: string, timeoutMs = 30000): Promise<void> {
+        const start = Date.now();
+        let lastStatus = 'unknown';
+        while (Date.now() - start < timeoutMs) {
+            try {
+                const statusResult = await ChildProcessUtil.Instance.execute(
+                    `podman inspect --format '{{.State.Status}}' ${shellQuote(containerName)}`
+                );
+                lastStatus = statusResult.stdout.trim();
+
+                if (lastStatus === 'running') {
+                    return;
+                }
+
+                // If container exited, get the error details
+                if (lastStatus === 'exited') {
+                    const exitCodeResult = await ChildProcessUtil.Instance.execute(
+                        `podman inspect --format '{{.State.ExitCode}}' ${shellQuote(containerName)}`
+                    );
+                    const logs = await ChildProcessUtil.Instance.execute(
+                        `podman logs ${shellQuote(containerName)}`
+                    ).catch(() => ({ stdout: '', stderr: 'Could not retrieve logs' }));
+
+                    throw new Error(
+                        `Container '${containerName}' exited with code ${exitCodeResult.stdout.trim()}.\n` +
+                        `Logs:\n${logs.stdout}\n${logs.stderr}`
+                    );
+                }
+            } catch (err) {
+                // If it's our error about container exiting, re-throw it
+                if (err.message && err.message.includes('exited with code')) {
+                    throw err;
+                }
+                // Otherwise container might not exist yet, keep waiting
+            }
+            await new Promise(resolve => setTimeout(resolve, 500));
+        }
+        throw new Error(`Container '${containerName}' did not become ready within ${timeoutMs}ms. Last status: ${lastStatus}`);
+    }
+
+    private buildRunArgs(
+        devfile: Data,
+        podName: string,
+        containerName: string,
+        container: Container,
+        isRunContainer: boolean,
+        workingDir: string | undefined,
+        commandLine: string | undefined,
+    ): string[] {
+        const mountsSource = container.mountSources !== false;
+
+        const args = ['run', '-d', '--pod', podName, '--name', containerName];
+
+        for (const envVar of container.env ?? []) {
+            args.push('-e', `${envVar.name}=${VariableResolver.resolveValue(devfile, envVar.value)}`);
+        }
+
+        // Create a named volume for the source mapping directory to avoid permission issues
+        // when the container runs as non-root
+        if (mountsSource) {
+            const volumeName = `${containerName}-projects`;
+            args.push('-v', `${volumeName}:${container.sourceMapping ?? '/projects'}`);
+        }
+
+        for (const volumeMount of container.volumeMounts ?? []) {
+            args.push('-v', `${volumeMount.name}:${volumeMount.path}`);
+        }
+
+        args.push(container.image);
+
+        if (isRunContainer) {
+            // Start the run container with a keep-alive command instead of the actual run command.
+            // We'll exec the real command after syncing files (matching cluster mode behavior).
+            args.push(...KEEP_ALIVE_COMMAND);
+        } else if (container.command?.length) {
+            args.push(...container.command.map(v => VariableResolver.resolveValue(devfile, v)));
+            if (container.args?.length) {
+                args.push(...container.args.map(v => VariableResolver.resolveValue(devfile, v)));
+            }
+        } else if (mountsSource) {
+            args.push(...KEEP_ALIVE_COMMAND);
+        }
+
+        return args;
+    }
+
+    private buildForwardedPortState(
+        containerComponents: { name: string; container: Container }[],
+        portMappings: { endpoint: Endpoint; localPort: number; targetPort: number }[],
+    ): DevStateForwardedPort[] {
+        return portMappings.map(mapping => {
+            const owner = containerComponents.find(c => c.container.endpoints?.includes(mapping.endpoint));
+            return {
+                containerName: owner?.name ?? '',
+                portName: mapping.endpoint.name,
+                isDebug: mapping.endpoint.name?.startsWith('debug'),
+                localAddress: '127.0.0.1',
+                localPort: mapping.localPort,
+                containerPort: mapping.targetPort,
+                exposure: mapping.endpoint.exposure,
+            };
+        });
+    }
+
+    /**
+     * Syncs files from the host into a podman container using tar streams.
+     * Similar to cluster mode's pushFiles, but uses podman exec instead of kubernetes exec.
+     */
+    private async pushFilesToContainer(
+        containerName: string,
+        localRoot: string,
+        targetDir: string,
+        relativePaths: string[],
+    ): Promise<void> {
+        if (relativePaths.length === 0) {
+            return;
+        }
+
+        // Create a tar stream of the files to sync
+        const tarStream = tar.pack(localRoot, { entries: relativePaths });
+
+        // Pipe the tar stream into podman exec to extract in the container
+        const execProcess = Util.spawn('podman', [
+            'exec', '-i', containerName,
+            'tar', 'xmf', '-', '-C', targetDir
+        ]);
+
+        // Capture stderr for better error messages
+        const stderrChunks: Buffer[] = [];
+        execProcess.stderr?.on('data', (chunk) => {
+            stderrChunks.push(chunk);
+        });
+
+        tarStream.pipe(execProcess.stdin);
+
+        await new Promise<void>((resolve, reject) => {
+            execProcess.on('close', (code) => {
+                if (code === 0) {
+                    resolve();
+                } else {
+                    const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+                    reject(new Error(
+                        `Failed to sync files to container: podman exec exited with code ${code}\n` +
+                        `Stderr: ${stderr || '(no output)'}`
+                    ));
+                }
+            });
+            execProcess.on('error', reject);
+        });
+    }
+
+    /**
+     * Removes files from a podman container.
+     */
+    private async removeFilesFromContainer(
+        containerName: string,
+        targetDir: string,
+        relativePaths: string[],
+    ): Promise<void> {
+        if (relativePaths.length === 0) {
+            return;
+        }
+
+        const containerPaths = relativePaths.map(p =>
+            `${targetDir.replace(/\/+$/, '')}/${p.replace(/^\/+/, '')}`
+        );
+
+        const result: CliExitData = await ChildProcessUtil.Instance.execute(
+            `podman exec ${shellQuote(containerName)} rm -rf ${containerPaths.map(shellQuote).join(' ')}`
+        );
+
+        if (result.error) {
+            throw new Error(`Failed to remove files from container: ${result.stderr || result.error.message}`);
+        }
+    }
+
+    private async run(command: string, args: string[]): Promise<void> {
+        const result: CliExitData = await ChildProcessUtil.Instance.execute(`${command} ${args.map(shellQuote).join(' ')}`);
+        // Match the codebase's established convention (e.g. ContainerRuntimeDetector) of checking
+        // only the exit code, not CliExitData.failed()'s stricter "any stderr output" check —
+        // podman routinely writes informational output to stderr on success.
+        if (result.error) {
+            throw new Error(`${command} ${args[0]} failed: ${result.stderr || result.error.message}`);
+        }
+    }
+}

--- a/src/devfile/parallelCompositeCommand.ts
+++ b/src/devfile/parallelCompositeCommand.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { Command } from '../odo/componentTypeDescription';
+import { Command } from './componentTypeDescription';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
 import { DevfileCommandRunner } from './devfileCommandRunner';
 

--- a/src/devfile/undeploy.ts
+++ b/src/devfile/undeploy.ts
@@ -5,12 +5,11 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { KubeConfig } from '@kubernetes/client-node';
 import { OpenshiftLogger } from '../util/childProcessUtil';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
-import { DeployState } from '../odo/componentTypeDescription';
+import { DeployState } from './componentTypeDescription';
 import { Oc } from '../oc/ocWrapper';
-import { deployContextKey } from './deploy';
+import { getCurrentDeployContextKey, loadDeployState } from './deployStateFile';
 
 export interface ComponentUndeployOptions {
     componentPath: string;
@@ -29,7 +28,7 @@ export async function undeployComponent(
     const stateFile = path.join(ctx.componentPath, '.odo', 'deploystate.json');
 
     // 1. Try to load deploy state
-    const deployState = await loadDeployState(stateFile);
+    const deployState = await loadDeployState(ctx.componentPath);
 
     if (deployState) {
         logInfo(ctx, `Found deployment state with ${deployState.resources.length} tracked resources`);
@@ -145,31 +144,6 @@ function isDevResource(resource: any): boolean {
     );
 }
 
-async function currentContextKey(): Promise<string> {
-    const kc = new KubeConfig();
-    kc.loadFromDefault();
-    const server = kc.getCurrentCluster()?.server || '';
-    const namespace = await Oc.Instance.getActiveProject() || 'default';
-    return deployContextKey(server, namespace);
-}
-
-async function loadDeployState(stateFile: string): Promise<DeployState | null> {
-    try {
-        const content = await fs.readFile(stateFile, 'utf-8');
-        const parsed = JSON.parse(content);
-        if (parsed.version === 1 && !parsed.deployments) {
-            return parsed as DeployState;
-        }
-        if (parsed.deployments) {
-            const key = await currentContextKey();
-            return parsed.deployments[key] || null;
-        }
-        return null;
-    } catch {
-        return null;
-    }
-}
-
 async function removeDeployStateEntry(stateFile: string): Promise<void> {
     const content = await fs.readFile(stateFile, 'utf-8');
     const parsed = JSON.parse(content);
@@ -179,7 +153,7 @@ async function removeDeployStateEntry(stateFile: string): Promise<void> {
         return;
     }
 
-    const key = await currentContextKey();
+    const key = await getCurrentDeployContextKey();
     delete parsed.deployments[key];
 
     if (Object.keys(parsed.deployments).length === 0) {

--- a/src/devfile/variableResolver.ts
+++ b/src/devfile/variableResolver.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { Apply, Container, Data, Exec } from '../odo/componentTypeDescription';
+import { Apply, Container, Data, Exec } from './componentTypeDescription';
 
 export class VariableResolver {
     private static readonly VARIABLE_REGEX = /\$\{([^}]+)\}/g;
@@ -13,6 +13,10 @@ export class VariableResolver {
             ...exec,
             workingDir: this.resolveValue(devfile, exec.workingDir ?? '/projects', exec.component),
             commandLine: this.resolveValue(devfile, exec.commandLine, exec.component),
+            env: exec.env?.map(e => ({
+                name: e.name,
+                value: this.resolveValue(devfile, e.value, exec.component),
+            })),
         };
     }
 
@@ -43,7 +47,8 @@ export class VariableResolver {
         componentName?: string,
     ): string {
         if (variable === 'PROJECT_SOURCE') {
-            return '/projects';
+            const container = devfile.components?.find((c) => c.name === componentName)?.container;
+            return container?.sourceMapping ?? '/projects';
         }
 
         // Check devfile.variables (from resolved devfile with merged parents)

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -30,7 +30,7 @@ import * as Helm from './helm/helm';
 import { HelmRepo } from './helm/helmChartType';
 import { getOutputFormat, helmfsUri, kubefsUri } from './k8s/vfs/kuberesources.utils';
 import { Oc } from './oc/ocWrapper';
-import { Component } from './openshift/component';
+import { getComponentStateByContext, onComponentStateChanged } from './openshift/componentStateFile';
 import { getServiceKindStubs, getServices } from './openshift/serviceHelpers';
 import { PortForward } from './port-forward';
 import { getKubeConfigFiles, getNamespaceKind, isOpenShiftCluster, KubeConfigInfo } from './util/kubeUtils';
@@ -155,7 +155,12 @@ export class OpenShiftExplorer implements TreeDataProvider<ExplorerItem>, Dispos
         this.treeView = window.createTreeView<ExplorerItem>('openshiftProjectExplorer', {
             treeDataProvider: this,
         });
-        Component.onDidStateChanged((_context) => {
+        onComponentStateChanged((context) => {
+            // Skip refresh for podman dev sessions (they don't create cluster resources)
+            const componentState = getComponentStateByContext(context);
+            if (componentState?.runOn === 'podman') {
+                return;
+            }
             this.refresh();
         });
     }

--- a/src/odo/command.ts
+++ b/src/odo/command.ts
@@ -3,22 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { CommandOption, CommandText } from '../base/command';
-
 export class Command {
-
-    static dev(debug: boolean, runOn?: 'podman', manualRebuild: boolean = false): CommandText {
-        const command = new CommandText('odo', 'dev');
-        if (debug) {
-            command.addOption(new CommandOption('--debug'));
-        }
-        if (runOn) {
-            command.addOption(new CommandOption('--platform', 'podman'));
-            command.addOption(new CommandOption('--forward-localhost'));
-        }
-        if (manualRebuild) {
-            command.addOption(new CommandOption('--no-watch'));
-        }
-        return command;
-    }
+    // This class previously contained Command.dev() for odo CLI integration.
+    // Dev mode is now implemented natively in TypeScript (see src/devfile/dev.ts).
 }

--- a/src/odo/componentType.ts
+++ b/src/odo/componentType.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { Url } from 'url';
-import { Data } from './componentTypeDescription';
+import { Data } from '../devfile/componentTypeDescription';
 
 export interface RegistryList {
     registries: Registry[];

--- a/src/odo/odoWrapper.ts
+++ b/src/odo/odoWrapper.ts
@@ -12,7 +12,7 @@ import { initComponent } from '../devfile/init';
 import { ToolsConfig } from '../tools';
 import { ChildProcessUtil, CliExitData, OpenshiftChannel } from '../util/childProcessUtil';
 import { VsCommandError } from '../vscommand';
-import { ComponentDescription } from './componentTypeDescription';
+import { ComponentDescription } from '../devfile/componentTypeDescription';
 
 /**
  * Wraps the `odo` cli tool.

--- a/src/odo/workspace.ts
+++ b/src/odo/workspace.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { EventEmitter, workspace, WorkspaceFolder } from 'vscode';
-import { ComponentDescription } from './componentTypeDescription';
+import { ComponentDescription } from '../devfile/componentTypeDescription';
 import { Odo } from './odoWrapper';
 
 export interface ComponentWorkspaceFolder {

--- a/src/openshift/component.ts
+++ b/src/openshift/component.ts
@@ -8,15 +8,18 @@ import { readFile } from 'fs/promises';
 import { platform } from 'os';
 import * as path from 'path';
 import { which } from 'shelljs';
-import { commands, debug, DebugConfiguration, DebugSession, Disposable, EventEmitter, extensions, ProgressLocation, Uri, window, workspace } from 'vscode';
-import { deployComponent, deployContextKey } from '../devfile/deploy';
+import { commands, debug, DebugConfiguration, DebugSession, Disposable, extensions, ProgressLocation, Uri, window, workspace } from 'vscode';
+import { deployComponent } from '../devfile/deploy';
+import { deployContextKey } from '../devfile/deployStateFile';
 import { describeComponentYAML } from '../devfile/describe';
+import { forceStopDevSession, startDevSession, stopDevSession, syncDevSession } from '../devfile/dev';
 import { DevfileCommandRunner } from '../devfile/devfileCommandRunner';
+import { createDevTerminalBridge } from '../devfile/inner-loop/devTerminalBridge';
 import { undeployComponent } from '../devfile/undeploy';
+import { OpenShiftExplorer } from '../explorer';
 import { BindableService } from '../k8s/servicebinding/bindableService';
 import { Oc } from '../oc/ocWrapper';
-import { Command } from '../odo/command';
-import { CommandProvider, DeployState } from '../odo/componentTypeDescription';
+import { CommandProvider, DeployState } from '../devfile/componentTypeDescription';
 import { Odo } from '../odo/odoWrapper';
 import { ComponentWorkspaceFolder } from '../odo/workspace';
 import sendTelemetry from '../telemetry';
@@ -26,7 +29,15 @@ import { Util as fs } from '../util/utils';
 import { vsCommand, VsCommandError } from '../vscommand';
 import AddServiceBindingViewLoader, { ServiceBindingFormResponse } from '../webview/add-service-binding/addServiceBindingLoader';
 import CreateComponentLoader from '../webview/create-component/createComponentLoader';
-import { OpenShiftTerminalApi, OpenShiftTerminalManager } from '../webview/openshift-terminal/openShiftTerminal';
+import { OpenShiftTerminalManager } from '../webview/openshift-terminal/openShiftTerminal';
+import {
+    componentStates,
+    ComponentContextState,
+    ComponentDevState,
+    DevProcessStopRequest,
+    fireComponentStateChanged,
+    onComponentStateChanged,
+} from './componentStateFile';
 import OpenShiftItem, { clusterRequired, projectRequired } from './openshiftItem';
 
 function createStartDebuggerResult(language: string, message = '') {
@@ -37,18 +48,9 @@ function createStartDebuggerResult(language: string, message = '') {
     return result;
 }
 
-export enum ComponentContextState {
-    DEV = 'dev-nrn',
-    DEV_STARTING = 'dev-str',
-    DEV_RUNNING = 'dev-run',
-    DEV_STOPPING = 'dev-stp',
-    DEB = 'deb-nrn',
-    DEB_RUNNING = 'deb-run',
-    DEP = 'dep-nrn',
-    DEP_STARTING = 'dep-str',
-    DEP_RUNNING = 'dep-run',
-    DEP_STOPPING = 'dep-stp',
-}
+// Re-export for backward compatibility
+export { ComponentContextState } from './componentStateFile';
+export type { ComponentDevState, DevProcessStopRequest } from './componentStateFile';
 
 export class ComponentStateRegex {
     public static readonly COMPONENT_DEV_STARTING = /openshift\.component\.dev-str.*/;
@@ -62,30 +64,11 @@ export class ComponentStateRegex {
     public static readonly COMPONENT_DEP_STOPPING = /openshift\.component.*\.dep-stp.*/;
 }
 
-interface ComponentDevState {
-    // dev state
-    devTerminal?: OpenShiftTerminalApi;
-    devStatus?: ComponentContextState;
-    contextValue?: string;
-    devProcessStopRequest?: DevProcessStopRequest;
-    // debug state
-    debugStatus?: string;
-    // deploy state
-    deployStatus?: string;
-    runOn?: undefined | 'podman';
-}
-
-interface DevProcessStopRequest extends Disposable {
-    isSigabrtSent: () => boolean;
-    sendSigabrt: () => void;
-}
-
 export class Component extends OpenShiftItem {
     private static debugSessions = new Map<string, DebugSession>();
-    private static stateChanged = new EventEmitter<string>();
 
     public static onDidStateChanged(listener: (context: string) => any) {
-        Component.stateChanged.event(listener);
+        return onComponentStateChanged(listener);
     }
 
     public static onContextChanged(): void {
@@ -100,7 +83,7 @@ export class Component extends OpenShiftItem {
         const currentContext = kc.getContextObject(kc.getCurrentContext());
         const currentNamespace = currentContext?.namespace || 'default';
 
-        for (const [contextPath, state] of Component.componentStates) {
+        for (const [contextPath, state] of componentStates) {
             if (state.deployStatus === ComponentContextState.DEP_RUNNING
                 || state.deployStatus === ComponentContextState.DEP) {
                 void Component.reconcileDeployState(contextPath, state, currentCluster, currentNamespace);
@@ -135,7 +118,7 @@ export class Component extends OpenShiftItem {
 
         if (state.deployStatus !== newStatus) {
             state.deployStatus = newStatus;
-            Component.stateChanged.fire(contextPath);
+            fireComponentStateChanged(contextPath);
         }
     }
 
@@ -144,20 +127,31 @@ export class Component extends OpenShiftItem {
             debug.onDidStartDebugSession((session) => {
                 if (session.configuration.contextPath) {
                     Component.debugSessions.set(session.configuration.contextPath, session);
+                    // Update debug state when VS Code debugger attaches
+                    const componentState = componentStates.get(session.configuration.contextPath);
+                    if (componentState) {
+                        componentState.debugStatus = ComponentContextState.DEB_RUNNING;
+                        fireComponentStateChanged(session.configuration.contextPath);
+                    }
                 }
             }),
             debug.onDidTerminateDebugSession((session) => {
                 if (session.configuration.contextPath) {
                     Component.debugSessions.delete(session.configuration.contextPath);
+                    // Restore debug state when VS Code debugger detaches (but dev might still be running)
+                    const componentState = componentStates.get(session.configuration.contextPath);
+                    if (componentState && componentState.devStatus === ComponentContextState.DEV_RUNNING) {
+                        // Reset to DEB (debugger available but not attached)
+                        componentState.debugStatus = ComponentContextState.DEB;
+                        fireComponentStateChanged(session.configuration.contextPath);
+                    }
                 }
             })
         ];
     }
 
-    private static readonly componentStates = new Map<string, ComponentDevState>();
-
     static getComponentDevState(folder: ComponentWorkspaceFolder): ComponentDevState {
-        let state = Component.componentStates.get(folder.contextPath);
+        let state = componentStates.get(folder.contextPath);
         if (!state) {
             state = {
                 devStatus: folder.component?.devfileData?.supportedOdoFeatures?.dev ? ComponentContextState.DEV : undefined,
@@ -165,7 +159,7 @@ export class Component extends OpenShiftItem {
                 deployStatus: folder.component?.devfileData?.supportedOdoFeatures?.deploy ? ComponentContextState.DEP : undefined,
             };
             if (folder.component?.devfileData?.supportedOdoFeatures !== undefined) {
-                Component.componentStates.set(folder.contextPath, state);
+                componentStates.set(folder.contextPath, state);
                 if (state.deployStatus === ComponentContextState.DEP) {
                     void Component.detectDeployedState(folder);
                 }
@@ -185,14 +179,14 @@ export class Component extends OpenShiftItem {
         const currentCluster = kc.getCurrentCluster()?.server;
         const currentContext = kc.getContextObject(kc.getCurrentContext());
         const currentNamespace = currentContext?.namespace || 'default';
-        const state = Component.componentStates.get(folder.contextPath);
+        const state = componentStates.get(folder.contextPath);
         if (state) {
             void Component.reconcileDeployState(folder.contextPath, state, currentCluster, currentNamespace);
         }
     }
 
     public static generateContextStateSuffixValue(folder: ComponentWorkspaceFolder): string {
-        const state = Component.componentStates.get(folder.contextPath);
+        const state = componentStates.get(folder.contextPath);
         let contextSuffix = '';
         if (state.devStatus) {
             contextSuffix = contextSuffix.concat('.').concat(state.devStatus);
@@ -240,7 +234,7 @@ export class Component extends OpenShiftItem {
 
     @vsCommand('openshift.component.showDevTerminal')
     static showDevTerminal(context: ComponentWorkspaceFolder) {
-        Component.componentStates.get(context.contextPath)?.devTerminal.focusTerminal();
+        componentStates.get(context.contextPath)?.devTerminal.focusTerminal();
     }
 
     static devModeExitTimeout(): number {
@@ -250,7 +244,7 @@ export class Component extends OpenShiftItem {
     }
 
     private static exitDevelopmentMode(componentContextPath: string) : DevProcessStopRequest {
-        const componentState = Component.componentStates.get(componentContextPath);
+        const componentState = componentStates.get(componentContextPath);
         if (componentState) {
             let sigAbortSent = false;
             let devCleaningTimeout = setTimeout( () => {
@@ -264,6 +258,7 @@ export class Component extends OpenShiftItem {
                             } else if (action === 'Force exit') {
                                 sigAbortSent = true;
                                 componentState.devTerminal.forceKill();
+                                void Component.stopDevSessionAndUpdateState(componentContextPath, true);
                             }
                         }
                     });
@@ -278,8 +273,54 @@ export class Component extends OpenShiftItem {
                 sendSigabrt: () => {
                     sigAbortSent = true;
                     componentState.devTerminal.forceKill();
+                    void Component.stopDevSessionAndUpdateState(componentContextPath, true);
                 }
             }
+        }
+    }
+
+    /**
+     * Tears down the running dev session (via `dev.ts`) and updates the tree/context-menu state
+     * to reflect it. `force: true` uses `forceStopDevSession()` (never throws, best-effort) for
+     * the "user already chose force exit, move on regardless" path; `force: false` uses
+     * `stopDevSession()`, which propagates a platform teardown failure to the user.
+     */
+    private static async stopDevSessionAndUpdateState(componentContextPath: string, force: boolean): Promise<void> {
+        const componentState = componentStates.get(componentContextPath);
+        if (!componentState) {
+            return;
+        }
+
+        // Output to the dev terminal if it exists
+        const sendOutput = (text: string) => {
+            if (componentState.devTerminal) {
+                componentState.devTerminal.sendText(text.endsWith('\r\n') ? text : `${text}\r\n`);
+            }
+        };
+
+        try {
+            sendOutput(force ? 'Force stopping dev mode...' : 'Stopping dev mode...');
+            if (force) {
+                await forceStopDevSession(componentContextPath);
+            } else {
+                await stopDevSession(componentContextPath);
+            }
+            sendOutput('Dev mode stopped. Press Ctrl-C to close terminal.');
+            // Refresh only for cluster mode (podman creates no cluster resources)
+            if (!componentState.runOn) {
+                OpenShiftExplorer.getInstance().refresh();
+            }
+        } catch (err) {
+            sendOutput(`Error stopping dev mode: ${err.toString()}`);
+            void window.showErrorMessage(err.toString());
+        } finally {
+            if (componentState.devProcessStopRequest) {
+                componentState.devProcessStopRequest.dispose();
+                componentState.devProcessStopRequest = undefined;
+            }
+            componentState.devStatus = ComponentContextState.DEV;
+            componentState.debugStatus = undefined; // Clear debug state when dev stops
+            fireComponentStateChanged(componentContextPath);
         }
     }
 
@@ -441,66 +482,99 @@ export class Component extends OpenShiftItem {
         const cs = Component.getComponentDevState(component);
         cs.devStatus = ComponentContextState.DEV_STARTING;
         cs.runOn = runOn;
-        Component.stateChanged.fire(component.contextPath)
-        if (!runOn) {
-            try {
-                await Oc.Instance.deleteDeploymentByComponentLabel(component.component.devfileData.devfile.metadata.name);
-            } catch {
-                // do nothing, it probably was already deleted
-            }
-        }
+        fireComponentStateChanged(component.contextPath)
+
+        const componentName = component.component.devfileData.devfile.metadata.name;
+
         try {
-            cs.devTerminal = await OpenShiftTerminalManager.getInstance().createTerminal(
-                Command.dev(component.component.devfileData.supportedOdoFeatures.debug, runOn, manualRebuild),
-                `odo dev: ${component.component.devfileData.devfile.metadata.name}`,
+            const terminalTitle = runOn === 'podman'
+                ? `Dev Mode: ${componentName} (Podman)`
+                : `Dev Mode: ${componentName}`;
+
+            const bridge = await createDevTerminalBridge(
+                terminalTitle,
                 component.contextPath,
-                process.env,
-                {
-                    onExit() {
-                        if (cs.devProcessStopRequest) {
-                            cs.devProcessStopRequest.dispose();
-                            cs.devProcessStopRequest = undefined;
-                        }
-                        cs.devStatus = ComponentContextState.DEV;
-                        Component.stateChanged.fire(component.contextPath);
-                    },
-                    onText(text: string) {
-                        if (cs.devStatus === ComponentContextState.DEV_STARTING  && text.includes('[p]')) {
-                            Component.stateChanged.fire(component.contextPath)
-                            cs.devStatus = ComponentContextState.DEV_RUNNING;
-                        }
-                        if (text.includes('^C')) {
-                            cs.devStatus = ComponentContextState.DEV_STOPPING;
-                            cs.devProcessStopRequest = Component.exitDevelopmentMode(component.contextPath);
-                            Component.stateChanged.fire(component.contextPath);
-                        }
+                () => {
+                    // Fires on a user-typed Ctrl-C in the terminal, or on our own kill() call from
+                    // exitDevMode() below — both funnel through the same terminal input path.
+                    if (cs.devStatus === ComponentContextState.DEV_STOPPING) {
+                        return;
                     }
+
+                    // If dev mode is already stopped, close this terminal
+                    if (cs.devStatus === ComponentContextState.DEV) {
+                        if (bridge.terminal) {
+                            bridge.terminal.forceKill();
+                            if (cs.devTerminal === bridge.terminal) {
+                                cs.devTerminal = undefined;
+                            }
+                        }
+                        return;
+                    }
+
+                    cs.devStatus = ComponentContextState.DEV_STOPPING;
+                    cs.devProcessStopRequest = Component.exitDevelopmentMode(component.contextPath);
+                    fireComponentStateChanged(component.contextPath);
+                    void Component.stopDevSessionAndUpdateState(component.contextPath, false);
                 },
             );
+            cs.devTerminal = bridge.terminal;
+
+            const debugEnabled = component.component.devfileData.supportedOdoFeatures.debug;
+            await startDevSession(
+                component.component.devfileData.devfile,
+                component,
+                {
+                    debug: debugEnabled,
+                    runOn,
+                    manualRebuild,
+                },
+                bridge.output,
+            );
+
+            cs.devStatus = ComponentContextState.DEV_RUNNING;
+            // Set debug state if dev started with debugger support
+            if (debugEnabled) {
+                cs.debugStatus = ComponentContextState.DEB;
+            }
+            fireComponentStateChanged(component.contextPath);
         } catch (err) {
+            cs.devStatus = ComponentContextState.DEV;
+            cs.debugStatus = undefined;
+            fireComponentStateChanged(component.contextPath);
             void window.showErrorMessage(err.toString());
         }
     }
 
     @vsCommand('openshift.component.exitDevMode')
     static exitDevMode(component: ComponentWorkspaceFolder): Promise<void> {
-        const componentState = Component.componentStates.get(component.contextPath)
-        if (componentState) {
+        const componentState = componentStates.get(component.contextPath)
+        if (componentState?.devTerminal) {
             componentState.devTerminal.focusTerminal();
+            // Sends the same raw Ctrl-C byte a user typing into the terminal would — triggers the
+            // devTerminalBridge's onStopRequested callback wired in devRunOn() above.
             componentState.devTerminal.kill();
         }
         return;
     }
 
     @vsCommand('openshift.component.forceExitDevMode')
-    static forceExitDevMode(component: ComponentWorkspaceFolder): Promise<void> {
-        const componentState = Component.componentStates.get(component.contextPath)
-        if (componentState && componentState.devTerminal) {
+    static async forceExitDevMode(component: ComponentWorkspaceFolder): Promise<void> {
+        const componentState = componentStates.get(component.contextPath)
+        if (componentState?.devTerminal) {
             componentState.devTerminal.focusTerminal();
             componentState.devTerminal.forceKill();
-            Component.stateChanged.fire(component.contextPath)
         }
-        return;
+        await Component.stopDevSessionAndUpdateState(component.contextPath, true);
+    }
+
+    @vsCommand('openshift.component.dev.sync')
+    static async syncDevFiles(component: ComponentWorkspaceFolder): Promise<void> {
+        try {
+            await syncDevSession(component.contextPath);
+        } catch (err) {
+            void window.showErrorMessage(`Failed to sync files: ${err.message || err.toString()}`);
+        }
     }
 
     @vsCommand('openshift.component.openInBrowser')
@@ -593,8 +667,9 @@ export class Component extends OpenShiftItem {
         const isJava = component.component.devfileData.devfile.metadata.tags.includes('Java') ;
         const isNode = component.component.devfileData.devfile.metadata.tags.includes('Node.js');
         const isPython = component.component.devfileData.devfile.metadata.tags.includes('Python');
+        const isGo = component.component.devfileData.devfile.metadata.tags.includes('Go');
 
-        if (isJava || isNode || isPython) {
+        if (isJava || isNode || isPython || isGo) {
             if (isJava) {
                 const JAVA_EXT = 'redhat.java';
                 const JAVA_DEBUG_EXT = 'vscjava.vscode-java-debug';
@@ -658,6 +733,35 @@ export class Component extends OpenShiftItem {
                         projectName: path.basename(component.contextPath)
                     });
                 }
+            } else if (isGo) {
+                const GO_EXT = 'golang.go';
+                const goExtIsInstalled = extensions.getExtension(GO_EXT);
+                if (!goExtIsInstalled) {
+                    const response = await window.showWarningMessage('Go extension (Publisher: Go Team at Google) is required to support debugging.', 'Install');
+                    if (response === 'Install') {
+                        await window.withProgress({ location: ProgressLocation.Notification }, async (progress) => {
+                            progress.report({ message: 'Installing extensions required to debug Go Component ...' });
+                            await commands.executeCommand('workbench.extensions.installExtension', GO_EXT);
+                        });
+                        await window.showInformationMessage('Please reload the window to activate installed extension.', 'Reload');
+                        await commands.executeCommand('workbench.action.reloadWindow');
+                    }
+                }
+                if (goExtIsInstalled) {
+                    result = Component.startOdoAndConnectDebugger(component, {
+                        name: `Attach to '${component.component.devfileData.devfile.metadata.name}' component.`,
+                        type: 'go',
+                        request: 'attach',
+                        mode: 'remote',
+                        cwd: component.contextPath,
+                        substitutePath: [
+                            {
+                                from: component.contextPath,
+                                to: '/projects'
+                            }
+                        ]
+                    });
+                }
             } else {
                 result = Component.startOdoAndConnectDebugger(component, {
                     name: `Attach to '${component.component.devfileData.devfile.metadata.name}' component.`,
@@ -669,7 +773,7 @@ export class Component extends OpenShiftItem {
                 });
             }
         } else {
-            void window.showWarningMessage('Debug command currently supports local components with Java, Node.Js and Python component types.');
+            void window.showWarningMessage('Debug command currently supports local components with Java, Node.js, Python, and Go component types.');
         }
         return result;
     }
@@ -706,6 +810,10 @@ export class Component extends OpenShiftItem {
                 if (config.type === 'python') {
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                     config.connect.port = port.fp.localPort;
+                } else if (config.type === 'go') {
+                    // Go debugger needs host and port separately for remote mode
+                    config.host = 'localhost';
+                    config.port = port.fp.localPort;
                 } else {
                     config.port = port.fp.localPort;
                 }
@@ -734,7 +842,7 @@ export class Component extends OpenShiftItem {
             // Update state
             const cs = Component.getComponentDevState(context);
             cs.deployStatus = ComponentContextState.DEP_STARTING;
-            Component.stateChanged.fire(context.contextPath);
+            fireComponentStateChanged(context.contextPath);
 
             // Execute deployment
             await deployComponent(
@@ -751,14 +859,14 @@ export class Component extends OpenShiftItem {
 
             // Update state
             cs.deployStatus = ComponentContextState.DEP_RUNNING;
-            Component.stateChanged.fire(context.contextPath);
+            fireComponentStateChanged(context.contextPath);
 
             void window.showInformationMessage(`Component '${componentName}' deployed successfully`);
         } catch (err) {
             // Reset state
             const cs = Component.getComponentDevState(context);
             cs.deployStatus = ComponentContextState.DEP;
-            Component.stateChanged.fire(context.contextPath);
+            fireComponentStateChanged(context.contextPath);
 
             void window.showErrorMessage(
                 `Deploy failed: ${err.message}. You can retry - oc apply is idempotent.`
@@ -781,7 +889,7 @@ export class Component extends OpenShiftItem {
         try {
             const cs = Component.getComponentDevState(context);
             cs.deployStatus = ComponentContextState.DEP_STOPPING;
-            Component.stateChanged.fire(context.contextPath);
+            fireComponentStateChanged(context.contextPath);
 
             await undeployComponent(
                 {
@@ -797,13 +905,13 @@ export class Component extends OpenShiftItem {
             );
 
             cs.deployStatus = ComponentContextState.DEP;
-            Component.stateChanged.fire(context.contextPath);
+            fireComponentStateChanged(context.contextPath);
 
             void window.showInformationMessage(`Component '${componentName}' undeployed`);
         } catch (err) {
             const cs = Component.getComponentDevState(context);
             cs.deployStatus = ComponentContextState.DEP_RUNNING;
-            Component.stateChanged.fire(context.contextPath);
+            fireComponentStateChanged(context.contextPath);
 
             void window.showErrorMessage(`Undeploy failed: ${err.message}`);
         }

--- a/src/openshift/componentStateFile.ts
+++ b/src/openshift/componentStateFile.ts
@@ -1,0 +1,75 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { Disposable, EventEmitter } from 'vscode';
+import { OpenShiftTerminalApi } from '../webview/openshift-terminal/openShiftTerminal';
+
+/**
+ * Component context state - used for setting/showing context menu items and tree icons.
+ */
+export enum ComponentContextState {
+    DEV = 'dev-nrn',
+    DEV_STARTING = 'dev-str',
+    DEV_RUNNING = 'dev-run',
+    DEV_STOPPING = 'dev-stp',
+    DEB = 'deb-nrn',
+    DEB_RUNNING = 'deb-run',
+    DEP = 'dep-nrn',
+    DEP_STARTING = 'dep-str',
+    DEP_RUNNING = 'dep-run',
+    DEP_STOPPING = 'dep-stp',
+}
+
+export interface DevProcessStopRequest extends Disposable {
+    isSigabrtSent: () => boolean;
+    sendSigabrt: () => void;
+}
+
+export interface ComponentDevState {
+    // dev state
+    devTerminal?: OpenShiftTerminalApi;
+    devStatus?: ComponentContextState;
+    contextValue?: string;
+    devProcessStopRequest?: DevProcessStopRequest;
+    // debug state
+    debugStatus?: string;
+    // deploy state
+    deployStatus?: string;
+    runOn?: undefined | 'podman';
+}
+
+/**
+ * In-memory component state map (dev/debug/deploy status, terminals, etc.).
+ * Extracted to break the circular dependency: explorer.ts → component.ts → explorer.ts
+ */
+export const componentStates = new Map<string, ComponentDevState>();
+
+/**
+ * Get component state by context path without creating a new one.
+ * Returns undefined if no state exists for the given path.
+ */
+export function getComponentStateByContext(contextPath: string): ComponentDevState | undefined {
+    return componentStates.get(contextPath);
+}
+
+/**
+ * Event emitter for component state changes.
+ * Fires with the context path when any component's state changes.
+ */
+const stateChangedEmitter = new EventEmitter<string>();
+
+/**
+ * Subscribe to component state changes.
+ */
+export function onComponentStateChanged(listener: (context: string) => any): Disposable {
+    return stateChangedEmitter.event(listener);
+}
+
+/**
+ * Fire a component state change event for the given context path.
+ */
+export function fireComponentStateChanged(contextPath: string): void {
+    stateChangedEmitter.fire(contextPath);
+}

--- a/src/registriesView.ts
+++ b/src/registriesView.ts
@@ -14,7 +14,7 @@ import { DevfileRegistry } from './devfile-registry/devfileRegistryWrapper';
 import {
     Registry
 } from './odo/componentType';
-import { StarterProject } from './odo/componentTypeDescription';
+import { StarterProject } from './devfile/componentTypeDescription';
 import { OdoPreference } from './odo/odoPreference';
 import { Odo } from './odo/odoWrapper';
 import { inputValue, quickBtn } from './util/inputValue';

--- a/src/util/devfileConverter.ts
+++ b/src/util/devfileConverter.ts
@@ -12,7 +12,7 @@ import {
     V230DevfileMetadata,
     V230DevfileProjects
 } from '@devfile/api';
-import { Data, Endpoint, Metadata } from '../odo/componentTypeDescription';
+import { Data, Endpoint, Metadata } from '../devfile/componentTypeDescription';
 import { ComponentV1, DevfileCommandV1, DevfileV1, DevfileVolumeV1, EndpointV1, EnvV1, MetadataV1, ProjectV1 } from './devfileV1Type';
 
 export type DevfileMetadataLike = V230DevfileMetadata & object;

--- a/src/util/kubeUtils.ts
+++ b/src/util/kubeUtils.ts
@@ -448,6 +448,33 @@ export async function detectKubernetesVariant(executionContext?: ExecutionContex
     return KubernetesVariant.Generic;
 }
 
+export type ClusterPlatformLabel = 'OpenShift' | 'Kubernetes' | 'Kind' | 'Minikube';
+
+export interface ClusterPlatformInfo {
+    isOpenShift: boolean;
+    variant: KubernetesVariant;
+    label: ClusterPlatformLabel;
+}
+
+/**
+ * Resolves which specific Kubernetes/OpenShift distribution the current context targets,
+ * for display purposes (e.g. describe's "Running on" field).
+ */
+export async function resolveClusterPlatform(executionContext?: ExecutionContext): Promise<ClusterPlatformInfo> {
+    const isOpenShift = await isOpenShiftCluster(executionContext);
+    const variant = isOpenShift ? KubernetesVariant.Generic : await detectKubernetesVariant(executionContext);
+
+    const label: ClusterPlatformLabel = isOpenShift
+        ? 'OpenShift'
+        : variant === KubernetesVariant.Kind
+            ? 'Kind'
+            : variant === KubernetesVariant.Minikube
+                ? 'Minikube'
+                : 'Kubernetes';
+
+    return { isOpenShift, variant, label };
+}
+
 export async function getNamespaceKind(executionContext?: ExecutionContext): Promise<string> {
     if (executionContext && executionContext.has(getNamespaceKind.name)) {
         return executionContext.get(getNamespaceKind.name);

--- a/src/webview/common/devfile.ts
+++ b/src/webview/common/devfile.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { StarterProject } from '../../odo/componentTypeDescription';
+import { StarterProject } from '../../devfile/componentTypeDescription';
 
 export type Devfile = {
     name: string;

--- a/src/webview/common/propertyTypes.ts
+++ b/src/webview/common/propertyTypes.ts
@@ -7,7 +7,7 @@ import React from 'react';
 import { Uri } from 'vscode';
 import { ChartResponse } from '../../helm/helmChartType';
 import { ComponentTypeDescription, Registry } from '../../odo/componentType';
-import { StarterProject } from '../../odo/componentTypeDescription';
+import { StarterProject } from '../../devfile/componentTypeDescription';
 
 export interface DefaultProps {
     analytics?: import('@segment/analytics-next').Analytics;

--- a/src/webview/create-component/createComponentLoader.ts
+++ b/src/webview/create-component/createComponentLoader.ts
@@ -15,7 +15,7 @@ import { Alizer } from '../../alizer/alizerWrapper';
 import { AlizerDevfileResponse, Version } from '../../alizer/types';
 import { DevfileInfo, DevfileInfoExt, DevfileVersionInfo } from '../../devfile-registry/devfileInfo';
 import { DevfileRegistry } from '../../devfile-registry/devfileRegistryWrapper';
-import { Endpoint } from '../../odo/componentTypeDescription';
+import { Endpoint } from '../../devfile/componentTypeDescription';
 import { Odo } from '../../odo/odoWrapper';
 import { ComponentTypesView } from '../../registriesView';
 import sendTelemetry from '../../telemetry';

--- a/src/webview/openshift-terminal/openShiftTerminal.ts
+++ b/src/webview/openshift-terminal/openShiftTerminal.ts
@@ -704,35 +704,80 @@ export class OpenShiftTerminalManager implements WebviewViewProvider {
         // create the object that manages the headless terminal and the pty.
         // the process is run as a child process under node.
         // the webview is synchronized to the pty and headless terminal using message passing
-        this.openShiftTerminals.set(
+        const term = new OpenShiftTerminal(
             newTermUUID,
-            new OpenShiftTerminal(
-                newTermUUID,
-                (message: Message) => {
-                    return this.sendMessage(message);
-                },
-                toolLocation,
-                commandText.args,
-                {
-                    cwd,
-                    env,
-                    name,
-                },
-                isKnative,
-                callbacks
-            )
+            (message: Message) => {
+                return this.sendMessage(message);
+            },
+            toolLocation,
+            commandText.args,
+            {
+                cwd,
+                env,
+                name,
+            },
+            isKnative,
+            callbacks
         );
 
+        return this.registerTerminal(newTermUUID, term, name);
+    }
+
+    /**
+     * Creates an interactive "virtual" terminal tab that isn't backed by a real spawned process
+     * (no `node-pty`, no executable resolution via `ToolsConfig`) — the caller pushes output over
+     * time via the returned API's `sendText()`, and `callbacks.onText` fires for terminal input
+     * exactly like a real spawned terminal's callbacks would (including a user pressing Ctrl-C,
+     * delivered as the raw control byte rather than the printable `^C` a real pty's line
+     * discipline would echo). Used by `devTerminalBridge.ts` to stream dev-session output without
+     * shelling out to a real CLI process.
+     */
+    public async createVirtualTerminal(
+        name: string,
+        cwd: string = process.cwd(),
+        env = process.env,
+        callbacks?: {
+            onSpawn?: () => void;
+            onExit?: (exitCode: number) => void;
+            onText?: (text: string) => void;
+        },
+    ): Promise<OpenShiftTerminalApi> {
+        await commands.executeCommand('openShiftTerminalView.focus');
+        await this.webviewResolved;
+
+        const uuid = randomUUID();
+        const term = new OpenShiftTerminal(
+            uuid,
+            (message: Message) => this.sendMessage(message),
+            '',   // no executable
+            [],
+            { cwd, env, name },
+            false,
+            callbacks,
+            false // do NOT spawn a real pty
+        );
+
+        return this.registerTerminal(uuid, term, name);
+    }
+
+    private async registerTerminal(uuid: string, term: OpenShiftTerminal, name: string): Promise<OpenShiftTerminalApi> {
+        this.openShiftTerminals.set(uuid, term);
+
         // issue request to create terminal in the webview
-        await this.sendMessage({ kind: 'createTerminal', data: { uuid: newTermUUID, name } });
+        await this.sendMessage({ kind: 'createTerminal', data: { uuid, name } });
 
         return {
-            sendText: (text: string) => this.openShiftTerminals.get(newTermUUID).write(text),
+            sendText: (text: string) => this.openShiftTerminals.get(uuid).write(text),
             focusTerminal: () =>
-                void this.sendMessage({ kind: 'switchToTerminal', data: { uuid: newTermUUID } }),
-            kill: () => this.openShiftTerminals.get(newTermUUID).write('\u0003'),
-            forceKill: () => this.openShiftTerminals.get(newTermUUID).forceKill(),
-            id: newTermUUID
+                void this.sendMessage({ kind: 'switchToTerminal', data: { uuid } }),
+            kill: () => this.openShiftTerminals.get(uuid).write('\u0003'),
+            forceKill: () => {
+                const term = this.openShiftTerminals.get(uuid);
+                term.forceKill();
+                // Send termExit message to actually close the terminal tab in the UI
+                void this.sendMessage({ kind: 'termExit', data: { uuid } });
+            },
+            id: uuid
         };
     }
 

--- a/test/integration/command.test.ts
+++ b/test/integration/command.test.ts
@@ -3,24 +3,19 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { V230Devfile } from '@devfile/api';
-import { fail } from 'assert';
 import { assert, expect } from 'chai';
-import { ChildProcess } from 'child_process';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as tmp from 'tmp';
 import { promisify } from 'util';
-import { EventEmitter, Terminal, window, workspace } from 'vscode';
-import { parse, stringify } from 'yaml';
+import { workspace } from 'vscode';
+import { stringify } from 'yaml';
 import { CommandText } from '../../src/base/command';
 import { CliChannel } from '../../src/cli';
-import { DevfileCommandRunner } from '../../src/devfile/devfileCommandRunner';
+import { getComponentDescription } from '../../src/devfile/describe';
 import { initComponent } from '../../src/devfile/init';
 import { Oc } from '../../src/oc/ocWrapper';
-import { Command } from '../../src/odo/command';
 import { OdoPreference } from '../../src/odo/odoPreference';
-import { Odo } from '../../src/odo/odoWrapper';
 import { ComponentWorkspaceFolder } from '../../src/odo/workspace';
 import { LoginUtil } from '../../src/util/loginUtil';
 import { YAML_STRINGIFY_OPTIONS } from '../../src/util/utils';
@@ -116,7 +111,7 @@ suite('odo commands integration', function () {
 
                 const componentFolder: ComponentWorkspaceFolder = {
                     contextPath: componentLocation,
-                    component: await Odo.Instance.describeComponent(componentLocation)
+                    component: await getComponentDescription(componentLocation)
                 };
 
                 // Import deploy functions
@@ -169,287 +164,13 @@ suite('odo commands integration', function () {
             });
         });
 
-        test('dev()', async function() {
-            const outputEmitter = new EventEmitter<string>();
-            let devProcess: ChildProcess;
-            function failListener(_error) {
-                assert.fail('odo dev errored before it was closed');
-            }
-            const term = window.createTerminal({
-                name: 'test terminal',
-                pty: {
-                    open: () => {
-                        void CliChannel.getInstance().spawnTool(Command.dev(false)) //
-                            .then(childProcess => {
-                                devProcess = childProcess
-                                devProcess.on('error', failListener);
-                            });
-                    },
-                    close: () => {
-                        if (devProcess) {
-                            devProcess.removeListener('error', failListener);
-                            devProcess.kill('SIGINT');
-                        }
-                    },
-                    handleInput: (data: string) => {
-                        if (data.length) {
-                            if (devProcess) {
-                                devProcess.removeListener('error', failListener);
-                                devProcess.kill('SIGINT');
-                            }
-                        }
-                    },
-                    onDidWrite: outputEmitter.event
-                }
-            });
-            await new Promise<void>(resolve => setTimeout(resolve, 3000));
-            // we instruct the pseudo terminal to close the dev session when any text is sent
-            term.sendText('a');
-            term.dispose();
-        });
+        // Dev mode tests removed - now using native TypeScript implementation
+        // See test/integration/dev.test.ts for comprehensive dev mode test coverage
 
     });
 
-    suite('component dev', function() {
-        const componentName = 'my-test-component';
-        const componentType = 'nodejs';
-        const componentStarterProject = 'nodejs-starter';
-        let componentLocation: string;
-
-        suiteSetup(async function () {
-            if (isOpenShift) {
-                await Oc.Instance.loginWithUsernamePassword(clusterUrl, username, password);
-            }
-            try {
-                await Oc.Instance.createProject(newProjectName);
-            } catch {
-                // do nothing; already exists
-            }
-            await Oc.Instance.setProject(newProjectName);
-            componentLocation = await promisify(tmp.dir)();
-        });
-
-        suiteTeardown(async function () {
-            let toRemove = -1;
-            for (let i = 0; i < workspace.workspaceFolders.length; i++) {
-                if (workspace.workspaceFolders[i].uri.fsPath === componentLocation) {
-                    toRemove = i;
-                    break;
-                }
-            }
-            if (toRemove !== -1) {
-                workspace.updateWorkspaceFolders(toRemove, 1);
-                // Give VSCode time to process workspace update before deleting
-                await new Promise(resolve => setTimeout(resolve, 100));
-            }
-            await fs.rm(componentLocation, { recursive: true, force: true });
-            await Oc.Instance.deleteProject(newProjectName);
-        });
-
-        interface TerminalListener {
-            onOutput(data: string): void;
-            onError(data:string): void;
-        }
-
-        function executeCommandInTerminal(commandText: CommandText, cwd: string, listener?: TerminalListener) : Terminal {
-            const outputEmitter = new EventEmitter<string>();
-            outputEmitter.event(data => {
-                if (listener) listener.onOutput(data);
-            });
-            let devProcess: ChildProcess;
-            function failListener(_error) {
-                assert.fail('odo dev errored before it was closed');
-            }
-            return window.createTerminal({
-                name: 'test terminal',
-                pty: {
-                    open: () => {
-                        void CliChannel.getInstance().spawnTool(Command.dev(true),
-                            {
-                                cwd
-                            })
-                            .then(childProcess => {
-                                devProcess = childProcess
-                                devProcess.on('error', failListener);
-                                devProcess.stdout.on('data', data => {
-                                    if (listener) listener.onOutput(data);
-                                });
-                                devProcess.stderr.on('data', data => {
-                                    if (listener) listener.onError(data);
-                                });
-                            });
-                    },
-                    close: () => {
-                        if (devProcess) {
-                            devProcess.removeListener('error', failListener);
-                            devProcess.kill('SIGINT');
-                        }
-                    },
-                    handleInput: (data: string) => {
-                        // Close terminal on any input
-                        if (data.length) {
-                            if (devProcess) {
-                                devProcess.removeListener('error', failListener);
-                                devProcess.kill('SIGINT');
-                            }
-                        }
-                    },
-                    onDidWrite: outputEmitter.event
-                }
-            });
-        }
-
-        async function startDevInTerminal(cwd?) : Promise<Terminal> {
-            let termOutput = '';
-            let termError = '';
-            const term = executeCommandInTerminal(Command.dev(true), cwd, {
-                onOutput(data) {
-                    termOutput = termOutput.concat(data);
-                },
-                onError(data) {
-                    termError = termError.concat(data);
-                }
-            });
-
-            let hopesLeft = 30;
-            let devIsRunning;
-            do {
-                hopesLeft--;
-                await new Promise<void>(resolve => setTimeout(resolve, 2000));
-                let index = termOutput.indexOf(`Developing using the "${componentName}" Devfile`);
-                if (index >= 0) index = termOutput.indexOf('✓  Pod is Running', index);
-                if (index >= 0) index = termOutput.indexOf('↪ Dev mode', index);
-                devIsRunning = (index >= 0);
-            } while (hopesLeft > 0 && !devIsRunning);
-            if (!devIsRunning) {
-                if (termError.trim().length > 0) {
-                    fail(`Start Dev failed: ${termError}`);
-                }
-                fail('Waiting for pod to start is timed out');
-            }
-            return term;
-        }
-
-        const helloWorldCommandId = 'hello-world';
-        const helloWorldCommandOutput = 'Hello, World!';
-        const helloWorldCommandExecCommandLine = `echo "${helloWorldCommandOutput}"`;
-
-        async function fixupDevFile(devfilePath: string): Promise<void> {
-            // Parse YAML into an Object, add:
-            //
-            // - exec:
-            //     group:
-            //       kind: run
-            //     commandLine: echo "Hello, World!"
-            //     component: runtime
-            //   id: hello-world
-            //
-            // and then save into the same debfile.yaml
-            const file = await fs.readFile(devfilePath, 'utf8');
-            const devfile = parse(file.toString()) as V230Devfile;
-            if (!devfile || !devfile.commands) {
-                fail(`DevFile '${devfilePath}' cannot be read`);
-            }
-            const devfileCommands = devfile.commands;
-            let helloWorldCommand;
-            for (let i = 0; i < devfileCommands.length; i++) {
-                if(devfileCommands[i].id === helloWorldCommandId) {
-                    helloWorldCommand = devfileCommands[i];
-                    break;
-                }
-            }
-            if (helloWorldCommand) {
-                helloWorldCommand.exec = {
-                    group:{
-                        kind: 'run'
-                    },
-                    commandLine: helloWorldCommandExecCommandLine,
-                    component: 'runtime'
-                }
-            } else {
-                devfileCommands.push({
-                    exec: {
-                        group:{
-                            kind: 'run'
-                        },
-                        commandLine: helloWorldCommandExecCommandLine,
-                        component: 'runtime'
-                    },
-                    id: helloWorldCommandId
-                })
-            }
-            await fs.writeFile(devfilePath, stringify(devfile, YAML_STRINGIFY_OPTIONS));
-        }
-
-        test('runComponentCommand()', async function () {
-            await initComponent({
-                projectPath: componentLocation,
-                name: componentName,
-
-                registryDevfile: componentType,
-                devfileVersion: '2.1.1',
-                registry: OdoPreference.DEFAULT_DEVFILE_REGISTRY_NAME,
-
-                starterProject: componentStarterProject
-            });
-
-            const devfilePath = path.join(componentLocation, 'devfile.yaml')
-            await fs.access(devfilePath);
-
-            await fixupDevFile(devfilePath);
-
-            const componentDescription = await Odo.Instance.describeComponent(componentLocation);
-
-            expect(componentDescription.devfileData.devfile.commands[0]?.id).exist;
-
-            const commands = componentDescription.devfileData.devfile.commands
-            let helloCommand: Command;
-            for (let i = 0; i < commands.length; i++) {
-                if (commands[i].id && helloWorldCommandId === commands[i].id) {
-                    helloCommand = commands[i];
-                    break;
-                }
-            }
-            if (!helloCommand) {
-                fail(`Command '${helloWorldCommandId}' doesn't exist in Component '${componentName}'`);
-            }
-
-            let devTerm: Terminal;
-
-            try {
-
-                devTerm =
-                    await startDevInTerminal(
-                        componentLocation
-                    );
-
-                const componentFolder: ComponentWorkspaceFolder = {
-                    contextPath: componentLocation,
-                    component: componentDescription
-                };
-
-                await DevfileCommandRunner.execute(
-                    componentFolder,
-                    helloWorldCommandId
-                );
-
-            } catch (err) {
-
-                fail(
-                    err instanceof Error
-                        ? err.message
-                        : String(err)
-                );
-
-            } finally {
-
-                if (devTerm) {
-                    devTerm.sendText('exit');
-                    devTerm.dispose();
-                }
-            }
-        });
-    });
+    // "component dev" suite removed - tested old odo CLI-based dev mode
+    // Dev mode is now native TypeScript - see test/integration/dev.test.ts for coverage
 
     suite('container runtime detection', function () {
         let detectedRuntime: string | null;
@@ -576,7 +297,7 @@ suite('odo commands integration', function () {
 
             const componentFolder: ComponentWorkspaceFolder = {
                 contextPath: componentLocation,
-                component: await Odo.Instance.describeComponent(componentLocation),
+                component: await getComponentDescription(componentLocation),
             };
 
             const result = await deployComponent(
@@ -606,7 +327,7 @@ suite('odo commands integration', function () {
 
             const componentFolder: ComponentWorkspaceFolder = {
                 contextPath: componentLocation,
-                component: await Odo.Instance.describeComponent(componentLocation),
+                component: await getComponentDescription(componentLocation),
             };
 
             await undeployComponent(

--- a/test/integration/describe.test.ts
+++ b/test/integration/describe.test.ts
@@ -1,0 +1,243 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { expect } from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { stringify } from 'yaml';
+import { DeployedResource, DeployState, DeployStateFile } from '../../src/devfile/componentTypeDescription';
+import { deployContextKey, getCurrentClusterAndNamespace } from '../../src/devfile/deployStateFile';
+import { getComponentDescription } from '../../src/devfile/describe';
+import { clearDevState, saveDevState } from '../../src/devfile/inner-loop/devStateFile';
+import { Oc } from '../../src/oc/ocWrapper';
+import { resolveClusterPlatform } from '../../src/util/kubeUtils';
+
+/**
+ * Covers describe.ts's dual dev/deploy-state merge — the part of the native `describe` rework
+ * this plan's other integration suites don't exercise (they call `getComponentDescription()`
+ * only incidentally, not to verify its own status-computation branches).
+ */
+suite('devfile/describe.ts', function () {
+    this.timeout(60000);
+
+    const TEST_NAMESPACE = 'describe-it-tests';
+    const COMPONENT_NAME = 'describe-it-test-component';
+
+    let componentPath: string;
+    let devfilePath: string;
+
+    function buildDeployedResource(labels: Record<string, string> = {}): DeployedResource {
+        return {
+            kind: 'Deployment',
+            name: COMPONENT_NAME,
+            namespace: TEST_NAMESPACE,
+            labels,
+            appliedAt: new Date().toISOString(),
+        };
+    }
+
+    async function writeDeployState(resources: DeployedResource[]): Promise<void> {
+        const { cluster, namespace } = await getCurrentClusterAndNamespace();
+        const state: DeployState = {
+            version: 2,
+            componentName: COMPONENT_NAME,
+            deployedAt: new Date().toISOString(),
+            platform: 'kubernetes',
+            cluster,
+            namespace,
+            resources,
+        };
+        const file: DeployStateFile = {
+            version: 2,
+            deployments: { [deployContextKey(cluster, namespace)]: state },
+        };
+        const odoDir = path.join(componentPath, '.odo');
+        await fs.mkdir(odoDir, { recursive: true });
+        await fs.writeFile(path.join(odoDir, 'deploystate.json'), JSON.stringify(file, null, 2), 'utf-8');
+    }
+
+    async function clearDeployState(): Promise<void> {
+        await fs.rm(path.join(componentPath, '.odo', 'deploystate.json'), { force: true });
+    }
+
+    suiteSetup(async function () {
+        await Oc.Instance.applyConfiguration(JSON.stringify({
+            apiVersion: 'v1',
+            kind: 'Namespace',
+            metadata: { name: TEST_NAMESPACE },
+        }));
+    });
+
+    suiteTeardown(async function () {
+        await Oc.Instance.deleteKubernetesObject('namespace', TEST_NAMESPACE).catch(() => {});
+    });
+
+    setup(async function () {
+        componentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'describe-it-'));
+        devfilePath = path.join(componentPath, 'devfile.yaml');
+        await fs.writeFile(devfilePath, stringify({
+            schemaVersion: '2.2.0',
+            metadata: { name: COMPONENT_NAME, version: '1.0.0' },
+            components: [
+                {
+                    name: 'runtime',
+                    container: {
+                        image: 'my-image:latest',
+                        memoryLimit: '256Mi',
+                        endpoints: [{ name: 'http', targetPort: 8080 }],
+                    },
+                },
+            ],
+            commands: [
+                {
+                    id: 'run',
+                    exec: { commandLine: 'npm start', component: 'runtime', group: { kind: 'run', isDefault: true } },
+                },
+            ],
+        }), 'utf-8');
+    });
+
+    teardown(async function () {
+        await clearDevState(componentPath);
+        await clearDeployState();
+        await fs.rm(componentPath, { recursive: true, force: true });
+    });
+
+    test('reports nothing running when there is no dev state, deploy state, or live cluster resource', async function () {
+        const result = await getComponentDescription(devfilePath, { namespace: TEST_NAMESPACE, componentName: COMPONENT_NAME });
+
+        expect(result.runningIn).to.deep.equal([]);
+        expect(result.runningOn).to.deep.equal([]);
+        expect(result.managedBy).to.be.undefined;
+    });
+
+    test('reports Dev running on the cluster platform, with a single forwarded-port entry', async function () {
+        await saveDevState({
+            pid: 1234,
+            platform: 'cluster',
+            forwardedPorts: [{
+                containerName: 'runtime', portName: 'http', localAddress: '127.0.0.1',
+                localPort: 40000, containerPort: 8080,
+            }],
+        }, componentPath);
+
+        const result = await getComponentDescription(devfilePath, { namespace: TEST_NAMESPACE, componentName: COMPONENT_NAME });
+
+        expect(result.runningIn).to.deep.equal(['Dev']);
+        expect(result.runningOn).to.deep.equal(['cluster: Dev']);
+        expect(result.devForwardedPorts).to.have.lengthOf(1);
+        expect(result.devForwardedPorts[0].platform).to.equal('cluster');
+    });
+
+    test('reports Dev running on podman, with cluster+podman forwarded-port entries', async function () {
+        await saveDevState({
+            pid: 1234,
+            platform: 'podman',
+            forwardedPorts: [{
+                containerName: 'runtime', portName: 'http', localAddress: '127.0.0.1',
+                localPort: 40000, containerPort: 8080,
+            }],
+        }, componentPath);
+
+        const result = await getComponentDescription(devfilePath, { namespace: TEST_NAMESPACE, componentName: COMPONENT_NAME });
+
+        expect(result.runningIn).to.deep.equal(['Dev']);
+        expect(result.runningOn).to.deep.equal(['podman: Dev']);
+        expect(result.devForwardedPorts.map(p => p.platform).sort()).to.deep.equal(['cluster', 'podman']);
+    });
+
+    test('reports Deploy running from deploystate.json, sourcing managedBy from its resource labels', async function () {
+        await writeDeployState([buildDeployedResource({ 'app.kubernetes.io/managed-by': 'my-custom-tool' })]);
+
+        const result = await getComponentDescription(devfilePath, { namespace: TEST_NAMESPACE, componentName: COMPONENT_NAME });
+
+        const { label } = await resolveClusterPlatform();
+        expect(result.runningIn).to.deep.equal(['Deploy']);
+        expect(result.runningOn).to.deep.equal([`${label}: Deploy`]);
+        expect(result.managedBy).to.equal('my-custom-tool');
+    });
+
+    test('defaults managedBy to openshift-toolkit when deploystate.json resources have no managed-by label', async function () {
+        await writeDeployState([buildDeployedResource()]);
+
+        const result = await getComponentDescription(devfilePath, { namespace: TEST_NAMESPACE, componentName: COMPONENT_NAME });
+
+        expect(result.managedBy).to.equal('openshift-toolkit');
+    });
+
+    test('reports both Dev and Deploy simultaneously when both states are present', async function () {
+        await saveDevState({ pid: 1234, platform: 'cluster', forwardedPorts: [] }, componentPath);
+        await writeDeployState([buildDeployedResource({ 'app.kubernetes.io/managed-by': 'openshift-toolkit' })]);
+
+        const result = await getComponentDescription(devfilePath, { namespace: TEST_NAMESPACE, componentName: COMPONENT_NAME });
+
+        expect(result.runningIn).to.deep.equal(['Dev', 'Deploy']);
+        expect(result.runningOn).to.have.lengthOf(2);
+        expect(result.runningOn[0]).to.equal('cluster: Dev');
+    });
+
+    suite('live cluster fallback (no deploystate.json)', function () {
+
+        teardown(async function () {
+            await Oc.Instance.deleteKubernetesObject('deployment', COMPONENT_NAME, TEST_NAMESPACE).catch(() => {});
+        });
+
+        test('sources managedBy from a live Deployment\'s label when no deploystate.json exists', async function () {
+            await Oc.Instance.applyConfiguration(JSON.stringify({
+                apiVersion: 'apps/v1',
+                kind: 'Deployment',
+                metadata: {
+                    name: COMPONENT_NAME,
+                    namespace: TEST_NAMESPACE,
+                    labels: {
+                        'app.kubernetes.io/instance': COMPONENT_NAME,
+                        'app.kubernetes.io/managed-by': 'someone-else',
+                    },
+                },
+                spec: {
+                    replicas: 0,
+                    selector: { matchLabels: { app: COMPONENT_NAME } },
+                    template: {
+                        metadata: { labels: { app: COMPONENT_NAME } },
+                        spec: { containers: [{ name: 'main', image: 'my-image:latest' }] },
+                    },
+                },
+            }));
+
+            const result = await getComponentDescription(devfilePath, { namespace: TEST_NAMESPACE, componentName: COMPONENT_NAME });
+
+            const { label } = await resolveClusterPlatform();
+            expect(result.runningIn).to.deep.equal(['Deploy']);
+            expect(result.runningOn).to.deep.equal([`${label}: Deploy`]);
+            expect(result.managedBy).to.equal('someone-else');
+        });
+
+        test('reports managedBy as Unknown when the live Deployment has no managed-by label', async function () {
+            await Oc.Instance.applyConfiguration(JSON.stringify({
+                apiVersion: 'apps/v1',
+                kind: 'Deployment',
+                metadata: {
+                    name: COMPONENT_NAME,
+                    namespace: TEST_NAMESPACE,
+                    labels: { 'app.kubernetes.io/instance': COMPONENT_NAME },
+                },
+                spec: {
+                    replicas: 0,
+                    selector: { matchLabels: { app: COMPONENT_NAME } },
+                    template: {
+                        metadata: { labels: { app: COMPONENT_NAME } },
+                        spec: { containers: [{ name: 'main', image: 'my-image:latest' }] },
+                    },
+                },
+            }));
+
+            const result = await getComponentDescription(devfilePath, { namespace: TEST_NAMESPACE, componentName: COMPONENT_NAME });
+
+            expect(result.runningIn).to.deep.equal(['Deploy']);
+            expect(result.managedBy).to.equal('Unknown');
+        });
+    });
+});

--- a/test/integration/dev.test.ts
+++ b/test/integration/dev.test.ts
@@ -1,0 +1,216 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { Exec, KubeConfig } from '@kubernetes/client-node';
+import { expect } from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Writable } from 'stream';
+import { ComponentDescription, Data } from '../../src/devfile/componentTypeDescription';
+import { forceStopDevSession, isDevSessionActive, startDevSession, stopDevSession } from '../../src/devfile/dev';
+import { loadDevState } from '../../src/devfile/inner-loop/devStateFile';
+import { Oc } from '../../src/oc/ocWrapper';
+import { ComponentWorkspaceFolder } from '../../src/odo/workspace';
+import { connectAndRead } from './inner-loop/netTestUtils';
+
+/**
+ * Exercises dev.ts's own orchestration layer end to end against a real Kind cluster — distinct
+ * from clusterDevPlatform.test.ts, which calls ClusterDevPlatform directly and never touches
+ * dev.ts/devSession.ts's registry, devstate.json persistence, or (most importantly) the
+ * file-watcher-driven sync path, since it only ever calls sync()/restartRunCommand() manually.
+ */
+suite('devfile/dev.ts', function () {
+    this.timeout(180000);
+
+    const COMPONENT_NAME = 'dev-ts-it';
+    const ENDPOINT_PORT = 8080;
+    const TEST_IMAGE = 'nodejs-image:latest';
+    const NAMESPACE = 'dev-ts-it-tests';
+
+    let componentPath: string;
+    let previousNamespace: string;
+    let kc: KubeConfig;
+    const output: string[] = [];
+
+    function buildDevfile(): Data {
+        return {
+            schemaVersion: '2.2.0',
+            metadata: { name: COMPONENT_NAME, version: '1.0.0' },
+            components: [
+                {
+                    name: 'runtime',
+                    container: {
+                        image: TEST_IMAGE,
+                        memoryLimit: '256Mi',
+                        mountSources: true,
+                        volumeMounts: [],
+                        endpoints: [{ name: 'http', targetPort: ENDPOINT_PORT }],
+                    },
+                },
+            ],
+            commands: [
+                {
+                    id: 'run',
+                    exec: {
+                        commandLine: `node -e "require('net').createServer(c=>{c.end('hello');}).listen(${ENDPOINT_PORT})"`,
+                        component: 'runtime',
+                        workingDir: '${PROJECT_SOURCE}',
+                        group: { kind: 'run', isDefault: true },
+                    },
+                },
+            ],
+        };
+    }
+
+    function buildComponentFolder(): ComponentWorkspaceFolder {
+        return {
+            contextPath: componentPath,
+            component: {
+                devfilePath: path.join(componentPath, 'devfile.yaml'),
+                devfileData: {
+                    devfile: buildDevfile(),
+                    commands: [],
+                    supportedOdoFeatures: { debug: false, deploy: false, dev: true },
+                },
+                devForwardedPorts: [],
+                runningIn: [],
+                runningOn: [],
+                managedBy: undefined,
+            } as unknown as ComponentDescription,
+        };
+    }
+
+    async function execCapture(podName: string, command: string[]): Promise<string> {
+        const exec = new Exec(kc);
+        const chunks: Buffer[] = [];
+        const stdout = new Writable({
+            write(chunk, _encoding, callback) {
+                chunks.push(Buffer.from(chunk));
+                callback();
+            },
+        });
+
+        await new Promise<void>((resolve, reject) => {
+            exec.exec(NAMESPACE, podName, 'runtime', command, stdout, null, null, false, (status) => {
+                if (status.status === 'Failure') {
+                    reject(new Error(status.message ?? 'command failed'));
+                } else {
+                    resolve();
+                }
+            }).catch(reject);
+        });
+
+        return Buffer.concat(chunks).toString('utf-8');
+    }
+
+    async function waitUntil(predicate: () => Promise<boolean>, timeoutMs: number, intervalMs = 1000): Promise<void> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            if (await predicate()) {
+                return;
+            }
+            await new Promise(resolve => setTimeout(resolve, intervalMs));
+        }
+        throw new Error('Timed out waiting for condition');
+    }
+
+    suiteSetup(async function () {
+        componentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'dev-ts-it-'));
+        kc = new KubeConfig();
+        kc.loadFromDefault();
+
+        // startDevSession() -> ClusterDevPlatform.start() deploys into the *ambient current*
+        // namespace, matching real dev-mode usage — pin a known-good one, restore afterward.
+        previousNamespace = await Oc.Instance.getActiveProject();
+        await Oc.Instance.applyConfiguration(JSON.stringify({
+            apiVersion: 'v1',
+            kind: 'Namespace',
+            metadata: { name: NAMESPACE },
+        }));
+        await Oc.Instance.setProject(NAMESPACE);
+    });
+
+    suiteTeardown(async function () {
+        await forceStopDevSession(componentPath).catch(() => {});
+        await fs.rm(componentPath, { recursive: true, force: true });
+        await Oc.Instance.deleteKubernetesObject('namespace', NAMESPACE).catch(() => {});
+        await Oc.Instance.setProject(previousNamespace).catch(() => {});
+    });
+
+    test('startDevSession() deploys the component and persists devstate.json', async function () {
+        expect(isDevSessionActive(componentPath)).to.be.false;
+
+        await startDevSession(
+            buildDevfile(),
+            buildComponentFolder(),
+            {},
+            { onOutput: line => output.push(line) },
+        );
+
+        expect(isDevSessionActive(componentPath)).to.be.true;
+
+        const devState = await loadDevState(componentPath);
+        expect(devState).to.not.be.null;
+        expect(devState.platform).to.equal('cluster');
+        expect(devState.forwardedPorts).to.have.lengthOf(1);
+        expect(devState.forwardedPorts[0].containerPort).to.equal(ENDPOINT_PORT);
+
+        const response = await connectAndRead(devState.forwardedPorts[0].localPort);
+        expect(response).to.equal('hello');
+    });
+
+    test('rejects starting a second session for the same component path', async function () {
+        try {
+            await startDevSession(buildDevfile(), buildComponentFolder(), {}, { onOutput: () => {} });
+            expect.fail('Should have thrown error');
+        } catch (err) {
+            expect(err.message).to.equal(`A dev session is already running for '${componentPath}'`);
+        }
+    });
+
+    test('the file watcher syncs a new local file into the running container without manual intervention', async function () {
+        await fs.writeFile(path.join(componentPath, 'marker.txt'), 'synced-by-watcher');
+
+        await waitUntil(async () => {
+            try {
+                const podName = await Oc.Instance.getComponentPod(COMPONENT_NAME);
+                const content = await execCapture(podName, ['cat', '/projects/marker.txt']);
+                return content === 'synced-by-watcher';
+            } catch {
+                return false;
+            }
+        }, 20000);
+    });
+
+    test('stopDevSession() tears down the Deployment and clears devstate.json', async function () {
+        await stopDevSession(componentPath);
+
+        expect(isDevSessionActive(componentPath)).to.be.false;
+        expect(await loadDevState(componentPath)).to.be.null;
+
+        const deadline = Date.now() + 30000;
+        let stillExists = true;
+        while (stillExists && Date.now() < deadline) {
+            try {
+                await Oc.Instance.getKubernetesObject('deployment', COMPONENT_NAME, NAMESPACE);
+                await new Promise(resolve => setTimeout(resolve, 1000));
+            } catch {
+                stillExists = false;
+            }
+        }
+        expect(stillExists).to.be.false;
+    });
+
+    test('forceStopDevSession() tears down a running session', async function () {
+        await startDevSession(buildDevfile(), buildComponentFolder(), {}, { onOutput: () => {} });
+        expect(isDevSessionActive(componentPath)).to.be.true;
+
+        await forceStopDevSession(componentPath);
+
+        expect(isDevSessionActive(componentPath)).to.be.false;
+        expect(await loadDevState(componentPath)).to.be.null;
+    });
+});

--- a/test/integration/inner-loop/clusterDevPlatform.test.ts
+++ b/test/integration/inner-loop/clusterDevPlatform.test.ts
@@ -1,0 +1,210 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { Exec, KubeConfig } from '@kubernetes/client-node';
+import { expect } from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Writable } from 'stream';
+import { ComponentDescription, Data } from '../../../src/devfile/componentTypeDescription';
+import { ClusterDevPlatform } from '../../../src/devfile/inner-loop/clusterDevPlatform';
+import { DevPlatformSession } from '../../../src/devfile/inner-loop/devPlatform';
+import { Oc } from '../../../src/oc/ocWrapper';
+import { ComponentWorkspaceFolder } from '../../../src/odo/workspace';
+import { connectAndRead } from './netTestUtils';
+
+const COMPONENT_NAME = 'cluster-dev-platform-it';
+const ENDPOINT_PORT = 8080;
+const TEST_IMAGE = 'nodejs-image:latest';
+
+function buildDevfile(): Data {
+    return {
+        schemaVersion: '2.2.0',
+        metadata: { name: COMPONENT_NAME, version: '1.0.0' },
+        components: [
+            {
+                name: 'runtime',
+                container: {
+                    image: TEST_IMAGE,
+                    memoryLimit: '256Mi',
+                    mountSources: true,
+                    volumeMounts: [],
+                    endpoints: [{ name: 'http', targetPort: ENDPOINT_PORT }],
+                },
+            },
+        ],
+        commands: [
+            {
+                id: 'run',
+                exec: {
+                    // Long-lived TCP server: replies 'hello' to any connection, then keeps
+                    // running so restartRunCommand() has something to actually restart.
+                    commandLine: `node -e "require('net').createServer(c=>{c.end('hello');}).listen(${ENDPOINT_PORT})"`,
+                    component: 'runtime',
+                    workingDir: '${PROJECT_SOURCE}',
+                    group: { kind: 'run', isDefault: true },
+                },
+            },
+        ],
+    };
+}
+
+function buildComponentFolder(contextPath: string, devfile: Data): ComponentWorkspaceFolder {
+    return {
+        contextPath,
+        component: {
+            devfilePath: path.join(contextPath, 'devfile.yaml'),
+            devfileData: {
+                devfile,
+                commands: [],
+                supportedOdoFeatures: { debug: false, deploy: false, dev: true },
+            },
+            devForwardedPorts: [],
+            runningIn: [],
+            runningOn: [],
+            managedBy: undefined,
+        } as unknown as ComponentDescription,
+    };
+}
+
+async function execCapture(kc: KubeConfig, namespace: string, podName: string, command: string[]): Promise<string> {
+    const exec = new Exec(kc);
+    const chunks: Buffer[] = [];
+    const stdout = new Writable({
+        write(chunk, _encoding, callback) {
+            chunks.push(Buffer.from(chunk));
+            callback();
+        },
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        exec.exec(namespace, podName, 'runtime', command, stdout, null, null, false, (status) => {
+            if (status.status === 'Failure') {
+                reject(new Error(status.message ?? 'command failed'));
+            } else {
+                resolve();
+            }
+        }).catch(reject);
+    });
+
+    return Buffer.concat(chunks).toString('utf-8');
+}
+
+suite('devfile/inner-loop/clusterDevPlatform.ts', function () {
+    this.timeout(180000);
+
+    let componentPath: string;
+    let platform: ClusterDevPlatform;
+    let session: DevPlatformSession | undefined;
+    let namespace: string;
+    let previousNamespace: string;
+    let kc: KubeConfig;
+    const output: string[] = [];
+
+    suiteSetup(async function () {
+        componentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'cluster-dev-platform-test-'));
+        platform = new ClusterDevPlatform();
+        kc = new KubeConfig();
+        kc.loadFromDefault();
+
+        // ClusterDevPlatform.start() correctly (matching real dev-mode usage) deploys into
+        // whatever the *ambient current* namespace is, rather than taking one as a parameter —
+        // so this test must pin a known-good namespace itself rather than trust whatever a prior,
+        // unrelated suite left the kubeconfig context pointed at (several existing integration
+        // tests switch the current namespace via Oc.Instance.createProject()/setProject() and
+        // never restore it). Restoring it afterward (see suiteTeardown) avoids leaving that same
+        // landmine for whatever runs next.
+        previousNamespace = await Oc.Instance.getActiveProject();
+        namespace = 'cluster-dev-platform-it-tests';
+        await Oc.Instance.applyConfiguration(JSON.stringify({
+            apiVersion: 'v1',
+            kind: 'Namespace',
+            metadata: { name: namespace },
+        }));
+        await Oc.Instance.setProject(namespace);
+    });
+
+    suiteTeardown(async function () {
+        if (session) {
+            await platform.stop(session).catch(() => {});
+        }
+        await fs.rm(componentPath, { recursive: true, force: true });
+        await Oc.Instance.deleteKubernetesObject('namespace', namespace).catch(() => {});
+        await Oc.Instance.setProject(previousNamespace).catch(() => {});
+    });
+
+    test('start() deploys the component, syncs sources, and forwards its endpoint', async function () {
+        const devfile = buildDevfile();
+        const componentFolder = buildComponentFolder(componentPath, devfile);
+
+        session = await platform.start(devfile, componentFolder, {}, { onOutput: line => output.push(line) });
+
+        expect(session.kind).to.equal('cluster');
+        expect(session.forwardedPorts).to.have.lengthOf(1);
+        expect(session.forwardedPorts[0].containerPort).to.equal(ENDPOINT_PORT);
+        expect(session.forwardedPorts[0].portName).to.equal('http');
+
+        const response = await connectAndRead(session.forwardedPorts[0].localPort);
+        expect(response).to.equal('hello');
+    });
+
+    test('sync() pushes a new local file into the running container', async function () {
+        await fs.writeFile(path.join(componentPath, 'marker.txt'), 'synced-content');
+
+        await platform.sync(session!, ['marker.txt'], []);
+
+        const podName = await Oc.Instance.getComponentPod(COMPONENT_NAME);
+        const content = await execCapture(kc, namespace, podName, ['cat', '/projects/marker.txt']);
+        expect(content).to.equal('synced-content');
+    });
+
+    test('sync() removes a deleted local file from the running container', async function () {
+        await fs.rm(path.join(componentPath, 'marker.txt'));
+
+        await platform.sync(session!, [], ['marker.txt']);
+
+        const podName = await Oc.Instance.getComponentPod(COMPONENT_NAME);
+        let stillExists = true;
+        try {
+            await execCapture(kc, namespace, podName, ['test', '-e', '/projects/marker.txt']);
+        } catch {
+            stillExists = false;
+        }
+        expect(stillExists).to.be.false;
+    });
+
+    test('restartRunCommand() restarts the run command, leaving it reachable again', async function () {
+        await platform.restartRunCommand(session!);
+
+        // give the restarted server a moment to rebind the port
+        await new Promise(resolve => setTimeout(resolve, 2000));
+
+        const response = await connectAndRead(session!.forwardedPorts[0].localPort);
+        expect(response).to.equal('hello');
+    });
+
+    test('stop() tears down the Deployment', async function () {
+        await platform.stop(session!);
+        session = undefined;
+
+        // Check the Deployment itself, by exact name/namespace, rather than getComponentPod()
+        // (which searches the *ambient* current namespace via broad label-selector fallbacks —
+        // an indirect, ambiguous signal compared to directly checking what stop() actually
+        // deletes). Deployment deletion is asynchronous, so poll rather than checking once
+        // immediately.
+        const deadline = Date.now() + 30000;
+        let stillExists = true;
+        while (stillExists && Date.now() < deadline) {
+            try {
+                await Oc.Instance.getKubernetesObject('deployment', COMPONENT_NAME, namespace);
+                await new Promise(resolve => setTimeout(resolve, 1000));
+            } catch {
+                stillExists = false;
+            }
+        }
+        expect(stillExists).to.be.false;
+    });
+});

--- a/test/integration/inner-loop/containerSync.test.ts
+++ b/test/integration/inner-loop/containerSync.test.ts
@@ -1,0 +1,105 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { Exec, KubeConfig } from '@kubernetes/client-node';
+import { expect } from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { Writable } from 'stream';
+import { pushFiles, removeFiles } from '../../../src/devfile/inner-loop/containerSync';
+import { createTestPod, deleteTestNamespace, deleteTestPod, ensureTestNamespace, TEST_NAMESPACE } from './testPod';
+
+const TARGET_DIR = '/tmp/sync-test';
+
+async function execCapture(kc: KubeConfig, podName: string, command: string[]): Promise<string> {
+    const exec = new Exec(kc);
+    const chunks: Buffer[] = [];
+    const stdout = new Writable({
+        write(chunk, _encoding, callback) {
+            chunks.push(Buffer.from(chunk));
+            callback();
+        },
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        exec.exec(TEST_NAMESPACE, podName, 'main', command, stdout, null, null, false, (status) => {
+            if (status.status === 'Failure') {
+                reject(new Error(status.message ?? 'command failed'));
+            } else {
+                resolve();
+            }
+        }).catch(reject);
+    });
+
+    return Buffer.concat(chunks).toString('utf-8');
+}
+
+suite('devfile/inner-loop/containerSync.ts', function () {
+    this.timeout(120000);
+
+    const podName = 'container-sync-test-pod';
+    let kc: KubeConfig;
+    let localRoot: string;
+
+    suiteSetup(async function () {
+        kc = new KubeConfig();
+        kc.loadFromDefault();
+
+        await ensureTestNamespace();
+        await createTestPod(podName);
+        await execCapture(kc, podName, ['mkdir', '-p', TARGET_DIR]);
+    });
+
+    suiteTeardown(async function () {
+        await deleteTestPod(podName);
+        await deleteTestNamespace();
+    });
+
+    setup(async function () {
+        localRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'container-sync-test-'));
+    });
+
+    teardown(async function () {
+        await fs.rm(localRoot, { recursive: true, force: true });
+    });
+
+    test('pushFiles copies local files (including nested paths) into the container', async function () {
+        await fs.writeFile(path.join(localRoot, 'hello.txt'), 'hello from sync test');
+        await fs.mkdir(path.join(localRoot, 'nested'));
+        await fs.writeFile(path.join(localRoot, 'nested', 'inner.txt'), 'nested content');
+
+        await pushFiles(kc, TEST_NAMESPACE, podName, 'main', localRoot, TARGET_DIR, ['hello.txt', 'nested/inner.txt']);
+
+        const content = await execCapture(kc, podName, ['cat', `${TARGET_DIR}/hello.txt`]);
+        expect(content).to.equal('hello from sync test');
+
+        const nestedContent = await execCapture(kc, podName, ['cat', `${TARGET_DIR}/nested/inner.txt`]);
+        expect(nestedContent).to.equal('nested content');
+    });
+
+    test('pushFiles is a no-op for an empty file list', async function () {
+        await pushFiles(kc, TEST_NAMESPACE, podName, 'main', localRoot, TARGET_DIR, []);
+    });
+
+    test('removeFiles deletes previously synced files from the container', async function () {
+        await fs.writeFile(path.join(localRoot, 'to-delete.txt'), 'delete me');
+        await pushFiles(kc, TEST_NAMESPACE, podName, 'main', localRoot, TARGET_DIR, ['to-delete.txt']);
+
+        await removeFiles(kc, TEST_NAMESPACE, podName, 'main', TARGET_DIR, ['to-delete.txt']);
+
+        let stillExists = true;
+        try {
+            await execCapture(kc, podName, ['test', '-e', `${TARGET_DIR}/to-delete.txt`]);
+        } catch {
+            stillExists = false;
+        }
+        expect(stillExists).to.be.false;
+    });
+
+    test('removeFiles is a no-op for an empty path list', async function () {
+        await removeFiles(kc, TEST_NAMESPACE, podName, 'main', TARGET_DIR, []);
+    });
+});

--- a/test/integration/inner-loop/devCommandExec.test.ts
+++ b/test/integration/inner-loop/devCommandExec.test.ts
@@ -1,0 +1,87 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { KubeConfig } from '@kubernetes/client-node';
+import { expect } from 'chai';
+import { startRunCommand } from '../../../src/devfile/inner-loop/devCommandExec';
+import { createTestPod, deleteTestNamespace, deleteTestPod, ensureTestNamespace, TEST_NAMESPACE } from './testPod';
+
+suite('devfile/inner-loop/devCommandExec.ts', function () {
+    this.timeout(120000);
+
+    const podName = 'command-exec-test-pod';
+    let kc: KubeConfig;
+
+    suiteSetup(async function () {
+        kc = new KubeConfig();
+        kc.loadFromDefault();
+
+        await ensureTestNamespace();
+        await createTestPod(podName);
+    });
+
+    suiteTeardown(async function () {
+        await deleteTestPod(podName);
+        await deleteTestNamespace();
+    });
+
+    test('streams output from a short-lived command and reports a successful exit code', async function () {
+        const output: string[] = [];
+
+        const exitCode = await new Promise<number | null>(resolve => {
+            void startRunCommand(
+                kc, TEST_NAMESPACE, podName, 'main', '/tmp',
+                'echo hello-from-run',
+                chunk => output.push(chunk),
+                resolve,
+            );
+        });
+
+        expect(output.join('')).to.contain('hello-from-run');
+        expect(exitCode).to.equal(0);
+    });
+
+    test('reports a non-zero exit code for a failing command', async function () {
+        const exitCode = await new Promise<number | null>(resolve => {
+            void startRunCommand(
+                kc, TEST_NAMESPACE, podName, 'main', '/tmp',
+                // `exit` is a shell builtin, not an executable — `exec exit 7` would fail with
+                // "not found" (127), not propagate 7. Wrap in `sh -c` so `exec` replaces the
+                // shell with a real binary (`sh`) that then runs its own `exit 7` builtin.
+                'sh -c "exit 7"',
+                () => { /* no output expected */ },
+                resolve,
+            );
+        });
+
+        expect(exitCode).to.equal(7);
+    });
+
+    test('stop() terminates a long-running command', async function () {
+        let exitCode: number | null | undefined;
+
+        const handle = await startRunCommand(
+            kc, TEST_NAMESPACE, podName, 'main', '/tmp',
+            'sleep 300',
+            () => { /* no output expected */ },
+            code => { exitCode = code; },
+        );
+
+        // give the process a moment to actually start (and write its PID file) before killing it
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        await handle.stop();
+
+        // poll for the exit callback rather than a single fixed sleep, to avoid flakiness under
+        // slow exec/websocket round-trips
+        const deadline = Date.now() + 15000;
+        while (exitCode === undefined && Date.now() < deadline) {
+            await new Promise(resolve => setTimeout(resolve, 500));
+        }
+
+        expect(exitCode).to.not.be.undefined;
+        expect(exitCode).to.not.equal(0);
+    });
+});

--- a/test/integration/inner-loop/devPortForward.test.ts
+++ b/test/integration/inner-loop/devPortForward.test.ts
@@ -1,0 +1,90 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { KubeConfig } from '@kubernetes/client-node';
+import { expect } from 'chai';
+import * as net from 'net';
+import { startRunCommand } from '../../../src/devfile/inner-loop/devCommandExec';
+import { startPodPortForward, stopPortForwards } from '../../../src/devfile/inner-loop/devPortForward';
+import { createTestPod, deleteTestNamespace, deleteTestPod, ensureTestNamespace, TEST_NAMESPACE } from './testPod';
+
+suite('devfile/inner-loop/devPortForward.ts', function () {
+    this.timeout(120000);
+
+    const podName = 'port-forward-test-pod';
+    const containerPort = 8123;
+    let kc: KubeConfig;
+
+    suiteSetup(async function () {
+        kc = new KubeConfig();
+        kc.loadFromDefault();
+
+        await ensureTestNamespace();
+        await createTestPod(podName, [containerPort]);
+
+        // Start the TCP echo server via startRunCommand() (foreground/attached exec), not a
+        // shell-backgrounded `nohup ... &` process — confirmed by direct reproduction that a
+        // process backgrounded that way does not reliably survive the k8s exec API the way it
+        // does under a real `kubectl exec` (the log file it should have created never even
+        // appeared), regardless of `nohup`.
+        await startRunCommand(
+            kc, TEST_NAMESPACE, podName, 'main', '/tmp',
+            `node -e "require('net').createServer(s => s.on('data', d => s.write(d))).listen(${containerPort})"`,
+            () => { /* no output expected */ },
+            () => { /* not asserted on in this suite */ },
+        );
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    });
+
+    suiteTeardown(async function () {
+        await deleteTestPod(podName);
+        await deleteTestNamespace();
+    });
+
+    test('forwards a local port to the pod and relays data', async function () {
+        const forward = await startPodPortForward(kc, TEST_NAMESPACE, podName, containerPort);
+
+        try {
+            expect(forward.containerPort).to.equal(containerPort);
+            expect(forward.localPort).to.be.a('number');
+
+            // Resolve as soon as data arrives rather than waiting for a graceful close — the echo
+            // server never closes the connection itself, and relying on a clean half-duplex close
+            // over the port-forward tunnel proved fragile.
+            const response = await new Promise<string>((resolve, reject) => {
+                const socket = net.createConnection(forward.localPort, '127.0.0.1', () => {
+                    socket.write('hello');
+                });
+
+                socket.on('data', chunk => {
+                    socket.destroy();
+                    resolve(chunk.toString());
+                });
+                socket.on('error', reject);
+            });
+
+            expect(response).to.equal('hello');
+        } finally {
+            stopPortForwards([forward]);
+        }
+    });
+
+    test('dispose() stops accepting new local connections', async function () {
+        const forward = await startPodPortForward(kc, TEST_NAMESPACE, podName, containerPort);
+        stopPortForwards([forward]);
+
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        await new Promise<void>((resolve, reject) => {
+            const socket = net.createConnection(forward.localPort, '127.0.0.1');
+            socket.on('connect', () => {
+                socket.destroy();
+                reject(new Error('expected connection to be refused after dispose()'));
+            });
+            socket.on('error', () => resolve());
+        });
+    });
+});

--- a/test/integration/inner-loop/netTestUtils.ts
+++ b/test/integration/inner-loop/netTestUtils.ts
@@ -1,0 +1,66 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as net from 'net';
+
+/**
+ * Shared connection helper for inner-loop integration tests that verify a dev session is actually
+ * reachable on localhost (via a cluster port-forward or a podman-published port). Not a test file
+ * itself, so it isn't picked up by the integration test runner's file discovery.
+ */
+
+function connectOnce(localPort: number, attemptTimeoutMs: number): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+        // Resolve as soon as data arrives rather than waiting for 'close' — relying on a clean
+        // half-duplex close propagating back through a port-forward tunnel proved fragile.
+        const socket = net.createConnection(localPort, '127.0.0.1');
+        const timer = setTimeout(() => {
+            socket.destroy();
+            reject(new Error('timed out waiting for data'));
+        }, attemptTimeoutMs);
+
+        socket.on('data', chunk => {
+            clearTimeout(timer);
+            socket.destroy();
+            resolve(chunk.toString());
+        });
+        socket.on('error', err => {
+            clearTimeout(timer);
+            reject(err);
+        });
+    });
+}
+
+/**
+ * Connects and waits for data, retrying with a fresh connection on failure. The remote process
+ * may need a moment to actually bind its listener right after start()/restartRunCommand()
+ * resolves (which only means the command was launched, not that it's finished starting) — a stuck
+ * first attempt doesn't reliably fail fast, so each attempt gets its own short timeout rather than
+ * relying on the socket ever emitting 'error'.
+ *
+ * Also waits `retryDelayMs` between attempts — some failure modes (e.g. `ECONNRESET` from a
+ * podman-published port whose rootless port-forwarding hasn't finished wiring up yet) fail nearly
+ * instantly rather than timing out, so without an explicit delay all `attempts` could burn through
+ * in well under a second, nowhere near enough real time for the target to become reachable.
+ */
+export async function connectAndRead(
+    localPort: number,
+    attempts = 10,
+    attemptTimeoutMs = 3000,
+    retryDelayMs = 1000,
+): Promise<string> {
+    let lastError: unknown;
+
+    for (let i = 0; i < attempts; i++) {
+        try {
+            return await connectOnce(localPort, attemptTimeoutMs);
+        } catch (err) {
+            lastError = err;
+            await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+        }
+    }
+
+    throw lastError;
+}

--- a/test/integration/inner-loop/podmanDevPlatform.test.ts
+++ b/test/integration/inner-loop/podmanDevPlatform.test.ts
@@ -1,0 +1,156 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { expect } from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { ComponentDescription, Data } from '../../../src/devfile/componentTypeDescription';
+import { DevPlatformSession } from '../../../src/devfile/inner-loop/devPlatform';
+import { PodmanDevPlatform } from '../../../src/devfile/inner-loop/podmanDevPlatform';
+import { ChildProcessUtil } from '../../../src/util/childProcessUtil';
+import { ComponentWorkspaceFolder } from '../../../src/odo/workspace';
+import { connectAndRead } from './netTestUtils';
+
+const COMPONENT_NAME = 'podman-dev-platform-it';
+const CONTAINER_NAME = 'runtime';
+const ENDPOINT_PORT = 8080;
+const TEST_IMAGE = 'localhost/nodejs-image:latest';
+
+function buildDevfile(): Data {
+    return {
+        schemaVersion: '2.2.0',
+        metadata: { name: COMPONENT_NAME, version: '1.0.0' },
+        components: [
+            {
+                name: CONTAINER_NAME,
+                container: {
+                    image: TEST_IMAGE,
+                    memoryLimit: '256Mi',
+                    mountSources: true,
+                    volumeMounts: [],
+                    endpoints: [{ name: 'http', targetPort: ENDPOINT_PORT }],
+                },
+            },
+        ],
+        commands: [
+            {
+                id: 'run',
+                exec: {
+                    // Long-lived TCP server: replies 'hello' to any connection, then keeps
+                    // running so restartRunCommand() has something to actually restart.
+                    commandLine: `node -e "require('net').createServer(c=>{c.end('hello');}).listen(${ENDPOINT_PORT})"`,
+                    component: CONTAINER_NAME,
+                    workingDir: '${PROJECT_SOURCE}',
+                    group: { kind: 'run', isDefault: true },
+                },
+            },
+        ],
+    };
+}
+
+function buildComponentFolder(contextPath: string, devfile: Data): ComponentWorkspaceFolder {
+    return {
+        contextPath,
+        component: {
+            devfilePath: path.join(contextPath, 'devfile.yaml'),
+            devfileData: {
+                devfile,
+                commands: [],
+                supportedOdoFeatures: { debug: false, deploy: false, dev: true },
+            },
+            devForwardedPorts: [],
+            runningIn: [],
+            runningOn: [],
+            managedBy: undefined,
+        } as unknown as ComponentDescription,
+    };
+}
+
+suite('devfile/inner-loop/podmanDevPlatform.ts', function () {
+    this.timeout(60000);
+
+    const podName = `${COMPONENT_NAME}-dev`;
+    let componentPath: string;
+    let platform: PodmanDevPlatform;
+    let session: DevPlatformSession | undefined;
+    const output: string[] = [];
+
+    suiteSetup(async function () {
+        this.timeout(120000); // Allow time for image build
+        componentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'podman-dev-platform-test-'));
+        // mkdtemp() defaults to mode 0700 (owner-only). Real component folders on disk are never
+        // this restrictive, but a 0700 dir bind-mounted into a container running as a non-root
+        // image user (e.g. this test image's UID 1001) is not even traversable, causing the run
+        // command to fail with "Permission denied" before it can start listening.
+        await fs.chmod(componentPath, 0o755);
+        platform = new PodmanDevPlatform();
+
+        // Build test image for the integration tests
+        const dockerfile = `FROM node:18-alpine
+WORKDIR /projects
+USER 1001`;
+        const dockerfilePath = path.join(componentPath, 'Dockerfile');
+        await fs.writeFile(dockerfilePath, dockerfile, 'utf-8');
+
+        const buildResult = await ChildProcessUtil.Instance.execute(
+            `podman build -t ${TEST_IMAGE} -f ${dockerfilePath} ${componentPath}`
+        );
+        if (buildResult.error) {
+            throw new Error(`Failed to build test image: ${buildResult.stderr || buildResult.error.message}`);
+        }
+    });
+
+    suiteTeardown(async function () {
+        if (session) {
+            await platform.stop(session).catch(() => {});
+        }
+        await ChildProcessUtil.Instance.execute(`podman pod rm -f ${podName}`).catch(() => {});
+        await ChildProcessUtil.Instance.execute(`podman rmi -f ${TEST_IMAGE}`).catch(() => {});
+        await fs.rm(componentPath, { recursive: true, force: true });
+    });
+
+    test('start() creates a pod, bind-mounts the workspace, and publishes its endpoint', async function () {
+        const devfile = buildDevfile();
+        const componentFolder = buildComponentFolder(componentPath, devfile);
+
+        session = await platform.start(devfile, componentFolder, {}, { onOutput: line => output.push(line) });
+
+        expect(session.kind).to.equal('podman');
+        expect(session.forwardedPorts).to.have.lengthOf(1);
+        expect(session.forwardedPorts[0].containerPort).to.equal(ENDPOINT_PORT);
+        expect(session.forwardedPorts[0].portName).to.equal('http');
+
+        const response = await connectAndRead(session.forwardedPorts[0].localPort);
+        expect(response).to.equal('hello');
+    });
+
+    test('sync() is a no-op — a file written on the host is already visible via bind mount', async function () {
+        await fs.writeFile(path.join(componentPath, 'marker.txt'), 'synced-content');
+
+        await platform.sync(session!, ['marker.txt'], []);
+
+        const result = await ChildProcessUtil.Instance.execute(`podman exec ${CONTAINER_NAME} cat /projects/marker.txt`);
+        if (result.error) {
+            throw new Error(`podman exec failed: ${result.stderr || result.error.message}`);
+        }
+        expect(result.stdout).to.equal('synced-content');
+    });
+
+    test('restartRunCommand() restarts the run command, leaving it reachable again', async function () {
+        await platform.restartRunCommand(session!);
+
+        const response = await connectAndRead(session!.forwardedPorts[0].localPort);
+        expect(response).to.equal('hello');
+    });
+
+    test('stop() tears down the pod', async function () {
+        await platform.stop(session!);
+        session = undefined;
+
+        const result = await ChildProcessUtil.Instance.execute(`podman pod exists ${podName}`);
+        expect(result.error).to.exist;
+    });
+});

--- a/test/integration/inner-loop/testPod.ts
+++ b/test/integration/inner-loop/testPod.ts
@@ -1,0 +1,77 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { Oc } from '../../../src/oc/ocWrapper';
+
+/**
+ * Shared helpers for inner-loop integration tests that need a real running pod to exec/sync/
+ * port-forward against. Not a test file itself (no `.test.ts` suffix), so it isn't picked up by
+ * the integration test runner's file discovery.
+ */
+
+export const TEST_NAMESPACE = 'inner-loop-it-tests';
+export const TEST_IMAGE = 'nodejs-image:latest';
+
+// Deliberately not Oc.Instance.createProject()/deleteProject(): those also switch the
+// kubeconfig's *current* namespace as a side effect (and never restore it), which would corrupt
+// ambient state for anything else relying on the active context/namespace — including
+// clusterDevPlatform.ts's own getCurrentClusterAndNamespace() call. A plain namespace manifest
+// applied server-side has no such side effect.
+
+export async function ensureTestNamespace(): Promise<void> {
+    await Oc.Instance.applyConfiguration(JSON.stringify({
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: TEST_NAMESPACE },
+    }));
+}
+
+export async function deleteTestNamespace(): Promise<void> {
+    await Oc.Instance.deleteKubernetesObject('namespace', TEST_NAMESPACE).catch(() => {});
+}
+
+export async function createTestPod(podName: string, containerPorts: number[] = []): Promise<void> {
+    const pod = {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: podName, namespace: TEST_NAMESPACE, labels: { app: podName } },
+        spec: {
+            containers: [{
+                name: 'main',
+                image: TEST_IMAGE,
+                // TEST_IMAGE is only loaded locally on the Kind node (see doc/plans);
+                // :latest otherwise defaults to imagePullPolicy Always, which would try (and
+                // fail) to pull it from a real registry.
+                imagePullPolicy: 'IfNotPresent',
+                command: ['sh', '-c', 'sleep 3600'],
+                ports: containerPorts.map(containerPort => ({ containerPort })),
+            }],
+        },
+    };
+
+    await Oc.Instance.applyConfiguration(JSON.stringify(pod));
+    await waitForPodRunning(podName);
+}
+
+async function waitForPodRunning(podName: string, timeoutMs = 60000): Promise<void> {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+        const pods = await Oc.Instance.getKubernetesObjects('pods', TEST_NAMESPACE, `app=${podName}`);
+        const pod = pods[0] as any;
+
+        if (pod?.status?.phase === 'Running' && pod.status.containerStatuses?.every((cs: any) => cs.ready)) {
+            return;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+    throw new Error(`Pod ${podName} did not become ready within ${timeoutMs}ms`);
+}
+
+export async function deleteTestPod(podName: string): Promise<void> {
+    await Oc.Instance.deleteKubernetesObject('pod', podName, TEST_NAMESPACE).catch(() => {});
+}

--- a/test/integration/odoWrapper.test.ts
+++ b/test/integration/odoWrapper.test.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import * as tmp from 'tmp';
 import { promisify } from 'util';
 import { Uri, workspace } from 'vscode';
+import { getComponentDescription } from '../../src/devfile/describe';
 import { Oc } from '../../src/oc/ocWrapper';
 import { OdoPreference } from '../../src/odo/odoPreference';
 import { Odo } from '../../src/odo/odoWrapper';
@@ -134,13 +135,16 @@ suite('./odo/odoWrapper.ts', function () {
         });
 
         test('describeComponent()', async function () {
-            const componentDescription1 = await Odo.Instance.describeComponent(tmpFolder1.fsPath);
+            // These components are only created locally, never deployed, so managedBy should be
+            // unset (matches odo's own behavior of not reporting a manager for non-deployed
+            // components) rather than defaulting to a blind guess.
+            const componentDescription1 = await getComponentDescription(tmpFolder1.fsPath);
             expect(componentDescription1).to.exist;
-            expect(componentDescription1.managedBy).to.equal('odo');
+            expect(componentDescription1.managedBy).to.be.undefined;
 
-            const componentDescription2 = await Odo.Instance.describeComponent(tmpFolder2.fsPath);
+            const componentDescription2 = await getComponentDescription(tmpFolder2.fsPath);
             expect(componentDescription2).to.exist;
-            expect(componentDescription2.managedBy).to.equal('odo');
+            expect(componentDescription2.managedBy).to.be.undefined;
         });
     });
 

--- a/test/ui/suite/componentContextMenu.ts
+++ b/test/ui/suite/componentContextMenu.ts
@@ -28,7 +28,7 @@ export function testComponentContextMenu() {
         let openshiftTerminal: OpenshiftTerminalWebviewView;
 
         const componentName = 'nodejs-starter';
-        const expectedTabName = `odo dev: ${componentName}`;
+        const expectedTabName = `Dev Mode: ${componentName}`;
 
         before(async function context() {
             this.timeout(45_000);
@@ -93,8 +93,10 @@ export function testComponentContextMenu() {
             expect(terminalText).to.contain(`Developing using the "${componentName}" Devfile`);
             expect(terminalText).to.contain('Running on the cluster in Dev mode');
             expect(terminalText).to.contain('Pod is Running');
-            expect(terminalText).to.contain('Waiting for the application to be ready');
-            expect(terminalText).to.contain('Keyboard Commands');
+            expect(terminalText).to.contain('Syncing files into the container');
+            expect(terminalText).to.contain('Building your application in container (command: build)');
+            expect(terminalText).to.contain('Executing the application (command: debug)');
+            expect(terminalText).to.contain('Press Ctrl-C to stop dev mode');
         });
 
         it('Stop Dev works', async function () {
@@ -119,11 +121,11 @@ export function testComponentContextMenu() {
 
             //check for terminal content
             const terminalText = await openshiftTerminal.getTerminalText();
-            expect(terminalText).to.include('Finished executing the application');
-            expect(terminalText).to.include('Press any key to close this terminal');
+            expect(terminalText).to.include('Stopping dev mode...');
+            expect(terminalText).to.include('Dev mode stopped. Press Ctrl-C to close terminal.');
 
             //close tab and check
-            await openshiftTerminal.sendKeysToTerminal([Key.ENTER]);
+            await openshiftTerminal.sendKeysToTerminal([`${Key.CONTROL}c`]);
             expect(await openshiftTerminal.isAnyTabOpened()).to.be.false;
         });
 
@@ -146,8 +148,8 @@ export function testComponentContextMenu() {
 
             //check for terminal content
             const terminalText = await openshiftTerminal.getTerminalText();
-            expect(terminalText).to.include('Finished executing the application');
-            expect(terminalText).to.include('Press any key to close this terminal');
+            expect(terminalText).to.include('Stopping dev mode...');
+            expect(terminalText).to.include('Dev mode stopped. Press Ctrl-C to close terminal.');
         });
 
         it('Start/Stop Dev on Podman works', async function () {
@@ -177,9 +179,8 @@ export function testComponentContextMenu() {
 
             //check for terminal content
             terminalText = await openshiftTerminal.getTerminalText();
-            expect(terminalText).to.include('context canceled');
-            expect(terminalText).to.include('Cleaning up resources');
-            expect(terminalText).to.include('Press any key to close this terminal');
+            expect(terminalText).to.include('Stopping dev mode...');
+            expect(terminalText).to.include('Dev mode stopped. Press Ctrl-C to close terminal.');
         });
 
         it('Deploy works', async function () {
@@ -240,9 +241,8 @@ export function testComponentContextMenu() {
             const contextMenu = await component.openContextMenu();
             await contextMenu.select(MENUS.describe);
 
-            //check tab name
-            const tabName = await openshiftTerminal.getActiveTabName();
-            expect(tabName).to.contain(`Describe '${componentName}' Component`);
+            //wait for describe terminal tab to appear
+            openshiftTerminal = await waitForTerminalWithActiveTab(`Describe '${componentName}' Component`);
 
             //Check for terminal content
             const terminalText = await openshiftTerminal.getTerminalText();

--- a/test/unit/devfile/applyCommand.test.ts
+++ b/test/unit/devfile/applyCommand.test.ts
@@ -8,7 +8,7 @@ import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
-import { DeployedResource } from '../../../src/odo/componentTypeDescription';
+import { DeployedResource } from '../../../src/devfile/componentTypeDescription';
 import { ApplyCommandExecutor, debugEcho } from '../../../src/devfile/applyCommand';
 
 const { expect } = chai;

--- a/test/unit/devfile/commandResolver.test.ts
+++ b/test/unit/devfile/commandResolver.test.ts
@@ -1,0 +1,159 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import { CommandResolver } from '../../../src/devfile/commandResolver';
+import { Data } from '../../../src/devfile/componentTypeDescription';
+
+const { expect } = chai;
+
+function baseDevfile(): Data {
+    return {
+        schemaVersion: '2.2.0',
+        metadata: { name: 'test-component', version: '1.0.0' },
+        components: [
+            {
+                name: 'runtime',
+                container: {
+                    image: 'my-image:latest',
+                    memoryLimit: '512Mi',
+                    mountSources: true,
+                    volumeMounts: [],
+                    endpoints: [],
+                    sourceMapping: '/custom-source',
+                },
+            },
+        ],
+    };
+}
+
+suite('devfile/commandResolver.ts', () => {
+
+    suite('getCommand()', () => {
+        test('finds a command by id, case-insensitively', () => {
+            const devfile: Data = {
+                ...baseDevfile(),
+                commands: [{ id: 'Run', exec: { commandLine: 'npm start', component: 'runtime', workingDir: '/projects' } }],
+            };
+
+            expect(CommandResolver.getCommand(devfile, 'run')).to.equal(devfile.commands[0]);
+        });
+
+        test('throws when the command does not exist', () => {
+            const devfile: Data = { ...baseDevfile(), commands: [] };
+
+            expect(() => CommandResolver.getCommand(devfile, 'missing')).to.throw('Command \'missing\' not found');
+        });
+    });
+
+    suite('getAllCommandsMap()', () => {
+        test('maps every command by lowercased id', () => {
+            const devfile: Data = {
+                ...baseDevfile(),
+                commands: [
+                    { id: 'Build', exec: { commandLine: 'npm install', component: 'runtime', workingDir: '/projects' } },
+                    { id: 'run', exec: { commandLine: 'npm start', component: 'runtime', workingDir: '/projects' } },
+                ],
+            };
+
+            const map = CommandResolver.getAllCommandsMap(devfile);
+
+            expect(map.get('build')).to.equal(devfile.commands[0]);
+            expect(map.get('run')).to.equal(devfile.commands[1]);
+        });
+    });
+
+    suite('findCommandByGroup()', () => {
+        test('finds the command whose exec group matches the requested kind', () => {
+            const devfile: Data = {
+                ...baseDevfile(),
+                commands: [
+                    { id: 'build', exec: { commandLine: 'npm install', component: 'runtime', workingDir: '/projects', group: { kind: 'build', isDefault: true } } },
+                    { id: 'run', exec: { commandLine: 'npm start', component: 'runtime', workingDir: '/projects', group: { kind: 'run', isDefault: true } } },
+                ],
+            };
+
+            const found = CommandResolver.findCommandByGroup(devfile, 'run');
+
+            expect(found?.id).to.equal('run');
+        });
+
+        test('prefers the command marked isDefault when several share a group', () => {
+            const devfile: Data = {
+                ...baseDevfile(),
+                commands: [
+                    { id: 'run-alt', exec: { commandLine: 'npm run alt', component: 'runtime', workingDir: '/projects', group: { kind: 'run', isDefault: false } } },
+                    { id: 'run-default', exec: { commandLine: 'npm start', component: 'runtime', workingDir: '/projects', group: { kind: 'run', isDefault: true } } },
+                ],
+            };
+
+            const found = CommandResolver.findCommandByGroup(devfile, 'run');
+
+            expect(found?.id).to.equal('run-default');
+        });
+
+        test('returns undefined when no command matches the group', () => {
+            const devfile: Data = { ...baseDevfile(), commands: [] };
+
+            expect(CommandResolver.findCommandByGroup(devfile, 'debug')).to.be.undefined;
+        });
+    });
+
+    suite('resolveRunCommand()', () => {
+        test('resolves container, source mapping, working directory, and command line', () => {
+            const devfile: Data = {
+                ...baseDevfile(),
+                commands: [
+                    { id: 'run', exec: { commandLine: 'npm start', component: 'runtime', workingDir: '${PROJECT_SOURCE}', group: { kind: 'run', isDefault: true } } },
+                ],
+            };
+
+            const resolved = CommandResolver.resolveRunCommand(devfile, 'run');
+
+            expect(resolved.containerName).to.equal('runtime');
+            expect(resolved.sourceMapping).to.equal('/custom-source');
+            expect(resolved.workingDir).to.equal('/custom-source');
+            expect(resolved.commandLine).to.equal('npm start');
+            expect(resolved.containerComponent?.name).to.equal('runtime');
+            expect(resolved.hotReloadCapable).to.be.false;
+        });
+
+        test('carries hotReloadCapable through from the devfile command', () => {
+            const devfile: Data = {
+                ...baseDevfile(),
+                commands: [
+                    { id: 'run', exec: { commandLine: 'npm start', component: 'runtime', workingDir: '${PROJECT_SOURCE}', group: { kind: 'run', isDefault: true }, hotReloadCapable: true } },
+                ],
+            };
+
+            const resolved = CommandResolver.resolveRunCommand(devfile, 'run');
+
+            expect(resolved.hotReloadCapable).to.be.true;
+        });
+
+        test('falls back to /projects when the container has no explicit sourceMapping', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'test-component', version: '1.0.0' },
+                components: [
+                    { name: 'runtime', container: { image: 'my-image:latest', memoryLimit: '512Mi', mountSources: true, volumeMounts: [], endpoints: [] } },
+                ],
+                commands: [
+                    { id: 'run', exec: { commandLine: 'npm start', component: 'runtime', workingDir: '${PROJECT_SOURCE}', group: { kind: 'run', isDefault: true } } },
+                ],
+            };
+
+            const resolved = CommandResolver.resolveRunCommand(devfile, 'run');
+
+            expect(resolved.sourceMapping).to.equal('/projects');
+        });
+
+        test('throws when no command matches the requested group', () => {
+            const devfile: Data = { ...baseDevfile(), commands: [] };
+
+            expect(() => CommandResolver.resolveRunCommand(devfile, 'run')).to.throw('No devfile command found for group \'run\'');
+        });
+    });
+});

--- a/test/unit/devfile/deploy.test.ts
+++ b/test/unit/devfile/deploy.test.ts
@@ -6,7 +6,7 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { Data } from '../../../src/odo/componentTypeDescription';
+import { Data } from '../../../src/devfile/componentTypeDescription';
 
 const { expect } = chai;
 chai.use(sinonChai);

--- a/test/unit/devfile/dev.test.ts
+++ b/test/unit/devfile/dev.test.ts
@@ -1,0 +1,221 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { ComponentDescription, Data } from '../../../src/devfile/componentTypeDescription';
+import { isDevSessionActive, startDevSession, stopDevSession, forceStopDevSession } from '../../../src/devfile/dev';
+import { ClusterDevPlatform } from '../../../src/devfile/inner-loop/clusterDevPlatform';
+import { DevPlatformSession } from '../../../src/devfile/inner-loop/devPlatform';
+import { loadDevState } from '../../../src/devfile/inner-loop/devStateFile';
+import { ComponentWorkspaceFolder } from '../../../src/odo/workspace';
+
+const { expect } = chai;
+
+const NOOP_OUTPUT = { onOutput: () => { /* no-op */ } };
+
+function buildDevfile(): Data {
+    return {
+        schemaVersion: '2.2.0',
+        metadata: { name: 'dev-test-component', version: '1.0.0' },
+        components: [
+            { name: 'runtime', container: { image: 'my-image:latest', memoryLimit: '512Mi', mountSources: true, volumeMounts: [], endpoints: [] } },
+        ],
+        commands: [
+            { id: 'run', exec: { commandLine: 'npm start', component: 'runtime', workingDir: '${PROJECT_SOURCE}', group: { kind: 'run', isDefault: true } } },
+        ],
+    };
+}
+
+function buildComponentFolder(contextPath: string): ComponentWorkspaceFolder {
+    return {
+        contextPath,
+        component: {
+            devfilePath: path.join(contextPath, 'devfile.yaml'),
+            devfileData: {
+                devfile: buildDevfile(),
+                commands: [],
+                supportedOdoFeatures: { debug: false, deploy: false, dev: true },
+            },
+            devForwardedPorts: [],
+            runningIn: [],
+            runningOn: [],
+            managedBy: undefined,
+        } as unknown as ComponentDescription,
+    };
+}
+
+function buildPlatformSession(): DevPlatformSession {
+    return {
+        kind: 'cluster',
+        pid: process.pid,
+        forwardedPorts: [{
+            containerName: 'runtime',
+            portName: 'http',
+            localAddress: '127.0.0.1',
+            localPort: 12345,
+            containerPort: 8080,
+        }],
+    };
+}
+
+suite('devfile/dev.ts', () => {
+    let sandbox: sinon.SinonSandbox;
+    let componentPath: string;
+    let componentFolder: ComponentWorkspaceFolder;
+    let startStub: sinon.SinonStub;
+    let stopStub: sinon.SinonStub;
+
+    setup(async () => {
+        sandbox = sinon.createSandbox();
+        componentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'dev-test-'));
+        componentFolder = buildComponentFolder(componentPath);
+        startStub = sandbox.stub(ClusterDevPlatform.prototype, 'start').resolves(buildPlatformSession());
+        stopStub = sandbox.stub(ClusterDevPlatform.prototype, 'stop').resolves();
+    });
+
+    teardown(async () => {
+        // Ensure no test leaves a session in the module-level registry for the next test.
+        await forceStopDevSession(componentPath);
+        sandbox.restore();
+        await fs.rm(componentPath, { recursive: true, force: true });
+    });
+
+    suite('startDevSession()', () => {
+        test('starts the resolved platform and marks the session active', async () => {
+            await startDevSession(buildDevfile(), componentFolder, { manualRebuild: true }, NOOP_OUTPUT);
+
+            expect(startStub.calledOnce).to.be.true;
+            expect(isDevSessionActive(componentPath)).to.be.true;
+        });
+
+        test('persists devstate.json from the platform session', async () => {
+            await startDevSession(buildDevfile(), componentFolder, { manualRebuild: true }, NOOP_OUTPUT);
+
+            const devState = await loadDevState(componentPath);
+            expect(devState).to.not.be.null;
+            expect(devState.pid).to.equal(process.pid);
+            expect(devState.platform).to.equal('cluster');
+            expect(devState.forwardedPorts).to.have.lengthOf(1);
+            expect(devState.forwardedPorts[0].localPort).to.equal(12345);
+        });
+
+        test('rejects starting a second session for the same component path', async () => {
+            await startDevSession(buildDevfile(), componentFolder, { manualRebuild: true }, NOOP_OUTPUT);
+
+            try {
+                await startDevSession(buildDevfile(), componentFolder, { manualRebuild: true }, NOOP_OUTPUT);
+                expect.fail('Should have thrown error');
+            } catch (err) {
+                expect(err.message).to.equal(`A dev session is already running for '${componentPath}'`);
+            }
+            expect(startStub.calledOnce).to.be.true;
+        });
+    });
+
+    suite('startDevSession() file watching', () => {
+        let syncStub: sinon.SinonStub;
+        let restartStub: sinon.SinonStub;
+
+        setup(() => {
+            syncStub = sandbox.stub(ClusterDevPlatform.prototype, 'sync').resolves();
+            restartStub = sandbox.stub(ClusterDevPlatform.prototype, 'restartRunCommand').resolves();
+        });
+
+        async function waitUntil(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+            const start = Date.now();
+            while (!predicate()) {
+                if (Date.now() - start > timeoutMs) {
+                    throw new Error('Timed out waiting for condition');
+                }
+                await new Promise(resolve => setTimeout(resolve, 50));
+            }
+        }
+
+        test('syncs and restarts the run command when a file changes', async () => {
+            await startDevSession(buildDevfile(), componentFolder, {}, NOOP_OUTPUT);
+
+            await fs.writeFile(path.join(componentPath, 'a.txt'), 'hello');
+
+            await waitUntil(() => syncStub.called && restartStub.called);
+
+            expect(syncStub.firstCall.args[1]).to.deep.equal(['a.txt']);
+            expect(syncStub.firstCall.args[2]).to.deep.equal([]);
+        });
+
+        test('does not restart the run command when it is hot-reload capable', async () => {
+            const devfile = buildDevfile();
+            devfile.commands[0].exec.hotReloadCapable = true;
+            await startDevSession(devfile, componentFolder, {}, NOOP_OUTPUT);
+
+            await fs.writeFile(path.join(componentPath, 'a.txt'), 'hello');
+
+            await waitUntil(() => syncStub.called);
+            // Give restartRunCommand a chance to have been (wrongly) called too.
+            await new Promise(resolve => setTimeout(resolve, 200));
+
+            expect(restartStub.called).to.be.false;
+        });
+
+        test('does not watch for changes when manualRebuild is set', async () => {
+            await startDevSession(buildDevfile(), componentFolder, { manualRebuild: true }, NOOP_OUTPUT);
+
+            await fs.writeFile(path.join(componentPath, 'a.txt'), 'hello');
+            await new Promise(resolve => setTimeout(resolve, 500));
+
+            expect(syncStub.called).to.be.false;
+        });
+    });
+
+    suite('stopDevSession()', () => {
+        test('stops the platform, clears devstate.json, and marks the session inactive', async () => {
+            await startDevSession(buildDevfile(), componentFolder, { manualRebuild: true }, NOOP_OUTPUT);
+
+            await stopDevSession(componentPath);
+
+            expect(stopStub.calledOnce).to.be.true;
+            expect(isDevSessionActive(componentPath)).to.be.false;
+            expect(await loadDevState(componentPath)).to.be.null;
+        });
+
+        test('is a no-op when no session is active', async () => {
+            await stopDevSession(componentPath);
+            expect(stopStub.called).to.be.false;
+        });
+
+        test('propagates a platform stop() failure and leaves the session tracked as stopped anyway', async () => {
+            stopStub.rejects(new Error('boom'));
+            await startDevSession(buildDevfile(), componentFolder, { manualRebuild: true }, NOOP_OUTPUT);
+
+            try {
+                await stopDevSession(componentPath);
+                expect.fail('Should have thrown error');
+            } catch (err) {
+                expect(err.message).to.equal('boom');
+            }
+            expect(isDevSessionActive(componentPath)).to.be.false;
+        });
+    });
+
+    suite('forceStopDevSession()', () => {
+        test('clears session state even when the platform stop() rejects', async () => {
+            stopStub.rejects(new Error('boom'));
+            await startDevSession(buildDevfile(), componentFolder, { manualRebuild: true }, NOOP_OUTPUT);
+
+            await forceStopDevSession(componentPath);
+
+            expect(isDevSessionActive(componentPath)).to.be.false;
+            expect(await loadDevState(componentPath)).to.be.null;
+        });
+
+        test('is a no-op when no session is active', async () => {
+            await forceStopDevSession(componentPath);
+            expect(stopStub.called).to.be.false;
+        });
+    });
+});

--- a/test/unit/devfile/inner-loop/devPlatform.test.ts
+++ b/test/unit/devfile/inner-loop/devPlatform.test.ts
@@ -1,0 +1,26 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import { resolveDevPlatformKind } from '../../../../src/devfile/inner-loop/devPlatform';
+
+const { expect } = chai;
+
+suite('devfile/inner-loop/devPlatform.ts', () => {
+
+    suite('resolveDevPlatformKind()', () => {
+        test('resolves to cluster when runOn is not specified', () => {
+            expect(resolveDevPlatformKind()).to.equal('cluster');
+        });
+
+        test('resolves to cluster when runOn is explicitly undefined', () => {
+            expect(resolveDevPlatformKind(undefined)).to.equal('cluster');
+        });
+
+        test('resolves to podman when runOn is podman', () => {
+            expect(resolveDevPlatformKind('podman')).to.equal('podman');
+        });
+    });
+});

--- a/test/unit/devfile/inner-loop/devResourceBuilder.test.ts
+++ b/test/unit/devfile/inner-loop/devResourceBuilder.test.ts
@@ -1,0 +1,276 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import * as path from 'path';
+import { Data } from '../../../../src/devfile/componentTypeDescription';
+import { buildDevResources } from '../../../../src/devfile/inner-loop/devResourceBuilder';
+
+const { expect } = chai;
+
+function loadFixture(name: string): Data {
+    const fixturePath = path.join(__dirname, '..', '..', '..', 'fixtures', 'components', name, 'devfile.yaml');
+    return yaml.load(fs.readFileSync(fixturePath, 'utf-8')) as Data;
+}
+
+suite('devfile/inner-loop/devResourceBuilder.ts', () => {
+
+    suite('buildDevResources() — comp-with-uris fixture', () => {
+        const devfile = loadFixture('comp-with-uris');
+
+        test('builds a Deployment named after the component with one container per container component', () => {
+            const { deployment } = buildDevResources(devfile);
+
+            expect(deployment.metadata.name).to.equal('nodejs-with-uris');
+            expect(deployment.spec.template.spec.containers).to.have.lengthOf(1);
+            expect(deployment.spec.template.spec.containers[0].name).to.equal('runtime');
+            expect(deployment.spec.template.spec.containers[0].image).to.equal('registry.access.redhat.com/ubi8/nodejs-18:latest');
+        });
+
+        test('sets imagePullPolicy to IfNotPresent so locally-loaded/cached images are not re-pulled', () => {
+            const { deployment } = buildDevResources(devfile);
+
+            expect(deployment.spec.template.spec.containers[0].imagePullPolicy).to.equal('IfNotPresent');
+        });
+
+        test('ignores non-container components (image, kubernetes)', () => {
+            const { deployment } = buildDevResources(devfile);
+
+            const names = deployment.spec.template.spec.containers.map((c: any) => c.name);
+            expect(names).to.not.include('image-build');
+            expect(names).to.not.include('kubernetes-deploy');
+        });
+
+        test('defaults to a keep-alive command when the devfile sets neither command nor args', () => {
+            const { deployment } = buildDevResources(devfile);
+
+            expect(deployment.spec.template.spec.containers[0].command).to.deep.equal(['tail', '-f', '/dev/null']);
+            expect(deployment.spec.template.spec.containers[0].args).to.be.undefined;
+        });
+
+        test('mounts the shared source volume at the default /projects path', () => {
+            const { deployment } = buildDevResources(devfile);
+
+            const mounts = deployment.spec.template.spec.containers[0].volumeMounts;
+            expect(mounts).to.deep.include({ name: 'devfile-source', mountPath: '/projects' });
+            expect(deployment.spec.template.spec.volumes).to.deep.include({ name: 'devfile-source', emptyDir: {} });
+        });
+
+        test('builds a Service exposing declared endpoints', () => {
+            const { service } = buildDevResources(devfile);
+
+            expect(service).to.not.be.undefined;
+            expect(service!.metadata.name).to.equal('nodejs-with-uris');
+            expect(service!.spec.ports).to.deep.equal([
+                { name: 'http', port: 3000, targetPort: 3000, protocol: 'TCP' },
+            ]);
+        });
+
+        test('labels resources for compatibility with existing selectors', () => {
+            const { deployment, service } = buildDevResources(devfile);
+
+            const expectedLabels = {
+                'app.kubernetes.io/instance': 'nodejs-with-uris',
+                'app.kubernetes.io/managed-by': 'openshift-toolkit',
+                component: 'nodejs-with-uris',
+                'odo.dev/mode': 'dev',
+            };
+
+            expect(deployment.metadata.labels).to.deep.equal(expectedLabels);
+            expect(service!.metadata.labels).to.deep.equal(expectedLabels);
+        });
+    });
+
+    suite('buildDevResources() — explicit command/args and env', () => {
+        test('respects an explicit command over the keep-alive default', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'explicit-cmd', version: '1.0.0' },
+                components: [
+                    {
+                        name: 'runtime',
+                        container: {
+                            image: 'my-image:latest',
+                            memoryLimit: '512Mi',
+                            mountSources: true,
+                            volumeMounts: [],
+                            endpoints: [],
+                            command: ['/bin/my-entrypoint'],
+                            args: ['--flag'],
+                        },
+                    },
+                ],
+            };
+
+            const { deployment } = buildDevResources(devfile);
+
+            expect(deployment.spec.template.spec.containers[0].command).to.deep.equal(['/bin/my-entrypoint']);
+            expect(deployment.spec.template.spec.containers[0].args).to.deep.equal(['--flag']);
+        });
+
+        test('resolves devfile ${VARIABLE} references in env values', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'with-env', version: '1.0.0' },
+                variables: { GREETING: 'hello' },
+                components: [
+                    {
+                        name: 'runtime',
+                        container: {
+                            image: 'my-image:latest',
+                            memoryLimit: '512Mi',
+                            mountSources: true,
+                            volumeMounts: [],
+                            endpoints: [],
+                            env: [
+                                { name: 'MESSAGE', value: '${GREETING}-world' },
+                                { name: 'SOURCE_DIR', value: '${PROJECT_SOURCE}' },
+                            ],
+                        },
+                    },
+                ],
+            };
+
+            const { deployment } = buildDevResources(devfile);
+
+            expect(deployment.spec.template.spec.containers[0].env).to.deep.equal([
+                { name: 'MESSAGE', value: 'hello-world' },
+                { name: 'SOURCE_DIR', value: '/projects' },
+            ]);
+        });
+
+        test('maps memoryLimit to container resource limits', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'with-memory', version: '1.0.0' },
+                components: [
+                    {
+                        name: 'runtime',
+                        container: {
+                            image: 'my-image:latest',
+                            memoryLimit: '2Gi',
+                            mountSources: true,
+                            volumeMounts: [],
+                            endpoints: [],
+                        },
+                    },
+                ],
+            };
+
+            const { deployment } = buildDevResources(devfile);
+
+            expect(deployment.spec.template.spec.containers[0].resources).to.deep.equal({
+                limits: { memory: '2Gi' },
+            });
+        });
+    });
+
+    suite('buildDevResources() — mountSources: false and volume components', () => {
+        test('does not mount the source volume or override command for a mountSources:false container', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'sidecar-db', version: '1.0.0' },
+                components: [
+                    {
+                        name: 'runtime',
+                        container: {
+                            image: 'my-image:latest',
+                            memoryLimit: '512Mi',
+                            mountSources: true,
+                            volumeMounts: [],
+                            endpoints: [],
+                        },
+                    },
+                    {
+                        name: 'db',
+                        container: {
+                            image: 'postgres:16',
+                            memoryLimit: '512Mi',
+                            mountSources: false,
+                            volumeMounts: [],
+                            endpoints: [],
+                        },
+                    },
+                ],
+            };
+
+            const { deployment } = buildDevResources(devfile);
+
+            const dbContainer = deployment.spec.template.spec.containers.find((c: any) => c.name === 'db');
+            expect(dbContainer.command).to.be.undefined;
+            expect(dbContainer.volumeMounts).to.not.deep.include({ name: 'devfile-source', mountPath: '/projects' });
+        });
+
+        test('backs a referenced volume component with an emptyDir volume', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'with-volume', version: '1.0.0' },
+                components: [
+                    {
+                        name: 'runtime',
+                        container: {
+                            image: 'my-image:latest',
+                            memoryLimit: '512Mi',
+                            mountSources: true,
+                            endpoints: [],
+                            volumeMounts: [{ name: 'shared-data', path: '/data' }],
+                        },
+                    },
+                    {
+                        name: 'shared-data',
+                        volume: { size: '1Gi' },
+                    },
+                ],
+            };
+
+            const { deployment } = buildDevResources(devfile);
+
+            expect(deployment.spec.template.spec.containers[0].volumeMounts).to.deep.include({
+                name: 'shared-data',
+                mountPath: '/data',
+            });
+            expect(deployment.spec.template.spec.volumes).to.deep.include({ name: 'shared-data', emptyDir: {} });
+        });
+    });
+
+    suite('buildDevResources() — no endpoints', () => {
+        test('does not build a Service when no endpoints are declared', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'no-endpoints', version: '1.0.0' },
+                components: [
+                    {
+                        name: 'runtime',
+                        container: {
+                            image: 'my-image:latest',
+                            memoryLimit: '512Mi',
+                            mountSources: true,
+                            volumeMounts: [],
+                            endpoints: [],
+                        },
+                    },
+                ],
+            };
+
+            const { service } = buildDevResources(devfile);
+
+            expect(service).to.be.undefined;
+        });
+    });
+
+    suite('buildDevResources() — invalid devfile', () => {
+        test('throws when the devfile has no container components', () => {
+            const devfile: Data = {
+                schemaVersion: '2.2.0',
+                metadata: { name: 'no-containers', version: '1.0.0' },
+                components: [],
+            };
+
+            expect(() => buildDevResources(devfile)).to.throw('Devfile has no container components to run in dev mode');
+        });
+    });
+});

--- a/test/unit/devfile/inner-loop/devStateFile.test.ts
+++ b/test/unit/devfile/inner-loop/devStateFile.test.ts
@@ -1,0 +1,117 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { DevState } from '../../../../src/devfile/componentTypeDescription';
+import { clearDevState, loadDevState, saveDevState } from '../../../../src/devfile/inner-loop/devStateFile';
+
+const { expect } = chai;
+
+suite('devfile/inner-loop/devStateFile.ts', () => {
+    let componentPath: string;
+
+    setup(async () => {
+        componentPath = await fs.mkdtemp(path.join(os.tmpdir(), 'devstate-test-'));
+    });
+
+    teardown(async () => {
+        await fs.rm(componentPath, { recursive: true, force: true });
+    });
+
+    suite('loadDevState()', () => {
+        test('returns null when no devstate.json exists', async () => {
+            const result = await loadDevState(componentPath);
+            expect(result).to.be.null;
+        });
+
+        test('returns null when devstate.json is invalid JSON', async () => {
+            await fs.mkdir(path.join(componentPath, '.odo'), { recursive: true });
+            await fs.writeFile(path.join(componentPath, '.odo', 'devstate.json'), 'not json', 'utf-8');
+
+            const result = await loadDevState(componentPath);
+            expect(result).to.be.null;
+        });
+    });
+
+    suite('saveDevState() / loadDevState() round-trip', () => {
+        test('persists and reloads a minimal dev state', async () => {
+            const state: DevState = {
+                pid: process.pid,
+                platform: 'cluster',
+            };
+
+            await saveDevState(state, componentPath);
+            const result = await loadDevState(componentPath);
+
+            expect(result).to.deep.equal(state);
+        });
+
+        test('persists and reloads forwarded ports and apiServerPort', async () => {
+            const state: DevState = {
+                pid: 1234,
+                platform: 'podman',
+                apiServerPort: 51234,
+                forwardedPorts: [
+                    {
+                        containerName: 'runtime',
+                        portName: 'http',
+                        localAddress: '127.0.0.1',
+                        localPort: 40001,
+                        containerPort: 8080,
+                        exposure: 'public',
+                    },
+                    {
+                        containerName: 'runtime',
+                        portName: 'debug',
+                        isDebug: true,
+                        localAddress: '127.0.0.1',
+                        localPort: 40002,
+                        containerPort: 5858,
+                    },
+                ],
+            };
+
+            await saveDevState(state, componentPath);
+            const result = await loadDevState(componentPath);
+
+            expect(result).to.deep.equal(state);
+        });
+
+        test('creates the .odo directory if it does not already exist', async () => {
+            const state: DevState = { pid: 1, platform: 'cluster' };
+
+            await saveDevState(state, componentPath);
+
+            const stat = await fs.stat(path.join(componentPath, '.odo', 'devstate.json'));
+            expect(stat.isFile()).to.be.true;
+        });
+
+        test('overwrites a previously saved state', async () => {
+            await saveDevState({ pid: 1, platform: 'cluster' }, componentPath);
+            await saveDevState({ pid: 2, platform: 'docker' }, componentPath);
+
+            const result = await loadDevState(componentPath);
+            expect(result).to.deep.equal({ pid: 2, platform: 'docker' });
+        });
+    });
+
+    suite('clearDevState()', () => {
+        test('removes an existing devstate.json', async () => {
+            await saveDevState({ pid: 1, platform: 'cluster' }, componentPath);
+
+            await clearDevState(componentPath);
+
+            const result = await loadDevState(componentPath);
+            expect(result).to.be.null;
+        });
+
+        test('does not throw when devstate.json does not exist', async () => {
+            await clearDevState(componentPath);
+        });
+    });
+});

--- a/test/unit/devfile/inner-loop/devTerminalBridge.test.ts
+++ b/test/unit/devfile/inner-loop/devTerminalBridge.test.ts
@@ -1,0 +1,36 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import { isStopRequest } from '../../../../src/devfile/inner-loop/devTerminalBridge';
+
+const { expect } = chai;
+
+suite('devfile/inner-loop/devTerminalBridge.ts', () => {
+
+    suite('isStopRequest()', () => {
+        test('detects the raw Ctrl-C control byte', () => {
+            expect(isStopRequest('\u0003')).to.be.true;
+        });
+
+        test('detects the control byte embedded in a larger chunk of input', () => {
+            expect(isStopRequest('some input\u0003more input')).to.be.true;
+        });
+
+        test('does not treat the printable "^C" text as a stop request', () => {
+            // A real pty's line discipline echoes Ctrl-C as printable "^C" — this virtual
+            // terminal has no such line discipline, so only the raw byte should count.
+            expect(isStopRequest('^C')).to.be.false;
+        });
+
+        test('returns false for ordinary program output', () => {
+            expect(isStopRequest('Server started on port 8080\r\n')).to.be.false;
+        });
+
+        test('returns false for empty input', () => {
+            expect(isStopRequest('')).to.be.false;
+        });
+    });
+});

--- a/test/unit/devfile/inner-loop/fileSync.test.ts
+++ b/test/unit/devfile/inner-loop/fileSync.test.ts
@@ -1,0 +1,141 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as chai from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { ChangeBatcher, resolveIgnoreRules } from '../../../../src/devfile/inner-loop/fileSync';
+
+const { expect } = chai;
+
+function wait(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+suite('devfile/inner-loop/fileSync.ts', () => {
+
+    suite('resolveIgnoreRules()', () => {
+        let rootDir: string;
+
+        setup(async () => {
+            rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'filesync-test-'));
+        });
+
+        teardown(async () => {
+            await fs.rm(rootDir, { recursive: true, force: true });
+        });
+
+        test('always ignores .git and .odo, even without a .gitignore', async () => {
+            const rules = await resolveIgnoreRules(rootDir);
+
+            expect(rules.ignores('.git')).to.be.true;
+            expect(rules.ignores('.git/HEAD')).to.be.true;
+            expect(rules.ignores('.odo')).to.be.true;
+            expect(rules.ignores('.odo/devstate.json')).to.be.true;
+        });
+
+        test('does not ignore ordinary source files when there is no .gitignore', async () => {
+            const rules = await resolveIgnoreRules(rootDir);
+
+            expect(rules.ignores('src/index.ts')).to.be.false;
+        });
+
+        test('adds patterns from the component root .gitignore', async () => {
+            await fs.writeFile(path.join(rootDir, '.gitignore'), 'node_modules\n*.log\ndist/\n');
+
+            const rules = await resolveIgnoreRules(rootDir);
+
+            expect(rules.ignores('node_modules/some-pkg/index.js')).to.be.true;
+            expect(rules.ignores('debug.log')).to.be.true;
+            expect(rules.ignores('dist/bundle.js')).to.be.true;
+            expect(rules.ignores('src/index.ts')).to.be.false;
+        });
+    });
+
+    suite('ChangeBatcher', () => {
+        test('coalesces multiple changes into a single batch after the debounce window', async () => {
+            const batches: { changed: string[]; deleted: string[] }[] = [];
+            const batcher = new ChangeBatcher((changed, deleted) => batches.push({ changed, deleted }), 20);
+
+            batcher.recordChange('a.txt');
+            batcher.recordChange('b.txt');
+            batcher.recordDelete('c.txt');
+
+            await wait(60);
+
+            expect(batches).to.have.lengthOf(1);
+            expect(batches[0].changed.sort()).to.deep.equal(['a.txt', 'b.txt']);
+            expect(batches[0].deleted).to.deep.equal(['c.txt']);
+        });
+
+        test('restarts the debounce window on each new event', async () => {
+            const batches: { changed: string[]; deleted: string[] }[] = [];
+            const batcher = new ChangeBatcher((changed, deleted) => batches.push({ changed, deleted }), 30);
+
+            batcher.recordChange('a.txt');
+            await wait(20);
+            expect(batches).to.have.lengthOf(0);
+
+            batcher.recordChange('b.txt');
+            await wait(20);
+            expect(batches).to.have.lengthOf(0);
+
+            await wait(20);
+            expect(batches).to.have.lengthOf(1);
+            expect(batches[0].changed.sort()).to.deep.equal(['a.txt', 'b.txt']);
+        });
+
+        test('the latest event for a path wins when it flips kind within the same window', async () => {
+            const batches: { changed: string[]; deleted: string[] }[] = [];
+            const batcher = new ChangeBatcher((changed, deleted) => batches.push({ changed, deleted }), 20);
+
+            batcher.recordChange('a.txt');
+            batcher.recordDelete('a.txt');
+
+            await wait(60);
+
+            expect(batches).to.have.lengthOf(1);
+            expect(batches[0].changed).to.deep.equal([]);
+            expect(batches[0].deleted).to.deep.equal(['a.txt']);
+        });
+
+        test('emits separate batches across separate debounce windows', async () => {
+            const batches: { changed: string[]; deleted: string[] }[] = [];
+            const batcher = new ChangeBatcher((changed, deleted) => batches.push({ changed, deleted }), 20);
+
+            batcher.recordChange('a.txt');
+            await wait(60);
+            batcher.recordChange('b.txt');
+            await wait(60);
+
+            expect(batches).to.have.lengthOf(2);
+            expect(batches[0].changed).to.deep.equal(['a.txt']);
+            expect(batches[1].changed).to.deep.equal(['b.txt']);
+        });
+
+        test('dispose() cancels a pending flush without emitting it', async () => {
+            const batches: { changed: string[]; deleted: string[] }[] = [];
+            const batcher = new ChangeBatcher((changed, deleted) => batches.push({ changed, deleted }), 20);
+
+            batcher.recordChange('a.txt');
+            batcher.dispose();
+
+            await wait(60);
+
+            expect(batches).to.have.lengthOf(0);
+        });
+
+        test('does not invoke the callback when nothing is pending', async () => {
+            const batches: { changed: string[]; deleted: string[] }[] = [];
+            const batcher = new ChangeBatcher((changed, deleted) => batches.push({ changed, deleted }), 20);
+
+            batcher.dispose();
+            await wait(30);
+
+            expect(batches).to.have.lengthOf(0);
+        });
+    });
+});

--- a/test/unit/devfile/variableResolver.test.ts
+++ b/test/unit/devfile/variableResolver.test.ts
@@ -5,7 +5,7 @@
 
 import * as chai from 'chai';
 import { VariableResolver } from '../../../src/devfile/variableResolver';
-import { Data, Apply } from '../../../src/odo/componentTypeDescription';
+import { Data, Apply } from '../../../src/devfile/componentTypeDescription';
 
 const { expect } = chai;
 

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -65,10 +65,9 @@ export async function run(): Promise<void> {
     testFiles.push(...await testFinder('openshift/component.test.js'));
     testFiles.push(...await testFinder('openshift/cluster.test.js'));
     testFiles.push(...await testFinder('openshift/project.test.js'));
-    testFiles.push(...await testFinder('devfile/*.test.js'));
+    testFiles.push(...await testFinder('devfile/**/*.test.js'));
     testFiles.push(...await testFinder('k8s/*.test.js'));
     testFiles.push(...await testFinder('util/*.test.js'));
-    testFiles.push(...await testFinder('devfile/*.test.js'));
 
     testFiles.forEach((f) => mocha.addFile(paths.join(testsRoot, f)));
 

--- a/test/unit/odo/workspace.test.ts
+++ b/test/unit/odo/workspace.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import * as vscode from 'vscode';
-import { ComponentDescription } from '../../../src/odo/componentTypeDescription';
+import { ComponentDescription } from '../../../src/devfile/componentTypeDescription';
 import { Odo } from '../../../src/odo/odoWrapper';
 import { OdoWorkspace } from '../../../src/odo/workspace';
 import * as fixtures from '../../fixtures';

--- a/test/unit/openshift/component.test.ts
+++ b/test/unit/openshift/component.test.ts
@@ -18,7 +18,7 @@ import { DevfileInfo } from '../../../src/devfile-registry/devfileInfo';
 import { DevfileRegistry } from '../../../src/devfile-registry/devfileRegistryWrapper';
 import { Oc } from '../../../src/oc/ocWrapper';
 import { Project } from '../../../src/oc/project';
-import { CommandProvider } from '../../../src/odo/componentTypeDescription';
+import { CommandProvider } from '../../../src/devfile/componentTypeDescription';
 import { Odo } from '../../../src/odo/odoWrapper';
 import { ComponentWorkspaceFolder, OdoWorkspace } from '../../../src/odo/workspace';
 import * as openShiftComponent from '../../../src/openshift/component';
@@ -605,5 +605,133 @@ suite('OpenShift/Component', function () {
             );
         });
 
+    });
+
+    suite('dev mode', () => {
+        let DevModeComponent: typeof openShiftComponent.Component;
+        let startDevSessionStub: sinon.SinonStub;
+        let stopDevSessionStub: sinon.SinonStub;
+        let forceStopDevSessionStub: sinon.SinonStub;
+        let createDevTerminalBridgeStub: sinon.SinonStub;
+        let fakeTerminal: { focusTerminal: sinon.SinonStub; kill: sinon.SinonStub; forceKill: sinon.SinonStub; sendText: sinon.SinonStub; id: string };
+        let onStopRequested: () => void;
+
+        setup(() => {
+            startDevSessionStub = sandbox.stub().resolves();
+            stopDevSessionStub = sandbox.stub().resolves();
+            forceStopDevSessionStub = sandbox.stub().resolves();
+
+            fakeTerminal = {
+                focusTerminal: sandbox.stub(),
+                kill: sandbox.stub().callsFake(() => onStopRequested()),
+                forceKill: sandbox.stub(),
+                sendText: sandbox.stub(),
+                id: 'fake-terminal-id',
+            };
+
+            createDevTerminalBridgeStub = sandbox.stub().callsFake(
+                async (_name: string, _cwd: string, stopCallback: () => void) => {
+                    onStopRequested = stopCallback;
+                    return { output: { onOutput: sandbox.stub() }, terminal: fakeTerminal };
+                },
+            );
+
+            DevModeComponent = pq('../../../src/openshift/component', {
+                '../devfile/dev': {
+                    startDevSession: startDevSessionStub,
+                    stopDevSession: stopDevSessionStub,
+                    forceStopDevSession: forceStopDevSessionStub,
+                },
+                '../devfile/inner-loop/devTerminalBridge': {
+                    createDevTerminalBridge: createDevTerminalBridgeStub,
+                },
+            }).Component as typeof openShiftComponent.Component;
+        });
+
+        suite('devRunOn()', () => {
+            test('starts a dev session and transitions to DEV_RUNNING', async () => {
+                await DevModeComponent.devRunOn(componentItem1, undefined, false);
+
+                expect(createDevTerminalBridgeStub).calledOnce;
+                expect(startDevSessionStub).calledOnceWith(
+                    componentItem1.component.devfileData.devfile,
+                    componentItem1,
+                    { debug: true, runOn: undefined, manualRebuild: false },
+                );
+                expect(DevModeComponent.getComponentDevState(componentItem1).devStatus)
+                    .to.equal(openShiftComponent.ComponentContextState.DEV_RUNNING);
+            });
+
+            test('passes runOn and manualRebuild through to startDevSession', async () => {
+                await DevModeComponent.devRunOn(componentItem1, 'podman', true);
+
+                expect(startDevSessionStub).calledOnceWith(
+                    componentItem1.component.devfileData.devfile,
+                    componentItem1,
+                    { debug: true, runOn: 'podman', manualRebuild: true },
+                );
+            });
+
+            test('reverts to DEV and shows an error message when startDevSession fails', async () => {
+                startDevSessionStub.rejects(new Error('boom'));
+                const errorStub = sandbox.stub(vscode.window, 'showErrorMessage').resolves();
+
+                await DevModeComponent.devRunOn(componentItem1, undefined, false);
+
+                expect(DevModeComponent.getComponentDevState(componentItem1).devStatus)
+                    .to.equal(openShiftComponent.ComponentContextState.DEV);
+                expect(errorStub).calledOnce;
+            });
+        });
+
+        suite('exitDevMode()', () => {
+            test('sends the stop signal through the terminal, stopping the session gracefully', async () => {
+                await DevModeComponent.devRunOn(componentItem1, undefined, false);
+
+                await DevModeComponent.exitDevMode(componentItem1);
+                // the stop flow is kicked off but not awaited by exitDevMode() itself
+                await new Promise(resolve => setImmediate(resolve));
+
+                expect(fakeTerminal.focusTerminal).calledOnce;
+                expect(fakeTerminal.kill).calledOnce;
+                expect(stopDevSessionStub).calledOnceWith(componentItem1.contextPath);
+                expect(DevModeComponent.getComponentDevState(componentItem1).devStatus)
+                    .to.equal(openShiftComponent.ComponentContextState.DEV);
+            });
+
+            test('does not stop a session twice if triggered again while already stopping', async () => {
+                await DevModeComponent.devRunOn(componentItem1, undefined, false);
+
+                fakeTerminal.kill();
+                fakeTerminal.kill();
+                await new Promise(resolve => setImmediate(resolve));
+
+                expect(stopDevSessionStub).calledOnce;
+            });
+        });
+
+        suite('forceExitDevMode()', () => {
+            test('force-kills the terminal and force-stops the session', async () => {
+                await DevModeComponent.devRunOn(componentItem1, undefined, false);
+
+                await DevModeComponent.forceExitDevMode(componentItem1);
+
+                expect(fakeTerminal.focusTerminal).calledOnce;
+                expect(fakeTerminal.forceKill).calledOnce;
+                expect(forceStopDevSessionStub).calledOnceWith(componentItem1.contextPath);
+                expect(DevModeComponent.getComponentDevState(componentItem1).devStatus)
+                    .to.equal(openShiftComponent.ComponentContextState.DEV);
+            });
+        });
+
+        suite('showDevTerminal()', () => {
+            test('focuses the dev terminal', async () => {
+                await DevModeComponent.devRunOn(componentItem1, undefined, false);
+
+                DevModeComponent.showDevTerminal(componentItem1);
+
+                expect(fakeTerminal.focusTerminal).calledOnce;
+            });
+        });
     });
 });

--- a/test/unit/util/kubeUtils.test.ts
+++ b/test/unit/util/kubeUtils.test.ts
@@ -183,3 +183,100 @@ suite('getOpenShiftRegistryUrl()', () => {
         expect(result).to.be.undefined;
     });
 });
+
+suite('resolveClusterPlatform()', () => {
+    let sandbox: sinon.SinonSandbox;
+    let executeSyncToolStub: sinon.SinonStub;
+    let resolveClusterPlatform: any;
+    const fixtureDir = path.resolve(__dirname, '..', '..', '..', '..', 'test', 'fixtures');
+    const configDir = path.resolve(fixtureDir, '.kube');
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        executeSyncToolStub = sandbox.stub();
+
+        const mod = pq('../../../src/util/kubeUtils', {
+            '../cli': {
+                CliChannel: {
+                    getInstance: () => ({
+                        executeSyncTool: executeSyncToolStub,
+                        executeTool: sandbox.stub(),
+                    }),
+                },
+            },
+        });
+        resolveClusterPlatform = mod.resolveClusterPlatform;
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('returns OpenShift without checking the Kubernetes variant', async () => {
+        sandbox.stub(process, 'env').value({
+            KUBECONFIG: path.join(configDir, 'config-generic'),
+        });
+        executeSyncToolStub.resolves('apps.openshift.io/v1');
+
+        const result = await resolveClusterPlatform();
+
+        expect(result).to.deep.equal({
+            isOpenShift: true,
+            variant: KubernetesVariant.Generic,
+            label: 'OpenShift',
+        });
+        // Only the 'oc api-versions' check should run — no kind/minikube CLI probing needed
+        // once the cluster is already known to be OpenShift.
+        expect(executeSyncToolStub).calledOnce;
+    });
+
+    test('returns Kind for a non-OpenShift Kind cluster', async () => {
+        sandbox.stub(process, 'env').value({
+            KUBECONFIG: path.join(configDir, 'config-kind'),
+        });
+        executeSyncToolStub.callsFake(async (cmd: any) => {
+            if (cmd.toString().includes('api-versions')) {
+                return 'v1';
+            }
+            return 'kind v0.20.0';
+        });
+
+        const result = await resolveClusterPlatform();
+
+        expect(result).to.deep.equal({
+            isOpenShift: false,
+            variant: KubernetesVariant.Kind,
+            label: 'Kind',
+        });
+    });
+
+    test('returns Minikube for a non-OpenShift Minikube cluster', async () => {
+        sandbox.stub(process, 'env').value({
+            KUBECONFIG: path.join(configDir, 'config-minikube'),
+        });
+        executeSyncToolStub.resolves('v1');
+
+        const result = await resolveClusterPlatform();
+
+        expect(result).to.deep.equal({
+            isOpenShift: false,
+            variant: KubernetesVariant.Minikube,
+            label: 'Minikube',
+        });
+    });
+
+    test('returns generic Kubernetes for an unrecognized non-OpenShift cluster', async () => {
+        sandbox.stub(process, 'env').value({
+            KUBECONFIG: path.join(configDir, 'config-generic'),
+        });
+        executeSyncToolStub.resolves('v1');
+
+        const result = await resolveClusterPlatform();
+
+        expect(result).to.deep.equal({
+            isOpenShift: false,
+            variant: KubernetesVariant.Generic,
+            label: 'Kubernetes',
+        });
+    });
+});


### PR DESCRIPTION
Replaces the CLI shell-out to `odo dev` / `odo dev --debug` with a native TypeScript dev-mode engine, following the same pattern already used to replace `odo init`/`odo deploy`/`odo undeploy`/`odo describe`. Dev mode now runs directly against the current Kubernetes/OpenShift cluster or a local podman runtime — deploying/starting the dev container(s), performing an initial `.gitignore`-aware file sync plus an ongoing file watcher that syncs and restarts the run/debug command on change, executing that command, and forwarding its endpoints — with no remaining dependency on the `odo` CLI for this feature. The component context-menu commands (dev/dev.manual/dev.onPodman/dev.onPodman.manual/exitDevMode/ forceExitDevMode/showDevTerminal) are rewired to this engine, and the OpenShift Terminal panel UX (live output, Ctrl-C-to-stop) is preserved via a generalized virtual-terminal mode rather than a real spawned process. `describe`'s status reporting was also reworked to accurately reflect simultaneous Dev/Deploy state, `managed-by`, and the actual cluster platform (OpenShift/Kubernetes/Kind/Minikube) for both engines.

Extends the Debug command to support Go components in addition to Java, Node.js, and Python, with automatic Delve debugger configuration and VS Code debugger attachment.

Adds unit and integration test coverage for all of the new dev-engine modules (session lifecycle, cluster/podman platforms, file sync, command execution, port-forwarding, terminal bridging) and extends existing test suites (`describe`, `kubeUtils`, `component`) to cover the reworked behavior.


Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>